### PR TITLE
fix: resolve issues #150, #151, #156, #167

### DIFF
--- a/frontend/afristore-app/src/components/ConnectWalletModal.tsx
+++ b/frontend/afristore-app/src/components/ConnectWalletModal.tsx
@@ -183,17 +183,19 @@ export function ConnectWalletModal({ isOpen, onClose }: ConnectWalletModalProps)
                                     </button>
 
                                     <button
-                                        onClick={() => setShowMagicModal(true)}
-                                        className="group relative flex w-full items-center gap-4 rounded-2xl border-2 border-gray-100 p-4 hover:border-brand-300 hover:bg-brand-50/30 transition-all duration-300"
+                                        disabled
+                                        className="group relative flex w-full items-center gap-4 rounded-2xl border-2 border-gray-100 p-4 opacity-60 cursor-not-allowed transition-all duration-300"
                                     >
-                                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-brand-100 text-brand-600 group-hover:bg-brand-500 group-hover:text-white transition-colors">
+                                        <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-gray-200 text-gray-400">
                                             <Mail size={24} />
                                         </div>
                                         <div className="text-left">
                                             <p className="font-bold text-midnight-900">Magic Wallet</p>
                                             <p className="text-xs text-gray-500">Email or Passkey</p>
                                         </div>
-                                        <ArrowRight size={18} className="absolute right-4 text-gray-300 group-hover:text-brand-500 group-hover:translate-x-1 transition-all" />
+                                        <span className="absolute right-4 text-[10px] font-bold uppercase tracking-wider text-brand-600 bg-brand-100 px-2 py-0.5 rounded-full">
+                                            Coming Soon
+                                        </span>
                                     </button>
 
                                     <div className="relative py-2">

--- a/frontend/afristore-app/src/context/WalletContext.tsx
+++ b/frontend/afristore-app/src/context/WalletContext.tsx
@@ -1,22 +1,71 @@
-// ─────────────────────────────────────────────────────────────
-// context/WalletContext.tsx — global wallet state via React Context
-// ─────────────────────────────────────────────────────────────
-
 "use client";
 
-import { createContext, useContext, ReactNode } from "react";
-import { useWallet, WalletState } from "@/hooks/useWallet";
+import { createContext, useContext, ReactNode, useMemo } from "react";
+import { useWallet, WalletState, WalletStatus } from "@/hooks/useWallet";
+import { useMagicWallet, MagicWalletState, MagicWalletStatus } from "@/hooks/useMagicWallet";
 
-const WalletContext = createContext<WalletState | null>(null);
+export type WalletType = "freighter" | "magic" | null;
+
+export interface UnifiedWalletState {
+  walletType: WalletType;
+  publicKey: string | null;
+  isConnected: boolean;
+  isConnecting: boolean;
+  isWrongNetwork: boolean;
+  error: string | null;
+  status: WalletStatus | "MAGIC_CONNECTED" | "DISCONNECTED";
+  networkPassphrase: string | null;
+  isInstalled: boolean;
+  connect: () => Promise<void>;
+  disconnect: () => void;
+  refresh: () => Promise<void>;
+  freighter: WalletState;
+  magic: MagicWalletState;
+}
+
+const WalletContext = createContext<UnifiedWalletState | null>(null);
 
 export function WalletProvider({ children }: { children: ReactNode }) {
-  const wallet = useWallet();
+  const freighter = useWallet();
+  const magic = useMagicWallet();
+
+  const walletType: WalletType = freighter.isConnected
+    ? "freighter"
+    : magic.isConnected
+      ? "magic"
+      : null;
+
+  const publicKey = freighter.publicKey ?? magic.publicAddress ?? null;
+
+  const status = freighter.isConnected || (!magic.isConnected && freighter.status !== "DISCONNECTED")
+    ? freighter.status
+    : magic.isConnected
+      ? "MAGIC_CONNECTED"
+      : "DISCONNECTED";
+
+  const value = useMemo(() => ({
+    walletType,
+    publicKey,
+    isConnected: freighter.isConnected || magic.isConnected,
+    isConnecting: freighter.isConnecting || magic.isConnecting,
+    isWrongNetwork: freighter.isWrongNetwork,
+    networkPassphrase: freighter.networkPassphrase,
+    isInstalled: freighter.isInstalled,
+    error: freighter.error ?? magic.error,
+    status,
+    connect: freighter.connect,
+    disconnect: freighter.disconnect,
+    refresh: freighter.refresh,
+    freighter,
+    magic,
+  }), [walletType, publicKey, status, freighter, magic]);
+
   return (
-    <WalletContext.Provider value={wallet}>{children}</WalletContext.Provider>
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
   );
 }
 
