### PR TITLE
fix(launchpad): bind salt to caller address to prevent front-running and griefing (#53)

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -20,7 +20,9 @@
 //! Every `deploy()` call shares that same WASM — no bytecode duplication.
 //! Each instance gets completely isolated storage.
 
-use soroban_sdk::{contract, contractimpl, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec};
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, xdr::ToXdr, Address, Bytes, BytesN, Env, String, Vec,
+};
 
 use crate::{
     events, storage,

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -369,7 +369,10 @@ fn same_salt_different_creators_normal_721_yields_different_addresses() {
     );
 
     // Because secure_salt = sha256(creator ‖ raw_salt) they must differ.
-    assert_ne!(addr_alice, addr_bob, "same raw salt must not collide across creators");
+    assert_ne!(
+        addr_alice, addr_bob,
+        "same raw salt must not collide across creators"
+    );
     assert_eq!(client.collection_count(), 2u64);
 }
 
@@ -527,7 +530,10 @@ fn front_runner_cannot_grief_normal_721() {
         &salt,
     );
 
-    assert_ne!(addr_alice, addr_bob, "front-runner must not occupy Alice's slot");
+    assert_ne!(
+        addr_alice, addr_bob,
+        "front-runner must not occupy Alice's slot"
+    );
     assert_eq!(client.collection_count(), 2u64);
 }
 


### PR DESCRIPTION
## Summary

Closes #53

Fixes a salt front-running / griefing vulnerability in the Launchpad contract.
All four `deploy_*` functions previously passed the user-supplied `salt` directly
to `env.deployer().with_current_contract(salt)`.
 Because the salt was not bound
to the caller, a malicious actor (Bob) watching the mempool could copy Alice's
salt, submit a transaction first, and cause Alice's deployment to fail with an
`already exists` error.

## Root Cause

```rust
// BEFORE (vulnerable)
let addr = env.deployer().with_current_contract(salt).deploy_v2(wasm, ());
