### PR TITLE
[codex] Add admin transfer entrypoint

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -41,6 +41,20 @@ impl MarketplaceContract {
         env.storage().persistent().set(&key, &admin);
     }
 
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        let key = crate::storage::DataKey::Admin;
+        let stored_admin = env
+            .storage()
+            .persistent()
+            .get::<_, Address>(&key)
+            .expect("admin not set");
+        if current_admin != stored_admin {
+            panic_with_error!(&env, MarketplaceError::Unauthorized);
+        }
+        env.storage().persistent().set(&key, &new_admin);
+    }
+
     pub fn get_admin(env: Env) -> Option<Address> {
         let key = crate::storage::DataKey::Admin;
         env.storage().persistent().get::<_, Address>(&key)

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -597,6 +597,28 @@ fn test_set_admin_only_once() {
 }
 
 #[test]
+fn test_transfer_admin_updates_admin() {
+    let (_env, client, artist, buyer, _) = setup();
+    client.set_admin(&artist);
+
+    client.transfer_admin(&artist, &buyer);
+
+    assert_eq!(client.get_admin(), Some(buyer.clone()));
+    client.set_protocol_fee(&buyer, &250u32);
+    assert_eq!(client.get_protocol_fee(), 250u32);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #5)")]
+fn test_transfer_admin_rejects_non_admin() {
+    let (env, client, artist, buyer, _) = setup();
+    client.set_admin(&artist);
+    let new_admin = Address::generate(&env);
+
+    client.transfer_admin(&buyer, &new_admin);
+}
+
+#[test]
 fn test_add_and_remove_token_whitelist() {
     let (env, client, artist, _, contract_id) = setup();
     client.set_admin(&artist);


### PR DESCRIPTION
## Summary
- Adds `transfer_admin(current_admin, new_admin)` to rotate marketplace admin control after initialization.
- Requires the current stored admin to authorize the transfer before updating admin storage.
- Adds regression tests for successful transfer and non-admin rejection.

## Why
`set_admin` is intentionally one-time initialization, but issue #162 points out that there is no way to recover or rotate admin control if the current admin key is compromised or lost.

## Payment signal
Fixes #162. This is a Stellar Wave + Contract issue.

## Validation
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.91.1 fmt --check -p soroban-marketplace`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.91.1 test -p soroban-marketplace transfer_admin`
- `PATH="$HOME/.cargo/bin:$PATH" cargo +1.91.1 test -p soroban-marketplace`