-export function useWalletContext(): WalletState {
+export function useWalletContext(): UnifiedWalletState {
   const ctx = useContext(WalletContext);
   if (!ctx) {
     throw new Error("useWalletContext must be used inside <WalletProvider>");

--- a/frontend/afristore-app/src/hooks/useAuctions.ts
+++ b/frontend/afristore-app/src/hooks/useAuctions.ts
@@ -91,6 +91,7 @@ export interface CreateAuctionInput {
   imageFile: File;
   reservePriceXlm: number;
   durationHours: number;
+  royaltyBps?: number;
 }
 
 export function useCreateAuction(creatorPublicKey: string | null) {
@@ -134,7 +135,8 @@ export function useCreateAuction(creatorPublicKey: string | null) {
           creatorPublicKey,
           metadataResult.cid,
           input.reservePriceXlm,
-          durationSeconds
+          durationSeconds,
+          input.royaltyBps
         );
 
         setProgress("Auction created successfully!");

--- a/frontend/afristore-app/src/lib/contract.ts
+++ b/frontend/afristore-app/src/lib/contract.ts
@@ -464,25 +464,28 @@ export async function createAuction(
   creatorPublicKey: string,
   metadataCid: string,
   reservePriceXlm: number,
-  durationSeconds: number
+  durationSeconds: number,
+  royaltyBps: number = 0,
+  recipients: Array<{ address: string; percentage: number }> = []
 ): Promise<number> {
   const reserveStroops = BigInt(Math.round(reservePriceXlm * 10_000_000));
   const nativeToken = getNativeTokenConfig();
 
+  const finalRecipients = recipients.length > 0
+    ? recipients
+    : [{ address: creatorPublicKey, percentage: 100 }];
+
   const args: xdr.ScVal[] = [
-    // creator: Address
     new Address(creatorPublicKey).toScVal(),
-    // metadata_cid: Bytes
     nativeToScVal(Buffer.from(metadataCid, "utf-8"), { type: "bytes" }),
     new Address(nativeToken.address).toScVal(),
-    // reserve_price: i128
     nativeToScVal(reserveStroops, { type: "i128" }),
-    // duration: u64
     nativeToScVal(BigInt(durationSeconds), { type: "u64" }),
-    // royalty_bps: u32
-    nativeToScVal(0, { type: "u32" }),
-    // recipients: Vec<Recipient> (empty for MVP)
-    nativeToScVal([], { type: "vec" }),
+    nativeToScVal(royaltyBps, { type: "u32" }),
+    nativeToScVal(finalRecipients.map(r => ({
+        address: new Address(r.address),
+        percentage: r.percentage
+    })), { type: "vec" }),
   ];
 
   const retVal = await invokeContract(

--- a/frontend/afristore-app/src/lib/magic.ts
+++ b/frontend/afristore-app/src/lib/magic.ts
@@ -160,32 +160,15 @@ export async function logoutFromMagic(): Promise<void> {
 
 /**
  * Sign a transaction with Magic (Stellar XDR)
+ *
+ * Magic SDK does not natively support Stellar transaction signing.
+ * This is a placeholder that throws a clear error until Stellar
+ * support is added (e.g. via Stellar Turrets, custodial relay, or
+ * Magic's Stellar extension).
  */
-export async function signWithMagic(txXdr: string): Promise<string> {
-  try {
-    const magic = getMagicInstance();
-    
-    // Magic provides a way to sign transactions through the user's account
-    // For Stellar, we need to use the underlying Ethereum-like signing capability
-    // and map it to Stellar's signing requirements
-    
-    const userMetadata = await magic.user.getInfo();
-    const publicAddress = (userMetadata as any).publicAddress || 
-                         (userMetadata as any).walletAddress || 
-                         (userMetadata as any).address;
-    
-    const signature = await magic.rpcProvider?.request({
-      method: "personal_sign",
-      params: [txXdr, publicAddress],
-    });
-
-    if (!signature || typeof signature !== "string") {
-      throw new Error("Failed to sign transaction with Magic");
-    }
-
-    return signature;
-  } catch (err) {
-    console.error("Error signing with Magic:", err);
-    throw err;
-  }
+export async function signWithMagic(_txXdr: string): Promise<string> {
+  throw new Error(
+    "Magic wallet does not support Stellar transaction signing yet. " +
+    "Please use Freighter wallet. Stellar support for Magic is coming soon."
+  );
 }

--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -12,9 +12,21 @@ const mockPrisma = vi.hoisted(() => ({
     findMany: vi.fn(),
     findFirst: vi.fn(),
   },
+  collection: {
+    findMany: vi.fn(),
+  },
+}));
+
+const mockRedis = vi.hoisted(() => ({
+  isOpen: false,
+  get: vi.fn(),
+  setEx: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn(),
+  connect: vi.fn().mockRejectedValue(new Error('No Redis')),
 }));
 
 vi.mock('../db', () => ({ default: mockPrisma }));
+vi.mock('../redis.js', () => ({ default: mockRedis }));
 
 import router from '../api/routes';
 
@@ -195,6 +207,66 @@ describe('GET /activity/recent', () => {
 
     const res = await request(app).get('/activity/recent');
     expect(res.status).toBe(500);
+  });
+});
+
+// ── GET /collections ─────────────────────────────────────────────────────────
+
+describe('GET /collections', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns all collections', async () => {
+    const sample = [{ contractAddress: 'CA', kind: 'normal_721', creator: 'GC', deployedAtLedger: 100 }];
+    mockPrisma.collection.findMany.mockResolvedValue(sample);
+
+    const res = await request(app).get('/collections');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('filters by kind query param', async () => {
+    mockPrisma.collection.findMany.mockResolvedValue([]);
+    await request(app).get('/collections?kind=normal_721');
+    expect(mockPrisma.collection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { kind: 'normal_721' } })
+    );
+  });
+
+  it('filters by creator query param', async () => {
+    mockPrisma.collection.findMany.mockResolvedValue([]);
+    await request(app).get('/collections?creator=GCREATOR');
+    expect(mockPrisma.collection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { creator: 'GCREATOR' } })
+    );
+  });
+
+  it('returns 500 on db error', async () => {
+    mockPrisma.collection.findMany.mockRejectedValue(new Error('DB down'));
+    const res = await request(app).get('/collections');
+    expect(res.status).toBe(500);
+  });
+});
+
+// ── GET /creators/:address/collections ───────────────────────────────────────
+
+describe('GET /creators/:address/collections', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns collections for a specific creator', async () => {
+    const sample = [{ contractAddress: 'CA', kind: 'lazy_1155', creator: 'GCREATOR', deployedAtLedger: 200 }];
+    mockPrisma.collection.findMany.mockResolvedValue(sample);
+
+    const res = await request(app).get('/creators/GCREATOR/collections');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('filters by creator address', async () => {
+    mockPrisma.collection.findMany.mockResolvedValue([]);
+    await request(app).get('/creators/OTHER/collections');
+    expect(mockPrisma.collection.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { creator: 'OTHER' } })
+    );
   });
 });
 

