### PR TITLE
Instance Storage TTL Not Extended on Deployments

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -132,6 +132,7 @@ impl Launchpad {
         wasm_lazy_721: BytesN<32>,
         wasm_lazy_1155: BytesN<32>,
     ) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
         storage::require_admin(&env)?;
         storage::set_wasm_hashes(
             &env,
@@ -160,6 +161,7 @@ impl Launchpad {
         royalty_receiver: Address,
         salt: BytesN<32>,
     ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
         creator.require_auth();
 
         // [FEE] Collect deployment fee (#54)
@@ -205,6 +207,7 @@ impl Launchpad {
         royalty_receiver: Address,
         salt: BytesN<32>,
     ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
         creator.require_auth();
 
         // [FEE] Collect deployment fee (#54)
@@ -253,6 +256,7 @@ impl Launchpad {
         royalty_receiver: Address,
         salt: BytesN<32>,
     ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
         creator.require_auth();
 
         // [FEE] Collect deployment fee (#54)
@@ -298,6 +302,7 @@ impl Launchpad {
         royalty_receiver: Address,
         salt: BytesN<32>,
     ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
         creator.require_auth();
 
         // [FEE] Collect deployment fee (#54)
@@ -333,12 +338,14 @@ impl Launchpad {
     // ── Admin management ──────────────────────────────────────────────────
 
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
         storage::require_admin(&env)?;
         storage::set_admin(&env, &new_admin);
         Ok(())
     }
 
     pub fn update_platform_fee(env: Env, receiver: Address, fee_bps: u32) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
         storage::require_admin(&env)?;
         storage::set_platform_fee(&env, &receiver, fee_bps);
         Ok(())

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -5,9 +5,13 @@ use crate::types::{CollectionKind, CollectionRecord, DataKey, Error};
 const TTL_THRESHOLD: u32 = 50_000;
 const TTL_BUMP: u32 = 100_000;
 
+pub fn extend_instance_ttl(env: &Env) {
+    env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_BUMP);
+}
+
 pub fn set_initialized(env: &Env) {
     env.storage().instance().set(&DataKey::Initialized, &true);
-    env.storage().instance().extend_ttl(TTL_THRESHOLD, TTL_BUMP);
+    extend_instance_ttl(env);
 }
 
 pub fn is_initialized(env: &Env) -> bool {

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1,13 +1,29 @@
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, Address, BytesN, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String};
 
 use crate::{CollectionKind, Launchpad, LaunchpadClient};
 
+fn jump_ledger(env: &Env, delta: u32) {
+    env.ledger().with_mut(|li| {
+        li.sequence_number += delta;
+    });
+}
+
 fn wasm_bytes(name: &str) -> std::vec::Vec<u8> {
-    let manifest = std::path::PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
-    let path = manifest
-        .join("../../target/wasm32-unknown-unknown/release")
+    // In Cursor's sandbox, cargo builds into an isolated target dir (not `./target`).
+    // Derive the target dir from the current test binary path:
+    //   .../cargo-target/debug/deps/<test-binary>
+    let exe = std::env::current_exe().unwrap();
+    let target_dir = exe
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .unwrap()
+        .to_path_buf();
+    let path = target_dir
+        .join("wasm32-unknown-unknown")
+        .join("release")
         .join(std::format!("{name}.wasm"));
 
     std::fs::read(&path).unwrap_or_else(|_| {
@@ -61,6 +77,7 @@ fn setup_launchpad(env: &Env) -> (LaunchpadClient<'_>, Address, Address, Address
 #[test]
 fn deploys_normal_721_twice_with_unique_addresses() {
     let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let salt_a = BytesN::from_array(&env, &[10u8; 32]);
@@ -108,6 +125,7 @@ fn deploys_normal_721_twice_with_unique_addresses() {
 #[test]
 fn deploys_normal_1155_twice_with_unique_addresses() {
     let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let salt_a = BytesN::from_array(&env, &[20u8; 32]);
@@ -151,6 +169,7 @@ fn deploys_normal_1155_twice_with_unique_addresses() {
 #[test]
 fn deploys_lazy_721_twice_with_unique_addresses() {
     let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let salt_a = BytesN::from_array(&env, &[30u8; 32]);
@@ -201,6 +220,7 @@ fn deploys_lazy_721_twice_with_unique_addresses() {
 #[test]
 fn deploys_lazy_1155_twice_with_unique_addresses() {
     let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let salt_a = BytesN::from_array(&env, &[40u8; 32]);
@@ -242,4 +262,63 @@ fn deploys_lazy_1155_twice_with_unique_addresses() {
         all.get(1).unwrap().kind,
         CollectionKind::LazyMint1155
     ));
+}
+
+#[test]
+fn deploy_calls_extend_instance_ttl() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let royalty_receiver = Address::generate(&env);
+    let currency = Address::generate(&env);
+
+    // After initialize(), instance TTL is bumped to 100_000 ledgers.
+    // Move forward so remaining TTL is below threshold (50_000),
+    // then call deploy_* which should bump instance TTL again.
+    jump_ledger(&env, 60_000);
+
+    let salt_a = BytesN::from_array(&env, &[60u8; 32]);
+    let _deployed_a = client.deploy_normal_721(
+        &creator,
+        &currency,
+        &String::from_str(&env, "TTL A"),
+        &String::from_str(&env, "TTLA"),
+        &100u64,
+        &500u32,
+        &royalty_receiver,
+        &salt_a,
+    );
+
+    // Without TTL extension on deploy, instance storage would now be expired:
+    // 60_000 + 60_000 > 100_000.
+    jump_ledger(&env, 60_000);
+
+    let salt_b = BytesN::from_array(&env, &[61u8; 32]);
+    let _deployed_b = client.deploy_normal_1155(
+        &creator,
+        &currency,
+        &String::from_str(&env, "TTL B"),
+        &500u32,
+        &royalty_receiver,
+        &salt_b,
+    );
+
+    assert_eq!(client.collection_count(), 2u64);
+}
+
+#[test]
+fn admin_calls_extend_instance_ttl() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, _creator) = setup_launchpad(&env);
+
+    jump_ledger(&env, 60_000);
+
+    let new_admin = Address::generate(&env);
+    client.transfer_admin(&new_admin);
+
+    jump_ledger(&env, 60_000);
+
+    assert_eq!(client.admin(), new_admin);
 }


### PR DESCRIPTION
## Description
**Resolves Issue:** Instance Storage TTL Not Extended on Deployments ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [x] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [x] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [x] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [x] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [x] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [x] I have added unit tests to cover my changes and tested edge cases.
- [x] All tests pass locally (`cargo test`).

## Additional Context
- Added `storage::extend_instance_ttl(&env)` helper for Launchpad instance storage.
- Called it at the start of all `deploy_*` entry points and relevant admin functions (`set_wasm_hashes`, `transfer_admin`, `update_platform_fee`) so instance storage (admin key + WASM hashes + initialized flag) doesn’t expire during periods of low activity.

closes #52