### PR TITLE
Add Launchpad navigation entry to Navbar

### DIFF
--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -7,7 +7,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
-import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck, Tag, Inbox, Compass, User, Gavel } from "lucide-react";
+import { Wallet, Store, LayoutDashboard, Menu, X, AlertTriangle, LogOut, ShieldCheck, Tag, Inbox, Compass, User, Gavel, Rocket } from "lucide-react";
 import { ConnectWalletModal } from "./ConnectWalletModal";
 
 export function Navbar() {
@@ -72,6 +72,13 @@ export function Navbar() {
             >
               <Gavel size={16} />
               Auctions
+            </Link>
+            <Link
+              href="/launchpad"
+              className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+            >
+              <Rocket size={16} />
+              Launchpad
             </Link>
             {isConnected && (
               <>
@@ -195,6 +202,14 @@ export function Navbar() {
               >
                 <Gavel size={20} className="text-brand-500" />
                 Auctions
+              </Link>
+              <Link
+                href="/launchpad"
+                onClick={() => setMobileOpen(false)}
+                className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+              >
+                <Rocket size={20} className="text-brand-500" />
+                Launchpad
               </Link>
               {isConnected && (
                 <>


### PR DESCRIPTION
## Title
feat: Add Launchpad navigation links to Navbar

closes #118

## Description
Previously, the `Navbar.tsx` component did not include any links to the launchpad section. This made it difficult for users to organically discover launchpad features, such as creating new NFT collections. 

This PR introduces direct navigation links to the `/launchpad` route in both the desktop and mobile views, improving feature discoverability and user onboarding for creators.

## Changes Made
* **Desktop Navigation:** Added a new `Launchpad` link (with a `Rocket` icon) to the main desktop navigation menu in `Navbar.tsx`.
* **Mobile Navigation:** Added the corresponding `Launchpad` link to the mobile navigation drawer, configured to properly close the drawer upon click.

## Checklist
- [x] Add "Launchpad" link to desktop navigation in `Navbar.tsx`
- [x] Add "Launchpad" link to mobile navigation drawer in `Navbar.tsx`
- [x] Tested desktop view for layout consistency
- [x] Tested mobile view to ensure the drawer closes on selection