--- a/indexer/src/__tests__/cache-middleware.test.ts
+++ b/indexer/src/__tests__/cache-middleware.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import request from 'supertest';
+import express from 'express';
+
+const mockRedisClient = vi.hoisted(() => ({
+  isOpen: true,
+  get: vi.fn(),
+  setEx: vi.fn().mockResolvedValue(undefined),
+  on: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock('../redis.js', () => ({ default: mockRedisClient }));
+
+import { cacheMiddleware } from '../api/cache-middleware';
+
+describe('Cache Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    app = express();
+    app.get('/test', cacheMiddleware(30), (req, res) => {
+      res.json({ message: 'fresh', value: Date.now() });
+    });
+  });
+
+  it('passes through when Redis is not connected', async () => {
+    mockRedisClient.isOpen = false;
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('fresh');
+    expect(mockRedisClient.get).not.toHaveBeenCalled();
+  });
+
+  it('returns cached data on cache hit', async () => {
+    mockRedisClient.isOpen = true;
+    mockRedisClient.get.mockResolvedValue(JSON.stringify({ message: 'cached', value: 123 }));
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('cached');
+    expect(res.body.value).toBe(123);
+    expect(mockRedisClient.setEx).not.toHaveBeenCalled();
+  });
+
+  it('caches the response on cache miss', async () => {
+    mockRedisClient.isOpen = true;
+    mockRedisClient.get.mockResolvedValue(null);
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('fresh');
+    expect(mockRedisClient.setEx).toHaveBeenCalledOnce();
+    expect(mockRedisClient.setEx).toHaveBeenCalledWith(
+      expect.stringContaining('cache:'),
+      30,
+      expect.any(String)
+    );
+  });
+
+  it('uses originalUrl as cache key', async () => {
+    mockRedisClient.isOpen = true;
+    mockRedisClient.get.mockResolvedValue(null);
+
+    await request(app).get('/test?foo=bar');
+    expect(mockRedisClient.setEx).toHaveBeenCalledWith(
+      expect.stringContaining('/test?foo=bar'),
+      expect.any(Number),
+      expect.any(String)
+    );
+  });
+
+  it('passes through on Redis error', async () => {
+    mockRedisClient.isOpen = true;
+    mockRedisClient.get.mockRejectedValue(new Error('Redis down'));
+
+    const res = await request(app).get('/test');
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('fresh');
+  });
+});

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -15,6 +15,9 @@ const mockPrisma = vi.hoisted(() => ({
     create: vi.fn().mockResolvedValue({ id: 1, lastLedger: 0 }),
     update: vi.fn().mockResolvedValue({}),
   },
+  collection: {
+    upsert: vi.fn().mockResolvedValue({}),
+  },
 }));
 
 vi.mock('../db', () => ({ default: mockPrisma }));
