### PR TITLE
fix(frontend): resolve lockfile, workspace root, stale effect, image …

### DIFF
--- a/frontend/afristore-app/README.md
+++ b/frontend/afristore-app/README.md
@@ -1,4 +1,41 @@
+## Known Issues & Warnings
+
+### Stellar SDK Critical Dependency Warning
+
+When running `npm run build`, you may see warnings like:
+
+```
+Critical dependency: require function is used in a way in which dependencies cannot be statically extracted
+Import trace for requested module:
+...sodium-native/index.js
+...@stellar/stellar-base/lib/signing.js
+...@stellar/stellar-sdk/lib/index.js
+```
+
+This is due to the `@stellar/stellar-sdk` package pulling in Node.js dependencies (like `sodium-native`) even when used in client-side code. The app uses dynamic imports and only loads what is needed, but the warning may still appear. This does not affect runtime behavior in the browser, but keep this in mind if you see these warnings during build.
+
+For more info, see: https://github.com/stellar/js-stellar-sdk/issues/922
+
+
 # afristore-app
+
+## Monorepo & Lockfile Strategy
+
+This project is part of a monorepo. The **frontend app uses npm as the package manager** and maintains a single lockfile at `frontend/afristore-app/package-lock.json`. Do not use yarn or pnpm for this workspace. Always run install/build/lint commands from the `frontend/afristore-app` directory.
+
+**Workspace root for Next.js output tracing is set to the monorepo root.**
+
+### Install & Build Directory
+
+All frontend commands (install, build, lint, test) should be run from:
+
+```
+cd frontend/afristore-app
+```
+
+This ensures consistent dependency resolution and avoids workspace root ambiguity.
+
+---
 
 Next.js 14 frontend for the Afristore decentralized African art marketplace.
 

--- a/frontend/afristore-app/next.config.js
+++ b/frontend/afristore-app/next.config.js
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  outputFileTracingRoot: require('path').resolve(__dirname, '../../'),
   reactStrictMode: true,
   images: {
     remotePatterns: [

--- a/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
+++ b/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
@@ -17,13 +17,13 @@ jest.mock('next/link', () => ({
   ),
 }));
 
-// Next.js Image — render as a plain <img>
+// Next.js Image — render as a plain <img> with valid alt handling
 jest.mock('next/image', () => ({
   __esModule: true,
   default: (props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => {
-    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
-    const { fill: _fill, ...rest } = props;
-    return <img {...rest} />;
+    // Remove non-standard props and ensure alt is always present
+    const { fill: _fill, alt, ...rest } = props;
+    return <img alt={alt || ''} {...rest} />;
   },
 }));
 

--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -4,7 +4,7 @@
 
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Image from "next/image";
 import { getAuction, stroopsToXlm, Auction } from "@/lib/contract";
@@ -32,7 +32,8 @@ export default function AuctionDetailPage() {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const loadAuction = async () => {
+
+  const loadAuction = useCallback(async () => {
     setIsLoading(true);
     setError(null);
     try {
@@ -45,11 +46,11 @@ export default function AuctionDetailPage() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [id]);
 
   useEffect(() => {
     if (id) loadAuction();
-  }, [id]);
+  }, [id, loadAuction]);
 
   const handleRefresh = async () => {
     try {

--- a/frontend/afristore-app/src/components/CollectionForm.tsx
+++ b/frontend/afristore-app/src/components/CollectionForm.tsx
@@ -7,7 +7,7 @@ import { Loader2, Rocket, CheckCircle, ArrowRight } from "lucide-react";
 import { GuardButton } from "./WalletGuard";
 import { CollectionKind } from "@/lib/launchpad";
 import { SUPPORTED_TOKENS, DEFAULT_TOKEN } from "@/config/tokens";
-import { StrKey } from "@stellar/stellar-sdk";
+
 
 export function CollectionForm() {
   const { publicKey } = useWalletContext();
@@ -36,7 +36,9 @@ export function CollectionForm() {
     // If it's a lazy collection, we need the pubkey bytes
     if (form.kind.startsWith("LazyMint")) {
       try {
-        const decoded = StrKey.decodeEd25519PublicKey(publicKey);
+        // Dynamically import StrKey to avoid Node deps in initial bundle
+        const sdk = await import("@stellar/stellar-sdk");
+        const decoded = sdk.StrKey.decodeEd25519PublicKey(publicKey);
         input.creatorPubkeyBytes = Buffer.from(decoded);
       } catch (err) {
         console.error("Failed to decode public key", err);


### PR DESCRIPTION
This pull request improves documentation, fixes Next.js configuration for monorepo compatibility, and optimizes frontend code for better dependency handling and test reliability. The changes address known issues with dependencies, clarify workspace usage, and refine component logic to reduce bundle size and avoid Node.js-only dependencies in client code.

**Documentation and Monorepo Setup:**
- Added a "Known Issues & Warnings" section to `README.md` explaining build warnings related to the `@stellar/stellar-sdk` dependency, and clarified the monorepo lockfile and workspace strategy for the frontend app.

**Build and Configuration:**
- Updated `next.config.js` to set `outputFileTracingRoot` to the monorepo root, ensuring Next.js output tracing works correctly in the monorepo context.

**Frontend Dependency Handling:**
- Changed the dynamic import of `StrKey` from `@stellar/stellar-sdk` in `CollectionForm` to avoid loading Node.js dependencies in the initial client bundle, improving bundle safety and compatibility. [[1]](diffhunk://#diff-d36c1c38b01e53a8615e0af4cb800f167dbfef1a86342118c02bd822e0745ab5L10-R10) [[2]](diffhunk://#diff-d36c1c38b01e53a8615e0af4cb800f167dbfef1a86342118c02bd822e0745ab5L39-R41)

**Component and Test Improvements:**
- Improved the Next.js Image mock in tests to always provide a valid `alt` attribute, ensuring better accessibility and test reliability.
- Refactored `AuctionDetailPage` to use `useCallback` for the `loadAuction` function, improving dependency management and preventing unnecessary re-renders or effect calls. ([frontend/afristore-app/src/app/auctions/[id]/page.tsxL7-R7](diffhunk://#diff-420e5ce055424c71a15b475df6dfff4690cd26a70d48e98f38cc4f0b2867e5f0L7-R7), [frontend/afristore-app/src/app/auctions/[id]/page.tsxL35-R36](diffhunk://#diff-420e5ce055424c71a15b475df6dfff4690cd26a70d48e98f38cc4f0b2867e5f0L35-R36), [frontend/afristore-app/src/app/auctions/[id]/page.tsxL48-R53](diffhunk://#diff-420e5ce055424c71a15b475df6dfff4690cd26a70d48e98f38cc4f0b2867e5f0L48-R53))…mock, and document Stellar SDK warning

## Description
**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [ ] I have added unit tests to cover my changes and tested edge cases.
- [ ] All tests pass locally (`cargo test`).

## Additional Context

close #95 
close #96 
close #97 
close #98 