### PR TITLE
fix: resolve prod vulns, remove unoptimized DOM warning, contain SDK bundle noise

### DIFF
--- a/frontend/afristore-app/next.config.js
+++ b/frontend/afristore-app/next.config.js
@@ -22,16 +22,34 @@ const nextConfig = {
       },
     ],
   },
-  webpack: (config) => {
-    // Required for @stellar/stellar-sdk in browser
-    config.resolve.fallback = {
-      ...config.resolve.fallback,
-      fs: false,
-      net: false,
-      tls: false,
-    };
+  webpack: (config, { isServer }) => {
+    if (!isServer) {
+      // Stub out Node-only modules that @stellar/stellar-sdk pulls in
+      // transitively (sodium-native, libsodium-wrappers, etc.).
+      // Without these stubs, the client bundle emits critical warnings and
+      // includes dead code that inflates the bundle size.
+      config.resolve.fallback = {
+        ...config.resolve.fallback,
+        // Standard Node builtins
+        fs: false,
+        net: false,
+        tls: false,
+        // Stellar SDK native crypto modules — not available in the browser;
+        // the SDK falls back to its wasm/js implementation automatically.
+        "sodium-native": false,
+        "libsodium-wrappers": false,
+        // Other optional native deps pulled by stellar-base / stellar-sdk
+        crypto: false,
+      };
+    }
     return config;
   },
+  // Suppress the expected "Can't resolve 'sodium-native'" critical warnings
+  // that Next.js surfaces from @stellar/stellar-sdk's optional native crypto.
+  // These are intentional — the browser bundle uses the wasm fallback instead.
+  //
+  // Note: Next 15 exposes `ignoreDuringBuilds` under experimental — once stable
+  // we can replace the webpack fallback stubs with a cleaner filterWarnings rule.
 };
 
 module.exports = nextConfig;

--- a/frontend/afristore-app/package-lock.json
+++ b/frontend/afristore-app/package-lock.json
@@ -86,6 +86,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2144,7 +2145,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2244,8 +2244,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2417,6 +2416,7 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2428,6 +2428,7 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2508,6 +2509,7 @@
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -3035,6 +3037,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3757,6 +3760,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4518,7 +4522,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4585,8 +4588,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -4892,6 +4894,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5061,6 +5064,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7715,6 +7719,7 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -7988,7 +7993,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8236,9 +8240,9 @@
       }
     },
     "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",
@@ -8255,9 +8259,9 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
@@ -8792,6 +8796,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -8951,7 +8956,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8967,7 +8971,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8980,8 +8983,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prompts": {
       "version": "2.4.2",
@@ -9100,6 +9102,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -9112,6 +9115,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10234,6 +10238,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10474,6 +10479,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/frontend/afristore-app/package.json
+++ b/frontend/afristore-app/package.json
@@ -37,5 +37,10 @@
     "postcss": "^8.4.38",
     "tailwindcss": "^3.4.4",
     "typescript": "^5.4.5"
+  },
+  "overrides": {
+    "next": {
+      "postcss": ">=8.5.10"
+    }
   }
 }

--- a/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
+++ b/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
@@ -17,12 +17,19 @@ jest.mock('next/link', () => ({
   ),
 }));
 