@@ -184,6 +187,43 @@ describe('processEvent — null listingId', () => {
     expect(mockPrisma.marketplaceEvent.create).toHaveBeenCalledOnce();
     expect(mockPrisma.listing.upsert).not.toHaveBeenCalled();
     expect(mockPrisma.listing.update).not.toHaveBeenCalled();
+  });
+});
+
+// ── Deploy event types (Collection upsert) ────────────────────────────────────
+
+describe('processEvent — deploy events', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  const deployTypes = ['DEPLOY_NORMAL_721', 'DEPLOY_NORMAL_1155', 'DEPLOY_LAZY_721', 'DEPLOY_LAZY_1155'];
+
+  for (const eventType of deployTypes) {
+    it(`upserts a collection on ${eventType}`, async () => {
+      const data = ['GCREATOR', 'CCONTRACT'];
+      await processEvent(makeEvent(eventType, null, 'GCREATOR', data, 700));
+
+      expect(mockPrisma.collection.upsert).toHaveBeenCalledOnce();
+      const call = mockPrisma.collection.upsert.mock.calls[0][0];
+      expect(call.where).toEqual({ contractAddress: 'CCONTRACT' });
+      expect(call.create.contractAddress).toBe('CCONTRACT');
+      expect(call.create.creator).toBe('GCREATOR');
+      expect(call.create.deployedAtLedger).toBe(700);
+    });
+  }
+
+  it('skips collection upsert when contract address is empty', async () => {
+    await processEvent(makeEvent('DEPLOY_NORMAL_721', null, 'GCREATOR', ['GCREATOR', ''], 700));
+    expect(mockPrisma.collection.upsert).not.toHaveBeenCalled();
+  });
+
+  it('falls back to actor as creator when creator field is missing in data', async () => {
+    const data = ['', 'CCONTRACT'];
+    await processEvent(makeEvent('DEPLOY_LAZY_1155', null, 'GACTOR', data, 800));
+    expect(mockPrisma.collection.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({ creator: 'GACTOR', contractAddress: 'CCONTRACT' }),
+      })
+    );
   });
 });
 

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -91,7 +91,37 @@ export async function processEvent(event: any) {
     },
   });
 
