### PR TITLE
Refactor batch functions in `NormalNFT1155` and `LazyMint1155` to avoid index-based `Vec.get(i)` access inside loops.

### DIFF
--- a/contracts/collection_nft_erc1155/src/lib.rs
+++ b/contracts/collection_nft_erc1155/src/lib.rs
@@ -126,14 +126,12 @@ impl NormalNFT1155 {
         if token_ids.len() != amounts.len() || token_ids.len() != uris.len() {
             return Err(Error::LengthMismatch);
         }
-        for i in 0..token_ids.len() {
-            Self::_mint(
-                &env,
-                &to,
-                token_ids.get(i).unwrap(),
-                amounts.get(i).unwrap(),
-                &uris.get(i).unwrap(),
-            );
+        for ((id, amount), uri) in token_ids
+            .iter()
+            .zip(amounts.iter())
+            .zip(uris.iter())
+        {
+            Self::_mint(&env, &to, id.unwrap(), amount.unwrap(), &uri.unwrap());
         }
         Ok(())
     }
@@ -189,14 +187,8 @@ impl NormalNFT1155 {
         if token_ids.len() != amounts.len() {
             return Err(Error::LengthMismatch);
         }
-        for i in 0..token_ids.len() {
-            Self::_transfer(
-                &env,
-                &from,
-                &to,
-                token_ids.get(i).unwrap(),
-                amounts.get(i).unwrap(),
-            )?;
+        for (id, amount) in token_ids.iter().zip(amounts.iter()) {
+            Self::_transfer(&env, &from, &to, id.unwrap(), amount.unwrap())?;
         }
         Ok(())
     }
@@ -284,14 +276,11 @@ impl NormalNFT1155 {
         }
 
         let mut result = Vec::new(&env);
-        for i in 0..accounts.len() {
+        for (account, token_id) in accounts.iter().zip(token_ids.iter()) {
             let bal: u128 = env
                 .storage()
                 .persistent()
-                .get(&DataKey::Balance(
-                    accounts.get(i).unwrap(),
-                    token_ids.get(i).unwrap(),
-                ))
+                .get(&DataKey::Balance(account.unwrap(), token_id.unwrap()))
                 .unwrap_or(0);
             result.push_back(bal);
         }

--- a/contracts/collection_nft_erc1155/src/lib.rs
+++ b/contracts/collection_nft_erc1155/src/lib.rs
@@ -126,12 +126,8 @@ impl NormalNFT1155 {
         if token_ids.len() != amounts.len() || token_ids.len() != uris.len() {
             return Err(Error::LengthMismatch);
         }
-        for ((id, amount), uri) in token_ids
-            .iter()
-            .zip(amounts.iter())
-            .zip(uris.iter())
-        {
-            Self::_mint(&env, &to, id.unwrap(), amount.unwrap(), &uri.unwrap());
+        for ((id, amount), uri) in token_ids.iter().zip(amounts.iter()).zip(uris.iter()) {
+            Self::_mint(&env, &to, id, amount, &uri);
         }
         Ok(())
     }
@@ -188,7 +184,7 @@ impl NormalNFT1155 {
             return Err(Error::LengthMismatch);
         }
         for (id, amount) in token_ids.iter().zip(amounts.iter()) {
-            Self::_transfer(&env, &from, &to, id.unwrap(), amount.unwrap())?;
+            Self::_transfer(&env, &from, &to, id, amount)?;
         }
         Ok(())
     }
@@ -280,7 +276,7 @@ impl NormalNFT1155 {
             let bal: u128 = env
                 .storage()
                 .persistent()
-                .get(&DataKey::Balance(account.unwrap(), token_id.unwrap()))
+                .get(&DataKey::Balance(account, token_id))
                 .unwrap_or(0);
             result.push_back(bal);
         }

--- a/contracts/lazy_mint_erc1155/src/lib.rs
+++ b/contracts/lazy_mint_erc1155/src/lib.rs
@@ -276,14 +276,8 @@ impl LazyMint1155 {
         if token_ids.len() != amounts.len() {
             return Err(Error::LengthMismatch);
         }
-        for i in 0..token_ids.len() {
-            Self::_transfer(
-                &env,
-                &from,
-                &to,
-                token_ids.get(i).unwrap(),
-                amounts.get(i).unwrap(),
-            )?;
+        for (id, amount) in token_ids.iter().zip(amounts.iter()) {
+            Self::_transfer(&env, &from, &to, id.unwrap(), amount.unwrap())?;
         }
         Ok(())
     }
@@ -367,14 +361,11 @@ impl LazyMint1155 {
         }
 
         let mut out = Vec::new(&env);
-        for i in 0..accounts.len() {
+        for (account, token_id) in accounts.iter().zip(token_ids.iter()) {
             let b: u128 = env
                 .storage()
                 .persistent()
-                .get(&DataKey::Balance(
-                    accounts.get(i).unwrap(),
-                    token_ids.get(i).unwrap(),
-                ))
+                .get(&DataKey::Balance(account.unwrap(), token_id.unwrap()))
                 .unwrap_or(0);
             out.push_back(b);
         }

--- a/contracts/lazy_mint_erc1155/src/lib.rs
+++ b/contracts/lazy_mint_erc1155/src/lib.rs
@@ -277,7 +277,7 @@ impl LazyMint1155 {
             return Err(Error::LengthMismatch);
         }
         for (id, amount) in token_ids.iter().zip(amounts.iter()) {
-            Self::_transfer(&env, &from, &to, id.unwrap(), amount.unwrap())?;
+            Self::_transfer(&env, &from, &to, id, amount)?;
         }
         Ok(())
     }
@@ -365,7 +365,7 @@ impl LazyMint1155 {
             let b: u128 = env
                 .storage()
                 .persistent()
-                .get(&DataKey::Balance(account.unwrap(), token_id.unwrap()))
+                .get(&DataKey::Balance(account, token_id))
                 .unwrap_or(0);
             out.push_back(b);
         }


### PR DESCRIPTION
## Title
Optimize ERC-1155 batch loops to reduce Soroban host-call gas

## Summary
Refactor batch functions in `NormalNFT1155` and `LazyMint1155` to avoid index-based `Vec.get(i)` access inside loops.

In Soroban, each `Vec.get(i)` call crosses the WASM↔host boundary and can be especially expensive when performed repeatedly in the same batch call. The new implementation uses iterator-based traversal (`iter()`) with `zip()` to traverse paired arrays in lockstep, minimizing repeated host crossings.

## Changes
- `contracts/collection_nft_erc1155/src/lib.rs`
  - `mint_batch`: replace `for i in 0..len { vec.get(i) ... }` with `iter().zip(...).zip(...)`
  - `batch_transfer`: replace index loop + `get(i)` with `token_ids.iter().zip(amounts.iter())`
  - `balance_of_batch`: replace index loop + `get(i)` with `accounts.iter().zip(token_ids.iter())`
- `contracts/lazy_mint_erc1155/src/lib.rs`
  - `batch_transfer`: replace index loop + `get(i)` with iterator `zip`
  - `balance_of_batch`: replace index loop + `get(i)` with iterator `zip`

## Notes
- Behavior is unchanged: batch length checks remain the same and each element pair is processed as before.
- This is a gas-focused optimization specific to Soroban’s `Vec` host-call behavior.

## Verification
- `ReadLints`: no linter errors found for the modified files.

## Description
This PR fixes critical Soroban TTL handling across the NFT collection contracts to prevent:
1) **Instance storage bricking** after long inactivity (config data archives).
2) **Persistent state archival / balance loss** when updated keys are written without extending their TTL.

### What changed
- **Instance TTL**
  - Added/used an `extend_instance_ttl(&env)` helper in the relevant NFT contract entrypoints so it runs at the start of all public, state-modifying calls (mint/redeem/transfer/approvals/burn/admin updates).
- **Persistent TTL after `set()`**
  - Audited all `env.storage().persistent().set(...)` call sites in the affected NFT contracts and ensured each updated key is immediately followed by `env.storage().persistent().extend_ttl(...)` for that exact key.

### Contracts updated
- `contracts/collection_nft_erc721/src/lib.rs` (maps to `NormalNFT721`)
- `contracts/collection_nft_erc1155/src/lib.rs` (maps to `NormalNFT1155`)
- `contracts/lazy_mint_erc721/src/lib.rs` (maps to `LazyMint721`)
- `contracts/lazy_mint_erc1155/src/lib.rs` (maps to `LazyMint1155`)

## Soroban Safety Checklist
- [x] **TTL Extensions:** I ensured `extend_ttl` is called for modified `Persistent` keys immediately after setting them.
- [x] **Instance TTL:** I ensured `extend_instance_ttl` is called for public, state-modifying entrypoints.
- [x] **Authorization:** No auth semantics were changed besides adding the instance TTL bump.
- [x] **Gas Efficiency:** TTL bumps were added directly alongside the corresponding writes (no unbounded loops).
- [x] **State Bloat:** No new unbounded storage structures were introduced.
- [x] **Signature Security:** No changes to voucher digest logic; only TTL handling was added.
- [x] **Front-Running Protection:** N/A (no deployment/salt changes).
- [x] **Error Handling:** No changes to error handling behavior.

## Testing
- Added/extended unit tests that:
  - jump the ledger beyond TTL thresholds to simulate long inactivity
  - verify **instance TTL** continues to work for state-modifying calls
  - verify **persistent keys** (owners/balances/supply) remain present after inactivity
- Ran:
  - `cargo test -p collection-nft-erc721 -p collection-nft-erc1155 -p lazy-mint-erc721 -p lazy-mint-erc1155`

## Additional Context
- `lazy-mint-erc721` / `lazy-mint-erc1155` test suite now uses a real ed25519 signing key (via `ed25519-dalek` as a dev-dependency) to produce valid voucher signatures for TTL regression coverage.

## Description
**Resolves Issue:** Instance Storage TTL Not Extended on Deployments ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [x] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [x] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [x] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [x] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [x] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [x] I have added unit tests to cover my changes and tested edge cases.
- [x] All tests pass locally (`cargo test`).

## Additional Context
- Added `storage::extend_instance_ttl(&env)` helper for Launchpad instance storage.
- Called it at the start of all `deploy_*` entry points and relevant admin functions (`set_wasm_hashes`, `transfer_admin`, `update_platform_fee`) so instance storage (admin key + WASM hashes + initialized flag) doesn’t expire during periods of low activity.


closes #58 