### PR TITLE
feat(frontend): implement auction and bidding UI

### DIFF
--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -1,0 +1,195 @@
+// ─────────────────────────────────────────────────────────────
+// app/auctions/[id]/page.tsx — Individual auction detail page
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useEffect } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import { getAuction, stroopsToXlm, Auction } from "@/lib/contract";
+import { fetchMetadata, cidToGatewayUrl, ArtworkMetadata } from "@/lib/ipfs";
+import { useWalletContext } from "@/context/WalletContext";
+import { BiddingPanel } from "@/components/BiddingPanel";
+import {
+  ArrowLeft,
+  ExternalLink,
+  User,
+  Calendar,
+  Hash,
+  Gavel,
+  Shield,
+  Percent,
+} from "lucide-react";
+
+export default function AuctionDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const router = useRouter();
+  const { publicKey } = useWalletContext();
+
+  const [auction, setAuction] = useState<Auction | null>(null);
+  const [metadata, setMetadata] = useState<ArtworkMetadata | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadAuction = async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const a = await getAuction(Number(id));
+      setAuction(a);
+      const m = await fetchMetadata(a.metadata_cid);
+      setMetadata(m);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load auction");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    if (id) loadAuction();
+  }, [id]);
+
+  const handleRefresh = async () => {
+    try {
+      const updated = await getAuction(Number(id));
+      setAuction(updated);
+    } catch {
+      // Silently fail on refresh
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-32">
+        <div className="h-10 w-10 animate-spin rounded-full border-4 border-brand-200 border-t-brand-500" />
+      </div>
+    );
+  }
+
+  if (error || !auction) {
+    return (
+      <div className="py-20 text-center">
+        <p className="text-red-500">{error ?? "Auction not found"}</p>
+        <button
+          onClick={() => router.back()}
+          className="mt-4 text-sm text-brand-500 hover:underline"
+        >
+          Back
+        </button>
+      </div>
+    );
+  }
+
+  const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
+
+  return (
+    <div className="min-h-screen bg-gray-50 pt-24">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
+        <button
+          onClick={() => router.back()}
+          className="mb-6 flex items-center gap-1.5 text-sm text-gray-500 hover:text-brand-600"
+        >
+          <ArrowLeft size={14} />
+          Back to auctions
+        </button>
+
+        <div className="grid gap-10 lg:grid-cols-2">
+          {/* Image */}
+          <div className="relative aspect-square overflow-hidden rounded-2xl bg-brand-50">
+            {imageUrl ? (
+              <Image
+                src={imageUrl}
+                alt={metadata?.title ?? "Auction artwork"}
+                fill
+                className="object-contain"
+                unoptimized
+              />
+            ) : (
+              <div className="flex h-full items-center justify-center">
+                <Gavel size={64} className="text-brand-300" />
+              </div>
+            )}
+          </div>
+
+          {/* Details */}
+          <div className="flex flex-col">
+            <h1 className="text-3xl font-display font-bold text-gray-900">
+              {metadata?.title ?? `Auction #${auction.auction_id}`}
+            </h1>
+
+            {metadata?.description && (
+              <p className="mt-3 text-gray-600 leading-relaxed">
+                {metadata.description}
+              </p>
+            )}
+
+            <div className="mt-6 space-y-3 text-sm text-gray-500">
+              <div className="flex items-center gap-2">
+                <User size={15} />
+                <span className="font-mono break-all">{auction.creator}</span>
+              </div>
+              {metadata?.year && (
+                <div className="flex items-center gap-2">
+                  <Calendar size={15} />
+                  <span>{metadata.year}</span>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Hash size={15} />
+                <a
+                  href={`https://ipfs.io/ipfs/${auction.metadata_cid}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 font-mono text-brand-500 hover:underline"
+                >
+                  {auction.metadata_cid.slice(0, 20)}...
+                  <ExternalLink size={12} />
+                </a>
+              </div>
+              {auction.royalty_bps > 0 && (
+                <div className="flex items-center gap-2">
+                  <Percent size={15} />
+                  <span>
+                    Royalty: {(auction.royalty_bps / 100).toFixed(2)}%
+                  </span>
+                </div>
+              )}
+              <div className="flex items-center gap-2">
+                <Shield size={15} />
+                <span className="font-mono text-xs break-all">
+                  Original creator: {auction.original_creator.slice(0, 8)}...
+                  {auction.original_creator.slice(-4)}
+                </span>
+              </div>
+            </div>
+
+            {/* Bidding Panel */}
+            <div className="mt-8">
+              <BiddingPanel
+                auction={auction}
+                onBidPlaced={handleRefresh}
+                onFinalized={handleRefresh}
+              />
+            </div>
+
+            {/* On-chain info */}
+            <div className="mt-6 text-xs text-gray-400 space-y-1">
+              <p>
+                Auction ID:{" "}
+                <span className="font-mono">#{auction.auction_id}</span>
+              </p>
+              <p>
+                End time:{" "}
+                <span className="font-mono">
+                  {new Date(auction.end_time * 1000).toLocaleString()}
+                </span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/app/auctions/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/page.tsx
@@ -1,0 +1,353 @@
+// ─────────────────────────────────────────────────────────────
+// app/auctions/page.tsx — Auction Browse Page
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useMemo, useEffect } from "react";
+import Link from "next/link";
+import Image from "next/image";
+import { useAuctions } from "@/hooks/useAuctions";
+import { Auction, stroopsToXlm } from "@/lib/contract";
+import { fetchMetadata, cidToGatewayUrl, ArtworkMetadata } from "@/lib/ipfs";
+import {
+  Gavel,
+  Clock,
+  Trophy,
+  Package,
+  RefreshCw,
+  AlertCircle,
+} from "lucide-react";
+
+type Tab = "all" | "Active" | "Finalized" | "Cancelled";
+
+const STATUS_COLOR: Record<string, string> = {
+  Active: "text-green-600 bg-green-50",
+  Finalized: "text-blue-600 bg-blue-50",
+  Cancelled: "text-gray-500 bg-gray-100",
+};
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "Active", label: "Active" },
+  { key: "Finalized", label: "Finalized" },
+  { key: "Cancelled", label: "Cancelled" },
+];
+
+// ── Metadata cache ──────────────────────────────────────────
+
+const metadataCache = new Map<string, ArtworkMetadata | null>();
+
+async function getCachedMetadata(
+  cid: string
+): Promise<ArtworkMetadata | null> {
+  if (metadataCache.has(cid)) return metadataCache.get(cid) ?? null;
+  try {
+    const meta = await fetchMetadata(cid);
+    metadataCache.set(cid, meta);
+    return meta;
+  } catch {
+    metadataCache.set(cid, null);
+    return null;
+  }
+}
+
+// ── Countdown helper ────────────────────────────────────────
+
+function TimeRemaining({ endTime }: { endTime: number }) {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(Math.floor(Date.now() / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const remaining = Math.max(0, endTime - now);
+  if (remaining <= 0)
+    return <span className="text-red-500 font-semibold">Expired</span>;
+
+  const d = Math.floor(remaining / 86400);
+  const h = Math.floor((remaining % 86400) / 3600);
+  const m = Math.floor((remaining % 3600) / 60);
+  const s = remaining % 60;
+
+  return (
+    <span className="font-mono text-xs text-gray-600">
+      {d > 0 && `${d}d `}
+      {String(h).padStart(2, "0")}:{String(m).padStart(2, "0")}:
+      {String(s).padStart(2, "0")}
+    </span>
+  );
+}
+
+// ── Auction Card ────────────────────────────────────────────
+
+function AuctionCard({ auction }: { auction: Auction }) {
+  const [metadata, setMetadata] = useState<ArtworkMetadata | null>(null);
+
+  useEffect(() => {
+    getCachedMetadata(auction.metadata_cid).then(setMetadata);
+  }, [auction.metadata_cid]);
+
+  const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
+  const currentBidXlm = Number(auction.highest_bid) / 10_000_000;
+
+  return (
+    <Link
+      href={`/auctions/${auction.auction_id}`}
+      className="group rounded-2xl border border-gray-100 bg-white shadow-sm overflow-hidden hover:shadow-md hover:-translate-y-1 transition-all duration-300"
+    >
+      {/* Image */}
+      <div className="relative aspect-square bg-brand-50">
+        {imageUrl ? (
+          <Image
+            src={imageUrl}
+            alt={metadata?.title ?? "Auction artwork"}
+            fill
+            className="object-cover group-hover:scale-105 transition-transform duration-500"
+            unoptimized
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center text-5xl text-brand-300">
+            <Gavel size={48} />
+          </div>
+        )}
+
+        {/* Status badge */}
+        <span
+          className={`absolute top-3 right-3 rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
+            STATUS_COLOR[auction.status] ?? ""
+          }`}
+        >
+          {auction.status}
+        </span>
+      </div>
+
+      {/* Info */}
+      <div className="p-4 space-y-2">
+        <h3 className="font-display font-bold text-gray-900 truncate">
+          {metadata?.title ?? `Auction #${auction.auction_id}`}
+        </h3>
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5">
+            <Trophy size={13} className="text-brand-500" />
+            <span className="text-sm font-semibold text-gray-800">
+              {currentBidXlm > 0
+                ? `${stroopsToXlm(auction.highest_bid)} XLM`
+                : "No bids"}
+            </span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock size={12} className="text-gray-400" />
+            <TimeRemaining endTime={auction.end_time} />
+          </div>
+        </div>
+
+        <p className="text-xs text-gray-400">
+          Reserve: {stroopsToXlm(auction.reserve_price)} XLM
+        </p>
+      </div>
+    </Link>
+  );
+}
+
+// ── Page ────────────────────────────────────────────────────
+
+export default function AuctionsPage() {
+  const { auctions, isLoading, error, refresh } = useAuctions();
+  const [tab, setTab] = useState<Tab>("all");
+
+  const [metadataMap, setMetadataMap] = useState<
+    Map<string, ArtworkMetadata | null>
+  >(new Map());
+
+  // Resolve metadata for all auctions
+  useEffect(() => {
+    if (auctions.length === 0) return;
+    let cancelled = false;
+    const resolveAll = async () => {
+      const entries: [string, ArtworkMetadata | null][] = [];
+      await Promise.all(
+        auctions.map(async (a) => {
+          const meta = await getCachedMetadata(a.metadata_cid);
+          entries.push([a.metadata_cid, meta]);
+        })
+      );
+      if (!cancelled) setMetadataMap(new Map(entries));
+    };
+    resolveAll();
+    return () => {
+      cancelled = true;
+    };
+  }, [auctions]);
+
+  const filtered = useMemo(() => {
+    const list =
+      tab === "all" ? auctions : auctions.filter((a) => a.status === tab);
+    return [...list].sort((a, b) => b.end_time - a.end_time);
+  }, [auctions, tab]);
+
+  const activeCnt = auctions.filter((a) => a.status === "Active").length;
+  const finalizedCnt = auctions.filter((a) => a.status === "Finalized").length;
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-midnight-900 pt-24 pb-12">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <h1 className="text-4xl font-display font-bold text-white">
+            Auctions
+          </h1>
+          <p className="mt-2 text-lg text-white/60">
+            Bid on unique African artworks
+          </p>
+
+          {/* Stats */}
+          <div className="mt-8 flex flex-wrap gap-6">
+            {[
+              { label: "Total Auctions", value: auctions.length },
+              { label: "Active", value: activeCnt },
+              { label: "Finalized", value: finalizedCnt },
+            ].map(({ label, value }) => (
+              <div key={label} className="flex items-center gap-3">
+                <span className="text-2xl font-bold text-brand-400">
+                  {value}
+                </span>
+                <span className="text-sm text-white/50">{label}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="sticky top-16 z-30 border-b border-gray-200 bg-white/95 backdrop-blur-sm shadow-sm">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 py-4">
+          <div className="flex items-center justify-between">
+            <div className="flex flex-wrap gap-2">
+              {TABS.map(({ key, label }) => {
+                const isActive = tab === key;
+                return (
+                  <button
+                    key={key}
+                    onClick={() => setTab(key)}
+                    className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
+                      isActive
+                        ? "bg-brand-500 text-white shadow-md shadow-brand-500/20"
+                        : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                    }`}
+                  >
+                    {label}
+                    {key === "all" && (
+                      <span className="ml-1.5 text-xs opacity-70">
+                        ({auctions.length})
+                      </span>
+                    )}
+                    {key === "Active" && (
+                      <span className="ml-1.5 text-xs opacity-70">
+                        ({activeCnt})
+                      </span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+
+            <button
+              onClick={refresh}
+              disabled={isLoading}
+              className="rounded-xl border border-gray-200 p-2.5 text-gray-500 hover:bg-gray-50 hover:text-brand-500 disabled:opacity-50 transition-all"
+              title="Refresh auctions"
+            >
+              <RefreshCw
+                size={16}
+                className={isLoading ? "animate-spin" : ""}
+              />
+            </button>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
+        {/* Error state */}
+        {error && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-500 mb-4">
+              <AlertCircle size={32} />
+            </div>
+            <h3 className="font-display font-bold text-gray-900 text-lg">
+              Failed to load auctions
+            </h3>
+            <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
+              {error}
+            </p>
+            <button
+              onClick={refresh}
+              className="mt-6 flex items-center gap-2 rounded-xl bg-brand-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-brand-600 transition-all"
+            >
+              <RefreshCw size={14} />
+              Try Again
+            </button>
+          </div>
+        )}
+
+        {/* Loading skeletons */}
+        {isLoading && !error && (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {Array.from({ length: 8 }).map((_, i) => (
+              <div
+                key={i}
+                className="animate-pulse rounded-2xl border border-gray-100 bg-white overflow-hidden"
+              >
+                <div className="aspect-square bg-gray-100" />
+                <div className="p-4 space-y-3">
+                  <div className="h-4 w-3/4 rounded bg-gray-100" />
+                  <div className="h-3 w-1/2 rounded bg-gray-100" />
+                  <div className="h-3 w-1/3 rounded bg-gray-100" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty state */}
+        {!isLoading && !error && filtered.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-20">
+            <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-brand-50 text-brand-500 mb-4">
+              <Package size={32} />
+            </div>
+            <h3 className="font-display font-bold text-gray-900 text-lg">
+              No auctions found
+            </h3>
+            <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
+              {tab === "all"
+                ? "No auctions have been created yet. Check back soon!"
+                : `No ${tab.toLowerCase()} auctions at the moment.`}
+            </p>
+            {tab !== "all" && (
+              <button
+                onClick={() => setTab("all")}
+                className="mt-6 flex items-center gap-2 rounded-xl bg-brand-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-brand-600 transition-all"
+              >
+                View All Auctions
+              </button>
+            )}
+          </div>
+        )}
+
+        {/* Auction grid */}
+        {!isLoading && !error && filtered.length > 0 && (
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {filtered.map((auction) => (
+              <AuctionCard key={auction.auction_id} auction={auction} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/components/BiddingPanel.tsx
+++ b/frontend/afristore-app/src/components/BiddingPanel.tsx
@@ -1,0 +1,318 @@
+// ─────────────────────────────────────────────────────────────
+// components/BiddingPanel.tsx — Auction bidding UI
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { Auction, stroopsToXlm } from "@/lib/contract";
+import { useWalletContext } from "@/context/WalletContext";
+import { usePlaceBid, useFinalizeAuction } from "@/hooks/useAuctions";
+import { GuardButton } from "@/components/WalletGuard";
+import {
+  Gavel,
+  Clock,
+  Trophy,
+  User,
+  AlertCircle,
+  CheckCircle,
+  Loader2,
+} from "lucide-react";
+
+interface BiddingPanelProps {
+  auction: Auction;
+  onBidPlaced?: () => void;
+  onFinalized?: () => void;
+}
+
+const STATUS_COLOR: Record<string, string> = {
+  Active: "text-green-600 bg-green-50",
+  Finalized: "text-blue-600 bg-blue-50",
+  Cancelled: "text-gray-500 bg-gray-100",
+};
+
+function truncateAddress(addr: string): string {
+  return `${addr.slice(0, 4)}...${addr.slice(-4)}`;
+}
+
+function useCountdown(endTime: number) {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setNow(Math.floor(Date.now() / 1000));
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const remaining = Math.max(0, endTime - now);
+  const days = Math.floor(remaining / 86400);
+  const hours = Math.floor((remaining % 86400) / 3600);
+  const minutes = Math.floor((remaining % 3600) / 60);
+  const seconds = remaining % 60;
+  const isExpired = remaining <= 0;
+
+  return { days, hours, minutes, seconds, remaining, isExpired };
+}
+
+export function BiddingPanel({
+  auction,
+  onBidPlaced,
+  onFinalized,
+}: BiddingPanelProps) {
+  const { publicKey } = useWalletContext();
+  const { bid, isBidding, error: bidError } = usePlaceBid(publicKey);
+  const { finalize, isFinalizing, error: finalizeError } =
+    useFinalizeAuction(publicKey);
+
+  const { days, hours, minutes, seconds, isExpired } = useCountdown(
+    auction.end_time
+  );
+
+  const [bidAmount, setBidAmount] = useState("");
+  const [bidSuccess, setBidSuccess] = useState(false);
+
+  const currentBidXlm = Number(auction.highest_bid) / 10_000_000;
+  const reserveXlm = Number(auction.reserve_price) / 10_000_000;
+  const minimumBid = Math.max(
+    currentBidXlm > 0 ? currentBidXlm + 0.0000001 : reserveXlm,
+    reserveXlm
+  );
+
+  const isOwn = publicKey === auction.creator;
+  const isActive = auction.status === "Active";
+  const canBid = isActive && !isExpired && !isOwn;
+  const canFinalize = isActive && isExpired;
+
+  const bidValidation = useMemo(() => {
+    const amount = parseFloat(bidAmount);
+    if (!bidAmount) return null;
+    if (isNaN(amount) || amount <= 0) return "Enter a valid amount";
+    if (amount < reserveXlm)
+      return `Bid must be at least ${reserveXlm} XLM (reserve price)`;
+    if (currentBidXlm > 0 && amount <= currentBidXlm)
+      return `Bid must be higher than current bid (${stroopsToXlm(auction.highest_bid)} XLM)`;
+    return null;
+  }, [bidAmount, reserveXlm, currentBidXlm, auction.highest_bid]);
+
+  const handleBid = async () => {
+    const amount = parseFloat(bidAmount);
+    if (isNaN(amount) || bidValidation) return;
+
+    const success = await bid(auction.auction_id, amount);
+    if (success) {
+      setBidSuccess(true);
+      setBidAmount("");
+      onBidPlaced?.();
+    }
+  };
+
+  const handleFinalize = async () => {
+    const success = await finalize(auction.auction_id);
+    if (success) {
+      onFinalized?.();
+    }
+  };
+
+  return (
+    <div className="rounded-2xl border border-brand-100 bg-brand-50 p-5 space-y-5">
+      {/* Status badge */}
+      <div className="flex items-center justify-between">
+        <span
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${
+            STATUS_COLOR[auction.status] ?? ""
+          }`}
+        >
+          {auction.status}
+        </span>
+
+        {isActive && !isExpired && (
+          <div className="flex items-center gap-1.5 text-sm text-gray-500">
+            <Clock size={14} />
+            <span className="font-mono text-xs">
+              {days > 0 && `${days}d `}
+              {String(hours).padStart(2, "0")}:
+              {String(minutes).padStart(2, "0")}:
+              {String(seconds).padStart(2, "0")}
+            </span>
+          </div>
+        )}
+
+        {isActive && isExpired && (
+          <span className="text-xs font-semibold text-red-500">Expired</span>
+        )}
+      </div>
+
+      {/* Countdown (large display for active auctions) */}
+      {isActive && !isExpired && (
+        <div className="grid grid-cols-4 gap-2 text-center">
+          {[
+            { label: "Days", value: days },
+            { label: "Hours", value: hours },
+            { label: "Mins", value: minutes },
+            { label: "Secs", value: seconds },
+          ].map(({ label, value }) => (
+            <div
+              key={label}
+              className="rounded-xl bg-white p-2 shadow-sm border border-gray-100"
+            >
+              <p className="text-2xl font-bold text-gray-900">
+                {String(value).padStart(2, "0")}
+              </p>
+              <p className="text-[10px] font-medium text-gray-400 uppercase tracking-wider">
+                {label}
+              </p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Current highest bid */}
+      <div>
+        <div className="flex items-center gap-2 text-brand-600">
+          <Trophy size={16} />
+          <span className="text-3xl font-bold">
+            {currentBidXlm > 0
+              ? `${stroopsToXlm(auction.highest_bid)} XLM`
+              : "No bids yet"}
+          </span>
+        </div>
+        {auction.highest_bidder && (
+          <p className="mt-1 flex items-center gap-1.5 text-xs text-gray-400">
+            <User size={12} />
+            Highest bidder:{" "}
+            <span className="font-mono">
+              {truncateAddress(auction.highest_bidder)}
+            </span>
+          </p>
+        )}
+      </div>
+
+      {/* Reserve price */}
+      <div className="text-xs text-gray-500">
+        Reserve price:{" "}
+        <span className="font-semibold text-gray-700">
+          {stroopsToXlm(auction.reserve_price)} XLM
+        </span>
+      </div>
+
+      {/* Bid success */}
+      {bidSuccess && (
+        <div className="flex items-center gap-2 rounded-lg bg-green-100 px-3 py-2 text-sm font-medium text-green-700">
+          <CheckCircle size={16} />
+          Bid placed successfully!
+        </div>
+      )}
+
+      {/* Errors */}
+      {bidError && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-500">
+          <AlertCircle size={14} />
+          {bidError}
+        </div>
+      )}
+      {finalizeError && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 px-3 py-2 text-sm text-red-500">
+          <AlertCircle size={14} />
+          {finalizeError}
+        </div>
+      )}
+
+      {/* Bid input + button */}
+      {canBid && (
+        <div className="space-y-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              Your Bid (XLM)
+            </label>
+            <div className="relative">
+              <input
+                type="number"
+                min={minimumBid}
+                step="any"
+                value={bidAmount}
+                onChange={(e) => {
+                  setBidAmount(e.target.value);
+                  setBidSuccess(false);
+                }}
+                placeholder={`Min ${minimumBid.toFixed(2)} XLM`}
+                className="w-full rounded-lg border border-gray-200 px-3 py-2.5 pr-14 text-sm focus:border-brand-500 focus:outline-none"
+              />
+              <span className="absolute right-3 top-1/2 -translate-y-1/2 text-sm font-medium text-gray-400">
+                XLM
+              </span>
+            </div>
+            {bidValidation && (
+              <p className="mt-1 text-xs text-red-500">{bidValidation}</p>
+            )}
+          </div>
+
+          <GuardButton
+            onAction={handleBid}
+            disabled={isBidding || !bidAmount || !!bidValidation}
+            actionName="To place a bid"
+            className="flex w-full items-center justify-center gap-2 rounded-xl bg-brand-500 py-3.5 font-bold text-white shadow-xl shadow-brand-500/20 hover:bg-brand-600 transition-all hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50"
+          >
+            {isBidding ? (
+              <>
+                <Loader2 size={18} className="animate-spin" />
+                Placing Bid…
+              </>
+            ) : (
+              <>
+                <Gavel size={18} />
+                Place Bid
+              </>
+            )}
+          </GuardButton>
+        </div>
+      )}
+
+      {/* Finalize button */}
+      {canFinalize && (
+        <GuardButton
+          onAction={handleFinalize}
+          disabled={isFinalizing}
+          actionName="To finalize this auction"
+          className="flex w-full items-center justify-center gap-2 rounded-xl bg-blue-600 py-3.5 font-bold text-white shadow-xl shadow-blue-600/20 hover:bg-blue-700 transition-all hover:scale-[1.02] active:scale-[0.98] disabled:opacity-50"
+        >
+          {isFinalizing ? (
+            <>
+              <Loader2 size={18} className="animate-spin" />
+              Finalizing…
+            </>
+          ) : (
+            <>
+              <CheckCircle size={18} />
+              Finalize Auction
+            </>
+          )}
+        </GuardButton>
+      )}
+
+      {/* Own auction message */}
+      {isOwn && isActive && !isExpired && (
+        <p className="text-center text-sm text-gray-400">
+          This is your auction.
+        </p>
+      )}
+
+      {/* Finalized info */}
+      {auction.status === "Finalized" && auction.highest_bidder && (
+        <div className="rounded-lg bg-blue-50 px-3 py-2 text-sm text-blue-700">
+          Won by{" "}
+          <span className="font-mono font-semibold">
+            {truncateAddress(auction.highest_bidder)}
+          </span>{" "}
+          for {stroopsToXlm(auction.highest_bid)} XLM
+        </div>
+      )}
+
+      {auction.status === "Cancelled" && (
+        <div className="rounded-lg bg-gray-100 px-3 py-2 text-sm text-gray-500">
+          This auction ended with no bids.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
-import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck, Tag, Inbox, Compass, User } from "lucide-react";
+import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck, Tag, Inbox, Compass, User, Gavel } from "lucide-react";
 import { ConnectWalletModal } from "./ConnectWalletModal";
 
 export function Navbar() {
@@ -65,6 +65,13 @@ export function Navbar() {
             >
               <Compass size={16} />
               Explore
+            </Link>
+            <Link
+              href="/auctions"
+              className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+            >
+              <Gavel size={16} />
+              Auctions
             </Link>
             {isConnected && (
               <>
@@ -180,6 +187,14 @@ export function Navbar() {
               >
                 <Compass size={20} className="text-brand-500" />
                 Explore
+              </Link>
+              <Link
+                href="/auctions"
+                onClick={() => setMobileOpen(false)}
+                className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+              >
+                <Gavel size={20} className="text-brand-500" />
+                Auctions
               </Link>
               {isConnected && (
                 <>

--- a/frontend/afristore-app/src/hooks/useAuctions.ts
+++ b/frontend/afristore-app/src/hooks/useAuctions.ts
@@ -1,0 +1,213 @@
+// ─────────────────────────────────────────────────────────────
+// hooks/useAuctions.ts — Auction data + actions hooks
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import {
+  getAllAuctions,
+  getAuction,
+  getArtistAuctions,
+  createAuction,
+  placeBid,
+  finalizeAuction,
+  Auction,
+} from "@/lib/contract";
+import { uploadImageToIPFS, uploadMetadataToIPFS, ArtworkMetadata } from "@/lib/ipfs";
+
+// ── useAuctions ──────────────────────────────────────────────
+
+/**
+ * Fetches all auctions from the contract.
+ */
+export function useAuctions() {
+  const [auctions, setAuctions] = useState<Auction[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const all = await getAllAuctions();
+      setAuctions(all);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load auctions");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { auctions, isLoading, error, refresh };
+}
+
+// ── useArtistAuctions ────────────────────────────────────────
+
+/**
+ * Fetches all auctions created by a specific artist.
+ */
+export function useArtistAuctions(artistPublicKey: string | null) {
+  const [auctions, setAuctions] = useState<Auction[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!artistPublicKey) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const ids = await getArtistAuctions(artistPublicKey);
+      const resolved = await Promise.all(ids.map((id) => getAuction(id)));
+      setAuctions(resolved);
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load artist auctions"
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [artistPublicKey]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  return { auctions, isLoading, error, refresh };
+}
+
+// ── useCreateAuction ─────────────────────────────────────────
+
+export interface CreateAuctionInput {
+  title: string;
+  description: string;
+  artistName: string;
+  year: string;
+  imageFile: File;
+  reservePriceXlm: number;
+  durationHours: number;
+}
+
+export function useCreateAuction(creatorPublicKey: string | null) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [progress, setProgress] = useState<string>("");
+  const [error, setError] = useState<string | null>(null);
+
+  const create = useCallback(
+    async (input: CreateAuctionInput): Promise<number | null> => {
+      if (!creatorPublicKey) {
+        setError("Wallet not connected");
+        return null;
+      }
+
+      setIsCreating(true);
+      setError(null);
+
+      try {
+        // Step 1: Upload image to IPFS.
+        setProgress("Uploading image to IPFS…");
+        const imageResult = await uploadImageToIPFS(input.imageFile, input.title);
+
+        // Step 2: Build metadata JSON.
+        const metadata: ArtworkMetadata = {
+          title: input.title,
+          description: input.description,
+          artist: input.artistName,
+          image: `ipfs://${imageResult.cid}`,
+          year: input.year,
+        };
+
+        // Step 3: Upload metadata to IPFS.
+        setProgress("Uploading metadata to IPFS…");
+        const metadataResult = await uploadMetadataToIPFS(metadata, input.title);
+
+        // Step 4: Call the Soroban contract.
+        setProgress("Creating on-chain auction…");
+        const durationSeconds = input.durationHours * 3600;
+        const auctionId = await createAuction(
+          creatorPublicKey,
+          metadataResult.cid,
+          input.reservePriceXlm,
+          durationSeconds
+        );
+
+        setProgress("Auction created successfully!");
+        return auctionId;
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : "Failed to create auction");
+        return null;
+      } finally {
+        setIsCreating(false);
+      }
+    },
+    [creatorPublicKey]
+  );
+
+  return { create, isCreating, progress, error };
+}
+
+// ── usePlaceBid ──────────────────────────────────────────────
+
+export function usePlaceBid(bidderPublicKey: string | null) {
+  const [isBidding, setIsBidding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const bid = useCallback(
+    async (auctionId: number, amountXlm: number): Promise<boolean> => {
+      if (!bidderPublicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsBidding(true);
+      setError(null);
+      try {
+        await placeBid(bidderPublicKey, auctionId, amountXlm);
+        return true;
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : "Failed to place bid");
+        return false;
+      } finally {
+        setIsBidding(false);
+      }
+    },
+    [bidderPublicKey]
+  );
+
+  return { bid, isBidding, error };
+}
+
+// ── useFinalizeAuction ───────────────────────────────────────
+
+export function useFinalizeAuction(callerPublicKey: string | null) {
+  const [isFinalizing, setIsFinalizing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const finalize = useCallback(
+    async (auctionId: number): Promise<boolean> => {
+      if (!callerPublicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsFinalizing(true);
+      setError(null);
+      try {
+        await finalizeAuction(callerPublicKey, auctionId);
+        return true;
+      } catch (err: unknown) {
+        setError(
+          err instanceof Error ? err.message : "Failed to finalize auction"
+        );
+        return false;
+      } finally {
+        setIsFinalizing(false);
+      }
+    },
+    [callerPublicKey]
+  );
+
+  return { finalize, isFinalizing, error };
+}

--- a/frontend/afristore-app/src/lib/contract.ts
+++ b/frontend/afristore-app/src/lib/contract.ts
@@ -447,3 +447,180 @@ export async function getOffererOffers(
   const ids = scValToNative(retVal) as bigint[];
   return ids.map(Number);
 }
+
+// ── Auction types mirrored from the Rust contract ─────────────
+
+export type AuctionStatus = "Active" | "Finalized" | "Cancelled";
+
+export interface Auction {
+  auction_id: number;
+  creator: string;
+  metadata_cid: string;
+  token: string;
+  reserve_price: bigint;
+  highest_bid: bigint;
+  highest_bidder: string | null;
+  end_time: number;
+  status: AuctionStatus;
+  royalty_bps: number;
+  original_creator: string;
+}
+
+// ── Auction ScVal parsing ─────────────────────────────────────
+
+function parseAuctionFromScVal(raw: unknown): Auction {
+  const obj = scValToNative(raw as xdr.ScVal) as Record<string, unknown>;
+
+  return {
+    auction_id: Number(obj["auction_id"]),
+    creator: (obj["creator"] as Address).toString(),
+    metadata_cid: Buffer.from(obj["metadata_cid"] as Uint8Array).toString(
+      "utf-8"
+    ),
+    token: (obj["token"] as Address).toString(),
+    reserve_price: BigInt(obj["reserve_price"] as bigint),
+    highest_bid: BigInt(obj["highest_bid"] as bigint),
+    highest_bidder: obj["highest_bidder"]
+      ? (obj["highest_bidder"] as Address).toString()
+      : null,
+    end_time: Number(obj["end_time"]),
+    status: String(obj["status"]) as AuctionStatus,
+    royalty_bps: Number(obj["royalty_bps"]),
+    original_creator: (obj["original_creator"] as Address).toString(),
+  };
+}
+
+// ── Auction contract methods ──────────────────────────────────
+
+/**
+ * create_auction — Artist creates a new on-chain auction.
+ *
+ * @param creatorPublicKey   Stellar public key of the creator (must match Freighter)
+ * @param metadataCid        IPFS CID string of the metadata JSON
+ * @param reservePriceXlm    Reserve price in XLM (will be converted to stroops)
+ * @param durationSeconds    Auction duration in seconds
+ * @returns                  The new auction_id (number)
+ */
+export async function createAuction(
+  creatorPublicKey: string,
+  metadataCid: string,
+  reservePriceXlm: number,
+  durationSeconds: number
+): Promise<number> {
+  const reserveStroops = BigInt(Math.round(reservePriceXlm * 10_000_000));
+
+  const args: xdr.ScVal[] = [
+    // creator: Address
+    new Address(creatorPublicKey).toScVal(),
+    // metadata_cid: Bytes
+    nativeToScVal(Buffer.from(metadataCid, "utf-8"), { type: "bytes" }),
+    // token: Address (native XLM contract)
+    new Address("CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC").toScVal(),
+    // reserve_price: i128
+    nativeToScVal(reserveStroops, { type: "i128" }),
+    // duration: u64
+    nativeToScVal(BigInt(durationSeconds), { type: "u64" }),
+    // royalty_bps: u32
+    nativeToScVal(0, { type: "u32" }),
+    // recipients: Vec<Recipient> (empty for MVP)
+    nativeToScVal([], { type: "vec" }),
+  ];
+
+  const retVal = await invokeContract(
+    creatorPublicKey,
+    "create_auction",
+    args
+  );
+  return Number(scValToNative(retVal));
+}
+
+/**
+ * place_bid — Bidder places a bid on an active auction.
+ */
+export async function placeBid(
+  bidderPublicKey: string,
+  auctionId: number,
+  amountXlm: number
+): Promise<boolean> {
+  const amountStroops = BigInt(Math.round(amountXlm * 10_000_000));
+
+  const args: xdr.ScVal[] = [
+    new Address(bidderPublicKey).toScVal(),
+    nativeToScVal(BigInt(auctionId), { type: "u64" }),
+    nativeToScVal(amountStroops, { type: "i128" }),
+  ];
+
+  await invokeContract(bidderPublicKey, "place_bid", args);
+  return true;
+}
+
+/**
+ * finalize_auction — Finalize an expired or creator-cancelled auction.
+ */
+export async function finalizeAuction(
+  callerPublicKey: string,
+  auctionId: number
+): Promise<boolean> {
+  const args: xdr.ScVal[] = [
+    nativeToScVal(BigInt(auctionId), { type: "u64" }),
+  ];
+
+  await invokeContract(callerPublicKey, "finalize_auction", args);
+  return true;
+}
+
+/**
+ * get_auction — Fetch a single auction by ID (read-only).
+ */
+export async function getAuction(auctionId: number): Promise<Auction> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const args: xdr.ScVal[] = [
+    nativeToScVal(BigInt(auctionId), { type: "u64" }),
+  ];
+
+  const retVal = await invokeContract(DUMMY_KEY, "get_auction", args, true);
+  return parseAuctionFromScVal(retVal);
+}
+
+/**
+ * get_artist_auctions — Fetch all auction IDs for an artist.
+ */
+export async function getArtistAuctions(
+  artistPublicKey: string
+): Promise<number[]> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const args: xdr.ScVal[] = [new Address(artistPublicKey).toScVal()];
+
+  const retVal = await invokeContract(
+    DUMMY_KEY,
+    "get_artist_auctions",
+    args,
+    true
+  );
+
+  const ids = scValToNative(retVal) as bigint[];
+  return ids.map(Number);
+}
+
+/**
+ * getAllAuctions — Convenience: fetch every auction by trying IDs
+ * sequentially from 1 until a fetch fails.
+ */
+export async function getAllAuctions(): Promise<Auction[]> {
+  const auctions: Auction[] = [];
+  let consecutiveFailures = 0;
+
+  for (let i = 1; consecutiveFailures < 3; i++) {
+    try {
+      const a = await getAuction(i);
+      auctions.push(a);
+      consecutiveFailures = 0;
+    } catch {
+      consecutiveFailures++;
+    }
+  }
+
+  return auctions;
+}


### PR DESCRIPTION
## Summary
- Add TypeScript wrappers in `contract.ts` for all auction contract methods (`createAuction`, `placeBid`, `finalizeAuction`, `getAuction`, `getArtistAuctions`, `getAllAuctions`)
- Add `useAuctions.ts` hooks: `useAuctions`, `useArtistAuctions`, `useCreateAuction`, `usePlaceBid`, `useFinalizeAuction`
- Add `BiddingPanel.tsx` component with live countdown timer, bid validation, highest bid display, reserve price, and status badges
- Add `/auctions` browse page with filter tabs (All/Active/Finalized/Cancelled), auction cards grid, and loading skeletons
- Add `/auctions/[id]` detail page with artwork image, bidding panel, creator info, and finalize button
- Add "Auctions" link with Gavel icon to Navbar

Closes #15

## Test plan
- [ ] Navigate to `/auctions` — verify auction cards render with countdown timers
- [ ] Click auction card — verify detail page loads with BiddingPanel
- [ ] Place a bid — verify validation (>= reserve, > current highest) and transaction submission
- [ ] Verify countdown timer updates in real-time
- [ ] Verify finalize button appears when auction expired
- [ ] Verify filter tabs correctly filter by status