### PR TITLE
Add offerer dashboard and owner offer inbox

### DIFF
--- a/frontend/afristore-app/src/app/offers/incoming/page.tsx
+++ b/frontend/afristore-app/src/app/offers/incoming/page.tsx
@@ -1,0 +1,190 @@
+// -----------------------------------------------------------------
+// app/offers/incoming/page.tsx -- Owner Offer Inbox
+// -----------------------------------------------------------------
+
+"use client";
+
+import { useWalletContext } from "@/context/WalletContext";
+import { useIncomingOffers, useAcceptOffer, useRejectOffer } from "@/hooks/useOffers";
+import { stroopsToXlm, Offer, Listing } from "@/lib/contract";
+import { Inbox, Clock, CheckCircle, XCircle } from "lucide-react";
+
+const STATUS_COLOR: Record<string, string> = {
+  Pending: "text-yellow-500 bg-yellow-50",
+  Accepted: "text-green-600 bg-green-50",
+  Rejected: "text-red-500 bg-red-50",
+  Withdrawn: "text-gray-500 bg-gray-100",
+};
+
+import { WalletGuard } from "@/components/WalletGuard";
+
+export default function IncomingOffersPage() {
+  const { publicKey } = useWalletContext();
+  const { offersByListing, isLoading, error, refresh } = useIncomingOffers(publicKey);
+  const { accept, isAccepting, error: acceptError } = useAcceptOffer(publicKey);
+  const { reject, isRejecting, error: rejectError } = useRejectOffer(publicKey);
+
+  // Flatten all offers for stats
+  const allOffers = offersByListing.flatMap(
+    (group: { listing: Listing; offers: Offer[] }) => group.offers
+  );
+  const pendingCnt = allOffers.filter((o: Offer) => o.status === "Pending").length;
+  const acceptedCnt = allOffers.filter((o: Offer) => o.status === "Accepted").length;
+
+  return (
+    <WalletGuard actionName="To access your offer inbox">
+      <div>
+        <div className="mb-8">
+          <h1 className="text-3xl font-display font-bold text-gray-900">
+            Offer Inbox
+          </h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Manage incoming offers on your artworks
+          </p>
+        </div>
+
+        {/* Stats */}
+        <div className="mb-8 grid gap-4 sm:grid-cols-3">
+          {[
+            { label: "Total Incoming", value: allOffers.length, icon: Inbox },
+            { label: "Pending Review", value: pendingCnt, icon: Clock },
+            { label: "Accepted", value: acceptedCnt, icon: CheckCircle },
+          ].map(({ label, value, icon: Icon }) => (
+            <div
+              key={label}
+              className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-gray-500">{label}</p>
+                <Icon size={18} className="text-brand-400" />
+              </div>
+              <p className="mt-2 text-3xl font-bold text-gray-900">{value}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Error banners */}
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+        {acceptError && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {acceptError}
+          </div>
+        )}
+        {rejectError && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {rejectError}
+          </div>
+        )}
+
+        {/* Content */}
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-xl bg-gray-100" />
+            ))}
+          </div>
+        ) : allOffers.length === 0 ? (
+          <div className="py-16 text-center text-gray-400">
+            <p className="text-lg font-medium">No incoming offers yet.</p>
+            <p className="mt-2 text-sm">
+              When buyers make offers on your artworks, they will appear here.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-6">
+            {offersByListing.map(
+              (group: { listing: Listing; offers: Offer[] }) => (
+                <div key={group.listing.listing_id}>
+                  {/* Listing group header */}
+                  <div className="mb-3 rounded-xl bg-gray-50 px-5 py-3 flex items-center gap-3">
+                    <span className="text-sm font-semibold text-gray-700">
+                      Listing #{group.listing.listing_id}
+                    </span>
+                    <span className="font-mono text-xs text-gray-400">
+                      {group.listing.metadata_cid.slice(0, 14)}...
+                    </span>
+                    <span className="ml-auto text-xs text-gray-400">
+                      {group.offers.length} offer
+                      {group.offers.length !== 1 ? "s" : ""}
+                    </span>
+                  </div>
+
+                  {/* Offers table */}
+                  <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
+                    <table className="min-w-full divide-y divide-gray-100">
+                      <thead className="bg-gray-50 text-xs font-medium uppercase text-gray-400">
+                        <tr>
+                          <th className="px-5 py-3 text-left">Offerer</th>
+                          <th className="px-5 py-3 text-right">Amount</th>
+                          <th className="px-5 py-3 text-center">Status</th>
+                          <th className="px-5 py-3 text-left">Created</th>
+                          <th className="px-5 py-3" />
+                        </tr>
+                      </thead>
+                      <tbody className="divide-y divide-gray-50">
+                        {group.offers.map((o: Offer) => (
+                          <tr key={o.offer_id} className="text-sm">
+                            <td className="px-5 py-3 font-mono text-xs text-gray-500">
+                              {o.offerer.slice(0, 6)}...{o.offerer.slice(-4)}
+                            </td>
+                            <td className="px-5 py-3 text-right font-semibold text-gray-800">
+                              {stroopsToXlm(o.amount)} XLM
+                            </td>
+                            <td className="px-5 py-3 text-center">
+                              <span
+                                className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                                  STATUS_COLOR[o.status] ?? ""
+                                }`}
+                              >
+                                {o.status}
+                              </span>
+                            </td>
+                            <td className="px-5 py-3 text-xs text-gray-400">
+                              {new Date(o.created_at * 1000).toLocaleDateString()}
+                            </td>
+                            <td className="px-5 py-3 text-right">
+                              {o.status === "Pending" && (
+                                <div className="flex items-center justify-end gap-2">
+                                  <button
+                                    onClick={async () => {
+                                      const ok = await accept(o.offer_id);
+                                      if (ok) refresh();
+                                    }}
+                                    disabled={isAccepting || isRejecting}
+                                    className="flex items-center gap-1 rounded-lg bg-green-500 px-2.5 py-1 text-xs text-white hover:bg-green-600 disabled:opacity-50"
+                                  >
+                                    <CheckCircle size={12} />
+                                    Accept
+                                  </button>
+                                  <button
+                                    onClick={async () => {
+                                      const ok = await reject(o.offer_id);
+                                      if (ok) refresh();
+                                    }}
+                                    disabled={isAccepting || isRejecting}
+                                    className="flex items-center gap-1 rounded-lg border border-red-200 px-2.5 py-1 text-xs text-red-500 hover:bg-red-50 disabled:opacity-50"
+                                  >
+                                    <XCircle size={12} />
+                                    Reject
+                                  </button>
+                                </div>
+                              )}
+                            </td>
+                          </tr>
+                        ))}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )
+            )}
+          </div>
+        )}
+      </div>
+    </WalletGuard>
+  );
+}

--- a/frontend/afristore-app/src/app/offers/page.tsx
+++ b/frontend/afristore-app/src/app/offers/page.tsx
@@ -1,0 +1,193 @@
+// ─────────────────────────────────────────────────────────────
+// app/offers/page.tsx — Offerer Dashboard
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useWalletContext } from "@/context/WalletContext";
+import { useOffererOffers, useWithdrawOffer } from "@/hooks/useOffers";
+import { stroopsToXlm, Offer } from "@/lib/contract";
+import { ShoppingCart, Clock, CheckCircle, XCircle } from "lucide-react";
+
+type Tab = "all" | "Pending" | "Accepted" | "Rejected" | "Withdrawn";
+
+const STATUS_COLOR: Record<string, string> = {
+  Pending: "text-yellow-500 bg-yellow-50",
+  Accepted: "text-green-600 bg-green-50",
+  Rejected: "text-red-500 bg-red-50",
+  Withdrawn: "text-gray-500 bg-gray-100",
+};
+
+import { WalletGuard } from "@/components/WalletGuard";
+
+export default function OffersPage() {
+  const { publicKey } = useWalletContext();
+  const { offers, isLoading, error, refresh } = useOffererOffers(publicKey);
+  const { withdraw, isWithdrawing, error: withdrawError } = useWithdrawOffer(publicKey);
+  const [tab, setTab] = useState<Tab>("all");
+
+  const pendingCnt = offers.filter((o: Offer) => o.status === "Pending").length;
+  const acceptedCnt = offers.filter((o: Offer) => o.status === "Accepted").length;
+
+  const filtered =
+    tab === "all" ? offers : offers.filter((o: Offer) => o.status === tab);
+
+  const tabs: { key: Tab; label: string }[] = [
+    { key: "all", label: "All" },
+    { key: "Pending", label: "Pending" },
+    { key: "Accepted", label: "Accepted" },
+    { key: "Rejected", label: "Rejected" },
+    { key: "Withdrawn", label: "Withdrawn" },
+  ];
+
+  return (
+    <WalletGuard actionName="To access your offers dashboard">
+      <div>
+        <div className="mb-8">
+          <h1 className="text-3xl font-display font-bold text-gray-900">
+            My Offers
+          </h1>
+          <p className="mt-1 font-mono text-sm text-gray-400">
+            {publicKey}
+          </p>
+        </div>
+
+        {/* Stats */}
+        <div className="mb-8 grid gap-4 sm:grid-cols-3">
+          {[
+            { label: "Total Offers", value: offers.length, icon: ShoppingCart },
+            { label: "Pending", value: pendingCnt, icon: Clock },
+            { label: "Accepted", value: acceptedCnt, icon: CheckCircle },
+          ].map(({ label, value, icon: Icon }) => (
+            <div
+              key={label}
+              className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm"
+            >
+              <div className="flex items-center justify-between">
+                <p className="text-sm text-gray-500">{label}</p>
+                <Icon size={18} className="text-brand-400" />
+              </div>
+              <p className="mt-2 text-3xl font-bold text-gray-900">{value}</p>
+            </div>
+          ))}
+        </div>
+
+        {/* Tabs */}
+        <div className="mb-6 flex gap-2 border-b border-gray-200">
+          {tabs.map(({ key, label }) => (
+            <button
+              key={key}
+              onClick={() => setTab(key)}
+              className={`pb-3 px-1 text-sm font-medium transition-colors border-b-2 ${
+                tab === key
+                  ? "border-brand-500 text-brand-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+
+        {/* Error banners */}
+        {error && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {error}
+          </div>
+        )}
+        {withdrawError && (
+          <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+            {withdrawError}
+          </div>
+        )}
+
+        {/* Content */}
+        {isLoading ? (
+          <div className="space-y-3">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="h-20 animate-pulse rounded-xl bg-gray-100" />
+            ))}
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="py-16 text-center text-gray-400">
+            <p className="text-lg font-medium">
+              {tab === "all" ? "No offers yet." : `No ${tab.toLowerCase()} offers.`}
+            </p>
+            {tab === "all" && (
+              <Link
+                href="/"
+                className="mt-4 inline-block rounded-lg bg-brand-500 px-5 py-2 text-sm font-medium text-white hover:bg-brand-600"
+              >
+                Browse listings
+              </Link>
+            )}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-gray-100">
+              <thead className="bg-gray-50 text-xs font-medium uppercase text-gray-400">
+                <tr>
+                  <th className="px-5 py-3 text-left">Offer ID</th>
+                  <th className="px-5 py-3 text-left">Listing</th>
+                  <th className="px-5 py-3 text-right">Amount</th>
+                  <th className="px-5 py-3 text-center">Status</th>
+                  <th className="px-5 py-3 text-left">Created</th>
+                  <th className="px-5 py-3" />
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-50">
+                {filtered.map((o: Offer) => (
+                  <tr key={o.offer_id} className="text-sm">
+                    <td className="px-5 py-3 font-mono text-gray-500">
+                      #{o.offer_id}
+                    </td>
+                    <td className="px-5 py-3 font-mono text-xs">
+                      <Link
+                        href={`/listing/${o.listing_id}`}
+                        className="text-brand-500 hover:text-brand-600 hover:underline"
+                      >
+                        #{o.listing_id}
+                      </Link>
+                    </td>
+                    <td className="px-5 py-3 text-right font-semibold text-gray-800">
+                      {stroopsToXlm(o.amount)} XLM
+                    </td>
+                    <td className="px-5 py-3 text-center">
+                      <span
+                        className={`rounded-full px-2.5 py-0.5 text-xs font-semibold ${
+                          STATUS_COLOR[o.status] ?? ""
+                        }`}
+                      >
+                        {o.status}
+                      </span>
+                    </td>
+                    <td className="px-5 py-3 text-xs text-gray-400">
+                      {new Date(o.created_at * 1000).toLocaleDateString()}
+                    </td>
+                    <td className="px-5 py-3 text-right">
+                      {o.status === "Pending" && (
+                        <button
+                          onClick={async () => {
+                            const ok = await withdraw(o.offer_id);
+                            if (ok) refresh();
+                          }}
+                          disabled={isWithdrawing}
+                          className="flex items-center gap-1 rounded-lg border border-red-200 px-2.5 py-1 text-xs text-red-500 hover:bg-red-50 disabled:opacity-50"
+                        >
+                          <XCircle size={12} />
+                          Withdraw
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </WalletGuard>
+  );
+}

--- a/frontend/afristore-app/src/components/ConnectWalletModal.tsx
+++ b/frontend/afristore-app/src/components/ConnectWalletModal.tsx
@@ -109,7 +109,7 @@ export function ConnectWalletModal({ isOpen, onClose }: ConnectWalletModalProps)
                                 </div>
                                 <h3 className="font-display font-bold text-midnight-900">Freighter Not Found</h3>
                                 <p className="mt-2 text-xs text-brand-700 leading-relaxed">
-                                    We couldn't detect the Freighter wallet. Please install it to continue.
+                                    We couldn&apos;t detect the Freighter wallet. Please install it to continue.
                                 </p>
                                 <a
                                     href="https://www.freighter.app/"

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
-import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck } from "lucide-react";
+import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck, Tag, Inbox } from "lucide-react";
 import { ConnectWalletModal } from "./ConnectWalletModal";
 
 export function Navbar() {
@@ -66,6 +66,24 @@ export function Navbar() {
               >
                 <LayoutDashboard size={16} />
                 Dashboard
+              </Link>
+            )}
+            {isConnected && (
+              <Link
+                href="/offers"
+                className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+              >
+                <Tag size={16} />
+                My Offers
+              </Link>
+            )}
+            {isConnected && (
+              <Link
+                href="/offers/incoming"
+                className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+              >
+                <Inbox size={16} />
+                Offer Inbox
               </Link>
             )}
           </div>
@@ -146,6 +164,26 @@ export function Navbar() {
                 >
                   <LayoutDashboard size={20} className="text-brand-500" />
                   Dashboard
+                </Link>
+              )}
+              {isConnected && (
+                <Link
+                  href="/offers"
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                >
+                  <Tag size={20} className="text-brand-500" />
+                  My Offers
+                </Link>
+              )}
+              {isConnected && (
+                <Link
+                  href="/offers/incoming"
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                >
+                  <Inbox size={20} className="text-brand-500" />
+                  Offer Inbox
                 </Link>
               )}
             </div>

--- a/frontend/afristore-app/src/hooks/useOffers.ts
+++ b/frontend/afristore-app/src/hooks/useOffers.ts
@@ -1,0 +1,262 @@
+// ─────────────────────────────────────────────────────────────
+// hooks/useOffers.ts — Offer data + actions hooks
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  getOffer,
+  getOffererOffers,
+  getListingOffers,
+  getArtistListings,
+  getListing,
+  withdrawOffer,
+  acceptOffer,
+  rejectOffer,
+  Offer,
+  Listing,
+} from "@/lib/contract";
+
+// ── useOffererOffers ─────────────────────────────────────────
+
+/**
+ * Fetches all offers placed by a user, enriched with listing data.
+ */
+export interface OffererOffer extends Offer {
+  listing?: Listing;
+}
+
+export function useOffererOffers(publicKey: string | null) {
+  const [offers, setOffers] = useState<OffererOffer[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!publicKey) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const ids = await getOffererOffers(publicKey);
+      const resolved = await Promise.all(ids.map((id) => getOffer(id)));
+
+      // Enrich each offer with its listing data.
+      const enriched: OffererOffer[] = await Promise.all(
+        resolved.map(async (offer) => {
+          try {
+            const listing = await getListing(offer.listing_id);
+            return { ...offer, listing };
+          } catch {
+            return { ...offer };
+          }
+        })
+      );
+
+      setOffers(enriched.sort((a, b) => b.created_at - a.created_at));
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load your offers"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { offers, isLoading, error, refresh };
+}
+
+// ── useListingOffers ─────────────────────────────────────────
+
+/**
+ * Fetches all offers for a specific listing.
+ */
+export function useListingOffers(listingId: number | null) {
+  const [offers, setOffers] = useState<Offer[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (listingId === null) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const ids = await getListingOffers(listingId);
+      const resolved = await Promise.all(ids.map((id) => getOffer(id)));
+      setOffers(resolved.sort((a, b) => b.created_at - a.created_at));
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load listing offers"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [listingId]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { offers, isLoading, error, refresh };
+}
+
+// ── useIncomingOffers ────────────────────────────────────────
+
+/**
+ * Fetches offers on all listings owned by the user.
+ * Gets the artist's listings, then for each active listing, fetches its offers.
+ */
+export function useIncomingOffers(ownerPublicKey: string | null) {
+  const [offersByListing, setOffersByListing] = useState<
+    Array<{ listing: Listing; offers: Offer[] }>
+  >([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!ownerPublicKey) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const listingIds = await getArtistListings(ownerPublicKey);
+      const listings = await Promise.all(
+        listingIds.map((id) => getListing(id))
+      );
+
+      const result: Array<{ listing: Listing; offers: Offer[] }> = [];
+
+      // Only fetch offers for active listings.
+      const activeListings = listings.filter((l) => l.status === "Active");
+
+      await Promise.all(
+        activeListings.map(async (listing) => {
+          try {
+            const offerIds = await getListingOffers(listing.listing_id);
+            const offers = await Promise.all(
+              offerIds.map((id) => getOffer(id))
+            );
+            result.push({
+              listing,
+              offers: offers.sort((a, b) => b.created_at - a.created_at),
+            });
+          } catch {
+            // Skip listings whose offers fail to load.
+          }
+        })
+      );
+
+      setOffersByListing(result);
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load incoming offers"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [ownerPublicKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { offersByListing, isLoading, error, refresh };
+}
+
+// ── useWithdrawOffer ─────────────────────────────────────────
+
+export function useWithdrawOffer(publicKey: string | null) {
+  const [isWithdrawing, setIsWithdrawing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const withdraw = useCallback(
+    async (offerId: number): Promise<boolean> => {
+      if (!publicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsWithdrawing(true);
+      setError(null);
+      try {
+        await withdrawOffer(publicKey, offerId);
+        return true;
+      } catch (err: unknown) {
+        setError(
+          err instanceof Error ? err.message : "Failed to withdraw offer"
+        );
+        return false;
+      } finally {
+        setIsWithdrawing(false);
+      }
+    },
+    [publicKey]
+  );
+
+  return { withdraw, isWithdrawing, error };
+}
+
+// ── useAcceptOffer ───────────────────────────────────────────
+
+export function useAcceptOffer(publicKey: string | null) {
+  const [isAccepting, setIsAccepting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const accept = useCallback(
+    async (offerId: number): Promise<boolean> => {
+      if (!publicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsAccepting(true);
+      setError(null);
+      try {
+        await acceptOffer(publicKey, offerId);
+        return true;
+      } catch (err: unknown) {
+        setError(
+          err instanceof Error ? err.message : "Failed to accept offer"
+        );
+        return false;
+      } finally {
+        setIsAccepting(false);
+      }
+    },
+    [publicKey]
+  );
+
+  return { accept, isAccepting, error };
+}
+
+// ── useRejectOffer ───────────────────────────────────────────
+
+export function useRejectOffer(publicKey: string | null) {
+  const [isRejecting, setIsRejecting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reject = useCallback(
+    async (offerId: number): Promise<boolean> => {
+      if (!publicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsRejecting(true);
+      setError(null);
+      try {
+        await rejectOffer(publicKey, offerId);
+        return true;
+      } catch (err: unknown) {
+        setError(
+          err instanceof Error ? err.message : "Failed to reject offer"
+        );
+        return false;
+      } finally {
+        setIsRejecting(false);
+      }
+    },
+    [publicKey]
+  );
+
+  return { reject, isRejecting, error };
+}

--- a/frontend/afristore-app/src/lib/contract.ts
+++ b/frontend/afristore-app/src/lib/contract.ts
@@ -285,3 +285,165 @@ export function stroopsToXlm(stroops: bigint): string {
   const xlm = Number(stroops) / 10_000_000;
   return xlm.toFixed(7).replace(/\.?0+$/, "");
 }
+
+// ── Offer types mirrored from the Rust contract ──────────────
+
+export type OfferStatus = "Pending" | "Accepted" | "Rejected" | "Withdrawn";
+
+export interface Offer {
+  offer_id: number;
+  listing_id: number;
+  offerer: string;
+  amount: bigint;
+  token: string;
+  status: OfferStatus;
+  created_at: number;
+}
+
+// ── Offer ScVal parsing ──────────────────────────────────────
+
+function parseOfferFromScVal(raw: unknown): Offer {
+  const obj = scValToNative(raw as xdr.ScVal) as Record<string, unknown>;
+
+  return {
+    offer_id: Number(obj["offer_id"]),
+    listing_id: Number(obj["listing_id"]),
+    offerer: (obj["offerer"] as Address).toString(),
+    amount: BigInt(obj["amount"] as bigint),
+    token: String(obj["token"]),
+    status: String(obj["status"]) as OfferStatus,
+    created_at: Number(obj["created_at"]),
+  };
+}
+
+// ── Offer contract methods ───────────────────────────────────
+
+/**
+ * make_offer — Places an offer on a listing.
+ *
+ * @param offererPublicKey  Stellar public key of the offerer (must match Freighter)
+ * @param listingId         The listing to place an offer on
+ * @param amountXlm         Offer amount in XLM (will be converted to stroops)
+ * @returns                 The new offer_id (number)
+ */
+export async function makeOffer(
+  offererPublicKey: string,
+  listingId: number,
+  amountXlm: number
+): Promise<number> {
+  const amountStroops = BigInt(Math.round(amountXlm * 10_000_000));
+
+  const args: xdr.ScVal[] = [
+    new Address(offererPublicKey).toScVal(),
+    nativeToScVal(BigInt(listingId), { type: "u64" }),
+    nativeToScVal(amountStroops, { type: "i128" }),
+    nativeToScVal("XLM", { type: "symbol" }),
+  ];
+
+  const retVal = await invokeContract(offererPublicKey, "make_offer", args);
+  return Number(scValToNative(retVal));
+}
+
+/**
+ * withdraw_offer — Offerer withdraws their pending offer.
+ */
+export async function withdrawOffer(
+  offererPublicKey: string,
+  offerId: number
+): Promise<boolean> {
+  const args: xdr.ScVal[] = [
+    new Address(offererPublicKey).toScVal(),
+    nativeToScVal(BigInt(offerId), { type: "u64" }),
+  ];
+
+  await invokeContract(offererPublicKey, "withdraw_offer", args);
+  return true;
+}
+
+/**
+ * accept_offer — Listing owner accepts an offer.
+ */
+export async function acceptOffer(
+  ownerPublicKey: string,
+  offerId: number
+): Promise<boolean> {
+  const args: xdr.ScVal[] = [
+    new Address(ownerPublicKey).toScVal(),
+    nativeToScVal(BigInt(offerId), { type: "u64" }),
+  ];
+
+  await invokeContract(ownerPublicKey, "accept_offer", args);
+  return true;
+}
+
+/**
+ * reject_offer — Listing owner rejects an offer.
+ */
+export async function rejectOffer(
+  ownerPublicKey: string,
+  offerId: number
+): Promise<boolean> {
+  const args: xdr.ScVal[] = [
+    new Address(ownerPublicKey).toScVal(),
+    nativeToScVal(BigInt(offerId), { type: "u64" }),
+  ];
+
+  await invokeContract(ownerPublicKey, "reject_offer", args);
+  return true;
+}
+
+/**
+ * get_offer — Fetch a single offer by ID (read-only, no Freighter needed).
+ */
+export async function getOffer(offerId: number): Promise<Offer> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const args: xdr.ScVal[] = [
+    nativeToScVal(BigInt(offerId), { type: "u64" }),
+  ];
+
+  const retVal = await invokeContract(DUMMY_KEY, "get_offer", args, true);
+  return parseOfferFromScVal(retVal);
+}
+
+/**
+ * get_listing_offers — Fetch all offer IDs for a listing (read-only).
+ */
+export async function getListingOffers(listingId: number): Promise<number[]> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const args: xdr.ScVal[] = [
+    nativeToScVal(BigInt(listingId), { type: "u64" }),
+  ];
+
+  const retVal = await invokeContract(
+    DUMMY_KEY,
+    "get_listing_offers",
+    args,
+    true
+  );
+
+  const ids = scValToNative(retVal) as bigint[];
+  return ids.map(Number);
+}
+
+/**
+ * get_offerer_offers — Fetch all offer IDs placed by an offerer (read-only).
+ */
+export async function getOffererOffers(
+  offererPublicKey: string
+): Promise<number[]> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const args: xdr.ScVal[] = [new Address(offererPublicKey).toScVal()];
+
+  const retVal = await invokeContract(
+    DUMMY_KEY,
+    "get_offerer_offers",
+    args,
+    true
+  );
+
+  const ids = scValToNative(retVal) as bigint[];
+  return ids.map(Number);
+}


### PR DESCRIPTION
## Summary

- Built the **Offerer Dashboard** at `/offers` where buyers can track their placed offers, filter by status (All/Pending/Accepted/Rejected/Withdrawn), and withdraw pending offers
- Built the **Owner Offer Inbox** at `/offers/incoming` where artists can review incoming offers grouped by listing and accept or reject pending offers
- Added offer types (`Offer`, `OfferStatus`) and contract client methods (`make_offer`, `withdraw_offer`, `accept_offer`, `reject_offer`, plus read queries) to `lib/contract.ts`
- Created `hooks/useOffers.ts` with hooks for fetching and mutating offer state (`useOffererOffers`, `useIncomingOffers`, `useWithdrawOffer`, `useAcceptOffer`, `useRejectOffer`)
- Added "My Offers" and "Offer Inbox" navigation links in the Navbar for connected users (desktop and mobile)

## Test plan

- [ ] Verify `/offers` page renders with wallet connected, shows empty state when no offers exist
- [ ] Verify `/offers/incoming` page renders with wallet connected, shows empty state when no incoming offers
- [ ] Verify status tab filtering works on the offerer dashboard
- [ ] Verify Withdraw button appears only for Pending offers
- [ ] Verify Accept/Reject buttons appear only for Pending offers in the inbox
- [ ] Verify navigation links appear in Navbar when wallet is connected
- [ ] Verify WalletGuard prompts connection when wallet is not connected

Closes #19
Closes #20