-// Next.js Image — render as a plain <img> with valid alt handling
+// Next.js Image — render as a plain <img>, stripping Next-only props that
+// are not valid DOM attributes (fill, unoptimized, priority, sizes, quality).
 jest.mock('next/image', () => ({
   __esModule: true,
-  default: (props: React.ImgHTMLAttributes<HTMLImageElement> & { fill?: boolean }) => {
-    // Remove non-standard props and ensure alt is always present
-    const { fill: _fill, alt, ...rest } = props;
+  default: (
+    props: React.ImgHTMLAttributes<HTMLImageElement> & {
+      fill?: boolean;
+      unoptimized?: boolean;
+      priority?: boolean;
+      quality?: number;
+    }
+  ) => {
+    const { fill: _fill, unoptimized: _unoptimized, priority: _priority, quality: _quality, alt, ...rest } = props;
     return <img alt={alt || ''} {...rest} />;
   },
 }));
@@ -209,5 +216,37 @@ describe('ListingCard', () => {
     await waitFor(() => {
       expect(screen.getByText('Artwork #99')).toBeInTheDocument();
     });
+  });
+});
+
+// ── Image mock regression (#105) ──────────────────────────────────────────────
+
+describe('next/image mock', () => {
+  const NextImage = jest.requireMock('next/image').default as React.FC<Record<string, unknown>>;
+
+  it('does not forward unoptimized to the DOM element', () => {
+    const { container } = render(
+      <NextImage src="/test.png" alt="test" unoptimized width={100} height={100} />
+    );
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img!.hasAttribute('unoptimized')).toBe(false);
+  });
+
+  it('does not forward fill to the DOM element', () => {
+    const { container } = render(
+      <NextImage src="/test.png" alt="test" fill />
+    );
+    const img = container.querySelector('img');
+    expect(img!.hasAttribute('fill')).toBe(false);
+  });
+
+  it('preserves alt and src attributes', () => {
+    const { container } = render(
+      <NextImage src="/test.png" alt="my image" unoptimized width={80} height={80} />
+    );
+    const img = container.querySelector('img');
+    expect(img!.getAttribute('alt')).toBe('my image');
+    expect(img!.getAttribute('src')).toBe('/test.png');
   });
 });

--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -1079,6 +1079,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1971,9 +1972,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -2555,9 +2556,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {
@@ -2590,6 +2591,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -3147,6 +3149,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3199,6 +3202,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",


### PR DESCRIPTION
## Summary

- Fixes #103 — **[Frontend][Security]** Resolve remaining production dependency vulnerabilities: added `"overrides": { "next": { "postcss": ">=8.5.10" } }` in `frontend/afristore-app/package.json` to force Next.js's internal postcss transitive dependency out of the GHSA-qx2v-qp2m-jg93 XSS range — without a breaking Next.js downgrade. Before: **2 moderate** prod vulnerabilities. After: **0**.

- Fixes #104 — **[Indexer][Security]** Resolve remaining production dependency vulnerability: ran `npm audit fix` in `indexer/` to resolve follow-redirects from GHSA-r4q5-vmmm-2653 (custom auth-header leak on cross-domain redirect). Before: **1 moderate** prod vulnerability. After: **0**.

- Fixes #105 — **[Frontend][Tests]** Remove non-boolean `unoptimized` warning from ListingCard tests: updated the `next/image` Jest mock to explicitly destructure and discard `unoptimized`, `fill`, `priority`, and `quality` before spreading the remainder onto the DOM `<img>` element — eliminating the React *"received `false` for a non-boolean attribute"* console warning from CI logs. Added a dedicated `next/image mock` describe block with 3 regression tests to guard the correct forwarding behaviour going forward.

- Fixes #107 — **[Frontend][Build]** Contain Stellar SDK client-bundle warnings in launchpad create flow: extended the webpack config in `next.config.js` to add `"sodium-native": false`, `"libsodium-wrappers": false`, and `"crypto": false` to `resolve.fallback` (client-side only). These are the modules that `@stellar/stellar-sdk` optionally requires for its native crypto path but which are unavailable in the browser — the SDK falls back to its wasm implementation automatically. Added an explanatory comment so future maintainers understand why the stubs are intentional.

## Before / After

| Area | Before | After |
|------|--------|-------|
| Frontend prod vulns (`npm audit --omit=dev`) | 2 moderate | 0 |
| Indexer prod vulns (`npm audit --omit=dev`) | 1 moderate | 0 |
| ListingCard test warnings | React unknown-prop warning for `unoptimized` | None |
| Launchpad create build | Critical warning: Can't resolve `sodium-native` | Suppressed via webpack fallback |

## Test plan

- [x] `npm audit --omit=dev` in `frontend/afristore-app` → 0 vulnerabilities
- [x] `npm audit --omit=dev` in `indexer` → 0 vulnerabilities
- [x] `npm test` in `frontend/afristore-app` → 31/31 pass, 4 suites, 0 failures, no React attribute warnings in output
- [ ] `npm run build` in `frontend/afristore-app` — launchpad/create route builds without `sodium-native` critical warning