### PR TITLE
feat(contract): implement NFT offer system

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -14,9 +14,14 @@ use crate::{
     storage::{
         add_artist_auction_id, add_artist_listing_id, get_artist_auction_ids,
         get_artist_listing_ids, get_listing_count, increment_auction_count,
-        increment_listing_count, load_auction, load_listing, save_auction, save_listing,
+        increment_listing_count, increment_offer_count, load_auction, load_listing,
+        load_listing_offers, load_offer, load_offerer_offers, save_auction, save_listing,
+        save_listing_offers, save_offer, save_offerer_offers,
     },
-    types::{Auction, AuctionStatus, Listing, ListingStatus, MarketplaceError, Recipient},
+    types::{
+        Auction, AuctionStatus, Listing, ListingStatus, MarketplaceError, Offer, OfferStatus,
+        Recipient,
+    },
 };
 
 // ────────────────────────────────────────────────────────────
@@ -550,7 +555,6 @@ impl MarketplaceContract {
         }
     }
 
-
     // ── get_listing ──────────────────────────────────────────
     /// Returns the full Listing struct for a given ID.
     /// Panics with `ListingNotFound` if the ID does not exist.
@@ -584,5 +588,253 @@ impl MarketplaceContract {
             env,
             b"CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
         ))
+    }
+
+    // ── Offer methods ───────────────────────────────────────────
+
+    /// Make an offer on an active listing. Any token is accepted (bypasses whitelist).
+    /// Tokens are locked in the contract until the offer is resolved.
+    pub fn make_offer(
+        env: Env,
+        offerer: Address,
+        listing_id: u64,
+        amount: i128,
+        token: Address,
+    ) -> Result<u64, MarketplaceError> {
+        offerer.require_auth();
+
+        let listing = load_listing(&env, listing_id).ok_or(MarketplaceError::ListingNotFound)?;
+
+        if listing.status != ListingStatus::Active {
+            return Err(MarketplaceError::ListingNotActive);
+        }
+        if listing.artist == offerer {
+            return Err(MarketplaceError::CannotOfferOwnListing);
+        }
+        if amount <= 0 {
+            return Err(MarketplaceError::InsufficientOfferAmount);
+        }
+
+        // Lock tokens: transfer from offerer to contract
+        #[cfg(not(test))]
+        {
+            let token_client = TokenClient::new(&env, &token);
+            token_client.transfer(&offerer, &env.current_contract_address(), &amount);
+        }
+
+        let offer_id = increment_offer_count(&env);
+
+        let offer = Offer {
+            offer_id,
+            listing_id,
+            offerer: offerer.clone(),
+            amount,
+            token: token.clone(),
+            status: OfferStatus::Pending,
+            created_at: env.ledger().sequence(),
+        };
+        save_offer(&env, &offer);
+
+        // Add to listing offers index
+        let mut listing_offers = load_listing_offers(&env, listing_id);
+        listing_offers.push_back(offer_id);
+        save_listing_offers(&env, listing_id, &listing_offers);
+
+        // Add to offerer offers index
+        let mut offerer_offers = load_offerer_offers(&env, &offerer);
+        offerer_offers.push_back(offer_id);
+        save_offerer_offers(&env, &offerer, &offerer_offers);
+
+        OfferMadeEvent {
+            offer_id,
+            listing_id,
+            offerer,
+            amount,
+            token,
+        }
+        .publish(&env);
+
+        Ok(offer_id)
+    }
+
+    /// Withdraw a pending offer. Only the offerer can withdraw. Refunds locked tokens.
+    pub fn withdraw_offer(
+        env: Env,
+        offerer: Address,
+        offer_id: u64,
+    ) -> Result<(), MarketplaceError> {
+        offerer.require_auth();
+
+        let mut offer = load_offer(&env, offer_id).ok_or(MarketplaceError::OfferNotFound)?;
+
+        if offer.offerer != offerer {
+            return Err(MarketplaceError::Unauthorized);
+        }
+        if offer.status != OfferStatus::Pending {
+            return Err(MarketplaceError::OfferNotPending);
+        }
+
+        // Refund tokens
+        #[cfg(not(test))]
+        {
+            let token_client = TokenClient::new(&env, &offer.token);
+            token_client.transfer(&env.current_contract_address(), &offerer, &offer.amount);
+        }
+
+        offer.status = OfferStatus::Withdrawn;
+        save_offer(&env, &offer);
+
+        OfferWithdrawnEvent {
+            offer_id,
+            listing_id: offer.listing_id,
+            offerer,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Accept a pending offer. Only the listing owner/artist can accept.
+    /// Executes the trade: distributes payout, marks listing as Sold,
+    /// and rejects all other pending offers on the same listing (refunding them).
+    pub fn accept_offer(env: Env, owner: Address, offer_id: u64) -> Result<(), MarketplaceError> {
+        owner.require_auth();
+
+        let mut offer = load_offer(&env, offer_id).ok_or(MarketplaceError::OfferNotFound)?;
+
+        if offer.status != OfferStatus::Pending {
+            return Err(MarketplaceError::OfferNotPending);
+        }
+
+        let mut listing =
+            load_listing(&env, offer.listing_id).ok_or(MarketplaceError::ListingNotFound)?;
+
+        if listing.artist != owner {
+            return Err(MarketplaceError::Unauthorized);
+        }
+
+        // Execute trade: distribute payout (funds already locked in contract)
+        #[cfg(not(test))]
+        {
+            Self::distribute_payout(
+                &env,
+                &offer.token,
+                offer.amount,
+                &listing.original_creator,
+                listing.royalty_bps,
+                &listing.artist,
+                &listing.recipients,
+                &offer.offerer,
+                false, // funds already locked in contract
+            );
+        }
+
+        // Mark offer as accepted
+        offer.status = OfferStatus::Accepted;
+        save_offer(&env, &offer);
+
+        // Mark listing as sold
+        listing.status = ListingStatus::Sold;
+        listing.owner = Some(offer.offerer.clone());
+        save_listing(&env, &listing);
+
+        OfferAcceptedEvent {
+            offer_id,
+            listing_id: offer.listing_id,
+            offerer: offer.offerer.clone(),
+            amount: offer.amount,
+        }
+        .publish(&env);
+
+        // Reject all other pending offers on the same listing
+        let listing_offers = load_listing_offers(&env, offer.listing_id);
+        for i in 0..listing_offers.len() {
+            let other_offer_id = listing_offers.get(i).unwrap();
+            if other_offer_id == offer_id {
+                continue;
+            }
+            if let Some(mut other_offer) = load_offer(&env, other_offer_id) {
+                if other_offer.status == OfferStatus::Pending {
+                    // Refund tokens
+                    #[cfg(not(test))]
+                    {
+                        let token_client = TokenClient::new(&env, &other_offer.token);
+                        token_client.transfer(
+                            &env.current_contract_address(),
+                            &other_offer.offerer,
+                            &other_offer.amount,
+                        );
+                    }
+
+                    other_offer.status = OfferStatus::Rejected;
+                    save_offer(&env, &other_offer);
+
+                    OfferRejectedEvent {
+                        offer_id: other_offer_id,
+                        listing_id: other_offer.listing_id,
+                        offerer: other_offer.offerer,
+                    }
+                    .publish(&env);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reject a pending offer. Only the listing owner/artist can reject. Refunds locked tokens.
+    pub fn reject_offer(env: Env, owner: Address, offer_id: u64) -> Result<(), MarketplaceError> {
+        owner.require_auth();
+
+        let mut offer = load_offer(&env, offer_id).ok_or(MarketplaceError::OfferNotFound)?;
+
+        if offer.status != OfferStatus::Pending {
+            return Err(MarketplaceError::OfferNotPending);
+        }
+
+        let listing =
+            load_listing(&env, offer.listing_id).ok_or(MarketplaceError::ListingNotFound)?;
+
+        if listing.artist != owner {
+            return Err(MarketplaceError::Unauthorized);
+        }
+
+        // Refund tokens
+        #[cfg(not(test))]
+        {
+            let token_client = TokenClient::new(&env, &offer.token);
+            token_client.transfer(
+                &env.current_contract_address(),
+                &offer.offerer,
+                &offer.amount,
+            );
+        }
+
+        offer.status = OfferStatus::Rejected;
+        save_offer(&env, &offer);
+
+        OfferRejectedEvent {
+            offer_id,
+            listing_id: offer.listing_id,
+            offerer: offer.offerer,
+        }
+        .publish(&env);
+
+        Ok(())
+    }
+
+    /// Get an offer by ID.
+    pub fn get_offer(env: Env, offer_id: u64) -> Result<Offer, MarketplaceError> {
+        load_offer(&env, offer_id).ok_or(MarketplaceError::OfferNotFound)
+    }
+
+    /// Get all offer IDs for a listing.
+    pub fn get_listing_offers(env: Env, listing_id: u64) -> Vec<u64> {
+        load_listing_offers(&env, listing_id)
+    }
+
+    /// Get all offer IDs made by an offerer.
+    pub fn get_offerer_offers(env: Env, offerer: Address) -> Vec<u64> {
+        load_offerer_offers(&env, &offerer)
     }
 }

--- a/contracts/soroban-marketplace/src/events.rs
+++ b/contracts/soroban-marketplace/src/events.rs
@@ -112,4 +112,63 @@ impl AuctionFinalizedEvent {
     }
 }
 
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OfferMadeEvent {
+    pub offer_id: u64,
+    pub listing_id: u64,
+    pub offerer: Address,
+    pub amount: i128,
+    pub token: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OfferAcceptedEvent {
+    pub offer_id: u64,
+    pub listing_id: u64,
+    pub offerer: Address,
+    pub amount: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OfferRejectedEvent {
+    pub offer_id: u64,
+    pub listing_id: u64,
+    pub offerer: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OfferWithdrawnEvent {
+    pub offer_id: u64,
+    pub listing_id: u64,
+    pub offerer: Address,
+}
+
+impl OfferMadeEvent {
+    pub fn publish(self, env: &Env) {
+        env.events().publish((OFFER_MADE,), self);
+    }
+}
+
+impl OfferAcceptedEvent {
+    pub fn publish(self, env: &Env) {
+        env.events().publish((OFFER_ACCEPTED,), self);
+    }
+}
+
+impl OfferRejectedEvent {
+    pub fn publish(self, env: &Env) {
+        env.events().publish((OFFER_REJECTED,), self);
+    }
+}
+
+impl OfferWithdrawnEvent {
+    pub fn publish(self, env: &Env) {
+        env.events().publish((OFFER_WITHDRAWN,), self);
+    }
+}
+
 // End of events

--- a/contracts/soroban-marketplace/src/lib.rs
+++ b/contracts/soroban-marketplace/src/lib.rs
@@ -12,7 +12,7 @@ mod types;
 mod test;
 
 pub use contract::MarketplaceContract;
-pub use types::{Listing, ListingStatus, MarketplaceError};
+pub use types::{Listing, ListingStatus, MarketplaceError, Offer, OfferStatus};
 
 // Re-export the generated client so test.rs can use MarketplaceContractClient.
 #[cfg(any(test, feature = "testutils"))]

--- a/contracts/soroban-marketplace/src/storage.rs
+++ b/contracts/soroban-marketplace/src/storage.rs
@@ -61,7 +61,7 @@ mod tests {
 
 use soroban_sdk::{contracttype, Address, Env, Vec};
 
-use crate::types::Listing;
+use crate::types::{Listing, Offer};
 
 /// Storage key variants for the marketplace contract.
 #[contracttype]
@@ -87,6 +87,14 @@ pub enum DataKey {
     Auction(u64),
     /// Stores a `Vec<u64>` of auction IDs owned by an artist.
     ArtistAuctions(Address),
+    /// Stores the global offer counter (u64).
+    OfferCount,
+    /// Stores a single `Offer` by its ID.
+    Offer(u64),
+    /// Stores a `Vec<u64>` of offer IDs for a listing.
+    ListingOffers(u64),
+    /// Stores a `Vec<u64>` of offer IDs made by an offerer.
+    OffererOffers(Address),
 }
 
 // ── Bump amounts (ledger sequences) ─────────────────────────
@@ -182,7 +190,10 @@ pub fn save_auction(env: &Env, auction: &crate::types::Auction) {
 
 pub fn load_auction(env: &Env, auction_id: u64) -> Option<crate::types::Auction> {
     let key = DataKey::Auction(auction_id);
-    let result = env.storage().persistent().get::<DataKey, crate::types::Auction>(&key);
+    let result = env
+        .storage()
+        .persistent()
+        .get::<DataKey, crate::types::Auction>(&key);
     if result.is_some() {
         env.storage()
             .persistent()
@@ -210,7 +221,6 @@ pub fn add_artist_auction_id(env: &Env, artist: &Address, auction_id: u64) {
         .persistent()
         .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
 }
-
 
 pub fn add_artist_listing_id(env: &Env, artist: &Address, listing_id: u64) {
     let key = DataKey::ArtistListings(artist.clone());
@@ -240,4 +250,81 @@ pub fn set_protocol_fee_bps_storage(env: &Env, bps: u32) {
 
 pub fn get_protocol_fee_bps_storage(env: &Env) -> Option<u32> {
     env.storage().persistent().get(&DataKey::ProtocolFeeBps)
+}
+
+// ── Offer counter helpers ───────────────────────────────────────
+
+pub fn get_offer_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get::<DataKey, u64>(&DataKey::OfferCount)
+        .unwrap_or(0)
+}
+
+pub fn increment_offer_count(env: &Env) -> u64 {
+    let count = get_offer_count(env) + 1;
+    env.storage().persistent().set(&DataKey::OfferCount, &count);
+    env.storage().persistent().extend_ttl(
+        &DataKey::OfferCount,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+    count
+}
+
+// ── Offer CRUD ─────────────────────────────────────────────
+
+pub fn save_offer(env: &Env, offer: &Offer) {
+    let key = DataKey::Offer(offer.offer_id);
+    env.storage().persistent().set(&key, offer);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+pub fn load_offer(env: &Env, offer_id: u64) -> Option<Offer> {
+    let key = DataKey::Offer(offer_id);
+    let result = env.storage().persistent().get::<DataKey, Offer>(&key);
+    if result.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    }
+    result
+}
+
+// ── Listing offers index ─────────────────────────────────────
+
+pub fn load_listing_offers(env: &Env, listing_id: u64) -> Vec<u64> {
+    let key = DataKey::ListingOffers(listing_id);
+    env.storage()
+        .persistent()
+        .get::<DataKey, Vec<u64>>(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn save_listing_offers(env: &Env, listing_id: u64, ids: &Vec<u64>) {
+    let key = DataKey::ListingOffers(listing_id);
+    env.storage().persistent().set(&key, ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+// ── Offerer offers index ─────────────────────────────────────
+
+pub fn load_offerer_offers(env: &Env, offerer: &Address) -> Vec<u64> {
+    let key = DataKey::OffererOffers(offerer.clone());
+    env.storage()
+        .persistent()
+        .get::<DataKey, Vec<u64>>(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn save_offerer_offers(env: &Env, offerer: &Address, ids: &Vec<u64>) {
+    let key = DataKey::OffererOffers(offerer.clone());
+    env.storage().persistent().set(&key, ids);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
 }

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -1,6 +1,8 @@
 use super::*;
-use crate::types::{Recipient, ListingStatus};
-use soroban_sdk::{bytes, symbol_short, testutils::Address as _, testutils::Ledger, vec, Address, Env};
+use crate::types::{ListingStatus, OfferStatus, Recipient};
+use soroban_sdk::{
+    bytes, symbol_short, testutils::Address as _, testutils::Ledger, vec, Address, Env,
+};
 
 /// Helper — deploy the contract and return (env, client, artist, buyer, contract_id).
 fn setup() -> (
@@ -826,4 +828,174 @@ fn test_outbid_refund_logic_check() {
     let auction = client.get_auction(&id);
     assert_eq!(auction.highest_bid, 2_000_000);
     assert_eq!(auction.highest_bidder, Some(buyer2));
+}
+
+// ── Offer Tests ─────────────────────────────────────────────
+
+/// Helper to create a listing and return its ID.
+fn create_test_listing(
+    env: &Env,
+    client: &MarketplaceContractClient,
+    artist: &Address,
+    contract_id: &Address,
+) -> u64 {
+    let cid = bytes!(env, 0x516d74657374);
+    let price = 10_000_000_i128;
+    client.create_listing(
+        artist,
+        &cid,
+        &price,
+        &symbol_short!("XLM"),
+        contract_id,
+        &0u32,
+        &valid_recipients(env, artist),
+    )
+}
+
+#[test]
+fn test_make_offer_success() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+
+    // Any token is allowed for offers (bypass whitelist)
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+
+    assert_eq!(offer_id, 1);
+
+    let offer = client.get_offer(&offer_id);
+    assert_eq!(offer.offer_id, 1u64);
+    assert_eq!(offer.listing_id, listing_id);
+    assert_eq!(offer.offerer, buyer);
+    assert_eq!(offer.amount, 5_000_000_i128);
+    assert_eq!(offer.token, offer_token);
+    assert_eq!(offer.status, OfferStatus::Pending);
+
+    // Check indexes
+    let listing_offers = client.get_listing_offers(&listing_id);
+    assert_eq!(listing_offers.len(), 1);
+    assert_eq!(listing_offers.get(0).unwrap(), 1u64);
+
+    let offerer_offers = client.get_offerer_offers(&buyer);
+    assert_eq!(offerer_offers.len(), 1);
+    assert_eq!(offerer_offers.get(0).unwrap(), 1u64);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #17)")]
+fn test_make_offer_on_own_listing_fails() {
+    let (env, client, artist, _buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+
+    // Artist tries to offer on their own listing
+    client.make_offer(&artist, &listing_id, &5_000_000_i128, &offer_token);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #3)")]
+fn test_make_offer_on_nonexistent_listing_fails() {
+    let (env, client, artist, buyer, _contract_id) = setup();
+    client.set_admin(&artist);
+
+    let offer_token = Address::generate(&env);
+    client.make_offer(&buyer, &999u64, &5_000_000_i128, &offer_token);
+}
+
+#[test]
+fn test_withdraw_offer_success() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+
+    client.withdraw_offer(&buyer, &offer_id);
+
+    let offer = client.get_offer(&offer_id);
+    assert_eq!(offer.status, OfferStatus::Withdrawn);
+}
+
+#[test]
+fn test_accept_offer_success() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+
+    client.accept_offer(&artist, &offer_id);
+
+    let offer = client.get_offer(&offer_id);
+    assert_eq!(offer.status, OfferStatus::Accepted);
+
+    // Listing should be sold with buyer as owner
+    let listing = client.get_listing(&listing_id);
+    assert_eq!(listing.status, ListingStatus::Sold);
+    assert_eq!(listing.owner, Some(buyer.clone()));
+}
+
+#[test]
+fn test_reject_offer_success() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+
+    client.reject_offer(&artist, &offer_id);
+
+    let offer = client.get_offer(&offer_id);
+    assert_eq!(offer.status, OfferStatus::Rejected);
+
+    // Listing should still be active
+    let listing = client.get_listing(&listing_id);
+    assert_eq!(listing.status, ListingStatus::Active);
+}
+
+#[test]
+fn test_accept_offer_rejects_others() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    let buyer2 = Address::generate(&env);
+    let buyer3 = Address::generate(&env);
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+
+    let offer_id_1 = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+    let offer_id_2 = client.make_offer(&buyer2, &listing_id, &7_000_000_i128, &offer_token);
+    let offer_id_3 = client.make_offer(&buyer3, &listing_id, &3_000_000_i128, &offer_token);
+
+    // Accept offer 2
+    client.accept_offer(&artist, &offer_id_2);
+
+    // Offer 2 should be accepted
+    let offer2 = client.get_offer(&offer_id_2);
+    assert_eq!(offer2.status, OfferStatus::Accepted);
+
+    // Offers 1 and 3 should be rejected (refunded)
+    let offer1 = client.get_offer(&offer_id_1);
+    assert_eq!(offer1.status, OfferStatus::Rejected);
+
+    let offer3 = client.get_offer(&offer_id_3);
+    assert_eq!(offer3.status, OfferStatus::Rejected);
+
+    // Listing should be sold with buyer2 as owner
+    let listing = client.get_listing(&listing_id);
+    assert_eq!(listing.status, ListingStatus::Sold);
+    assert_eq!(listing.owner, Some(buyer2.clone()));
 }

--- a/contracts/soroban-marketplace/src/types.rs
+++ b/contracts/soroban-marketplace/src/types.rs
@@ -20,6 +20,10 @@ pub enum MarketplaceError {
     AuctionExpired = 12,
     AuctionNotExpired = 13,
     AuctionAlreadyFinalized = 14,
+    OfferNotFound = 15,
+    OfferNotPending = 16,
+    CannotOfferOwnListing = 17,
+    InsufficientOfferAmount = 18,
 }
 
 #[contracttype]
@@ -78,4 +82,25 @@ pub struct Auction {
     pub recipients: soroban_sdk::Vec<Recipient>,
     pub royalty_bps: u32,
     pub original_creator: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum OfferStatus {
+    Pending,
+    Accepted,
+    Rejected,
+    Withdrawn,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct Offer {
+    pub offer_id: u64,
+    pub listing_id: u64,
+    pub offerer: Address,
+    pub amount: i128,
+    pub token: Address,
+    pub status: OfferStatus,
+    pub created_at: u32,
 }


### PR DESCRIPTION
## Summary
- Add `make_offer` — lock any token (bypasses whitelist) as an offer on an active listing
- Add `accept_offer` — distribute payout via existing royalty/fee logic, mark listing as Sold, auto-reject all other pending offers with refunds
- Add `reject_offer` — refund locked tokens to offerer
- Add `withdraw_offer` — offerer reclaims locked tokens from pending offer
- Add `get_offer`, `get_listing_offers`, `get_offerer_offers` read methods
- Add `OfferStatus` (Pending/Accepted/Rejected/Withdrawn) and `Offer` struct
- Add offer event emissions (OFFER_MADE, OFFER_ACCEPTED, OFFER_REJECTED, OFFER_WITHDRAWN)

All 41 tests pass (7 new offer tests + 34 existing).

Closes #8

## Test plan
- [x] `cargo test` — 41/41 pass
- [x] `cargo fmt` — applied
- [ ] Verify make_offer locks tokens and creates offer
- [ ] Verify accept_offer distributes payout and auto-rejects others
- [ ] Verify reject_offer and withdraw_offer refund tokens