-  // 2. Update Listing state based on event type
+  // 2. Handle deploy events (no listingId — collection deployments)
+  if (eventType === 'DEPLOY_NORMAL_721' || eventType === 'DEPLOY_NORMAL_1155' ||
+      eventType === 'DEPLOY_LAZY_721' || eventType === 'DEPLOY_LAZY_1155') {
+    const kindMap: Record<string, string> = {
+      DEPLOY_NORMAL_721:  'normal_721',
+      DEPLOY_NORMAL_1155: 'normal_1155',
+      DEPLOY_LAZY_721:    'lazy_721',
+      DEPLOY_LAZY_1155:   'lazy_1155',
+    };
+    const rawData = Array.isArray(data) ? data : [];
+    const creatorAddr  = rawData[0]?.toString() || actor;
+    const contractAddr = rawData[1]?.toString() || '';
+    if (contractAddr) {
+      await prisma.collection.upsert({
+        where: { contractAddress: contractAddr },
+        create: {
+          contractAddress: contractAddr,
+          kind: kindMap[eventType],
+          creator: creatorAddr,
+          deployedAtLedger: ledgerSequence,
+        },
+        update: {
+          creator: creatorAddr,
+          deployedAtLedger: ledgerSequence,
+        },
+      });
+    }
+    return;
+  }
+
+  // 3. Update Listing state based on event type
   if (!listingId) return;
 
   switch (eventType) {
@@ -165,36 +195,5 @@ export async function processEvent(event: any) {
         });
         break;
 
-    case 'DEPLOY_NORMAL_721':
-    case 'DEPLOY_NORMAL_1155':
-    case 'DEPLOY_LAZY_721':
-    case 'DEPLOY_LAZY_1155': {
-      const kindMap: Record<string, string> = {
-        DEPLOY_NORMAL_721:  'normal_721',
-        DEPLOY_NORMAL_1155: 'normal_1155',
-        DEPLOY_LAZY_721:    'lazy_721',
-        DEPLOY_LAZY_1155:   'lazy_1155',
-      };
-      // data is the raw tuple array [creator, collectionAddress]
-      const rawData = Array.isArray(data) ? data : [];
-      const creatorAddr  = rawData[0]?.toString() || actor;
-      const contractAddr = rawData[1]?.toString() || '';
-      if (contractAddr) {
-        await prisma.collection.upsert({
-          where: { contractAddress: contractAddr },
-          create: {
-            contractAddress: contractAddr,
-            kind: kindMap[eventType],
-            creator: creatorAddr,
-            deployedAtLedger: ledgerSequence,
-          },
-          update: {
-            creator: creatorAddr,
-            deployedAtLedger: ledgerSequence,
-          },
-        });
-      }
-      break;
-    }
   }
 }


### PR DESCRIPTION
## Summary

### #150: `createAuction` passes empty recipients and 0 royalty hardcoded
- Added `royaltyBps` and `recipients` parameters to `createAuction` in `contract.ts`
- Defaults recipients to `[{ address: creatorPublicKey, percentage: 100 }]` when none provided (matching `createListing` pattern)
- Added `royaltyBps?` to `CreateAuctionInput` interface
- Passes through to the contract call

### #151: Magic wallet `signWithMagic` uses Ethereum `personal_sign` for Stellar
- Replaced `signWithMagic` implementation to throw a clear error that Magic does not support Stellar transaction signing yet
- Disabled the Magic Wallet option in `ConnectWalletModal` with a "Coming Soon" badge

### #156: WalletContext doesn't expose Magic wallet state
- Rewrote `WalletContext` as a unified provider exposing both Freighter and Magic wallet state
- Added `walletType: 'freighter' | 'magic' | null` discriminator
- Exposes a single `publicKey` from whichever wallet is connected
- All consuming components receive a unified `publicKey` and `isConnected` from context

### #167: No indexer integration tests
- Added deploy event tests (`DEPLOY_NORMAL_721`, `DEPLOY_NORMAL_1155`, `DEPLOY_LAZY_721`, `DEPLOY_LAZY_1155`) to `poller.test.ts`
- Added collection API route tests (`GET /collections`, `GET /creators/:address/collections`) to `api.test.ts`
- Added cache middleware tests (`cache-middleware.test.ts`)
- Fixed unreachable deploy event handling in `poller.ts` (deploy events have no `listingId`, so they were skipped by the early return guard)

Closes #150
Closes #151
Closes #156 
Closes #167