### PR TITLE
fix: poller window reset, admin transfer, auction detail page & event emissions

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -13,11 +13,13 @@ use crate::events::*;
 use crate::{
     storage::{
         acquire_auction_lock, acquire_listing_lock, add_artist_auction_id, add_artist_listing_id,
-        get_artist_listing_ids, get_listing_count, increment_auction_count,
-        increment_listing_count, increment_offer_count, is_artist_revoked_storage, load_auction,
-        load_listing, load_listing_offers, load_offer, load_offerer_offers, release_auction_lock,
+        clear_pending_admin_storage, get_artist_listing_ids, get_listing_count,
+        get_pending_admin_storage, increment_auction_count, increment_listing_count,
+        increment_offer_count, is_artist_revoked_storage, load_auction, load_listing,
+        load_listing_offers, load_offer, load_offerer_offers, release_auction_lock,
         release_listing_lock, remove_artist_revocation_storage, save_auction, save_listing,
         save_listing_offers, save_offer, save_offerer_offers, set_artist_revocation_storage,
+        set_pending_admin_storage,
     },
     types::{
         Auction, AuctionStatus, Listing, ListingStatus, MarketplaceError, Offer, OfferStatus,
@@ -44,6 +46,48 @@ impl MarketplaceContract {
     pub fn get_admin(env: Env) -> Option<Address> {
         let key = crate::storage::DataKey::Admin;
         env.storage().persistent().get::<_, Address>(&key)
+    }
+
+    /// Step 1 of a 2-step admin transfer: the current admin proposes a successor.
+    /// The successor must call `accept_admin` to complete the handover.
+    pub fn transfer_admin(env: Env, current_admin: Address, new_admin: Address) {
+        current_admin.require_auth();
+        let stored_admin = Self::get_admin(env.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, MarketplaceError::Unauthorized));
+        if current_admin != stored_admin {
+            panic_with_error!(&env, MarketplaceError::Unauthorized);
+        }
+        set_pending_admin_storage(&env, &new_admin);
+        crate::events::AdminTransferProposedEvent {
+            current_admin,
+            proposed_admin: new_admin,
+        }
+        .publish(&env);
+    }
+
+    /// Step 2 of a 2-step admin transfer: the proposed new admin accepts the role.
+    pub fn accept_admin(env: Env, new_admin: Address) {
+        new_admin.require_auth();
+        let pending = get_pending_admin_storage(&env)
+            .unwrap_or_else(|| panic_with_error!(&env, MarketplaceError::Unauthorized));
+        if new_admin != pending {
+            panic_with_error!(&env, MarketplaceError::Unauthorized);
+        }
+        let old_admin = Self::get_admin(env.clone())
+            .unwrap_or_else(|| panic_with_error!(&env, MarketplaceError::Unauthorized));
+        let key = crate::storage::DataKey::Admin;
+        env.storage().persistent().set(&key, &new_admin);
+        env.storage().persistent().extend_ttl(
+            &key,
+            crate::storage::LEDGER_TTL_THRESHOLD,
+            crate::storage::LEDGER_TTL_BUMP,
+        );
+        clear_pending_admin_storage(&env);
+        crate::events::AdminTransferredEvent {
+            old_admin,
+            new_admin,
+        }
+        .publish(&env);
     }
 
     pub fn set_treasury(env: Env, admin: Address, treasury: Address) {
@@ -280,12 +324,22 @@ impl MarketplaceContract {
             panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
 
-        listing.metadata_cid = new_metadata_cid;
+        listing.metadata_cid = new_metadata_cid.clone();
         listing.price = new_price;
         listing.token = new_token;
         listing.recipients = new_recipients;
 
         save_listing(&env, &listing);
+
+        ListingUpdatedEvent {
+            listing_id,
+            artist: artist.clone(),
+            new_price,
+            metadata_cid: new_metadata_cid,
+            ledger_sequence: env.ledger().sequence(),
+        }
+        .publish(&env);
+
         true
     }
 
@@ -345,6 +399,16 @@ impl MarketplaceContract {
         listing.owner = Some(buyer.clone());
         save_listing(&env, &listing);
 
+        ArtworkSoldEvent {
+            listing_id,
+            artist: listing.artist.clone(),
+            buyer: buyer.clone(),
+            price: listing.price,
+            currency: listing.currency.clone(),
+            ledger_sequence: env.ledger().sequence(),
+        }
+        .publish(&env);
+
         // Reject all pending offers
         let offers = load_listing_offers(&env, listing_id);
         for offer_id in offers.iter() {
@@ -383,6 +447,14 @@ impl MarketplaceContract {
         }
         listing.status = ListingStatus::Cancelled;
         save_listing(&env, &listing);
+
+        ListingCancelledEvent {
+            listing_id,
+            artist: artist.clone(),
+            ledger_sequence: env.ledger().sequence(),
+        }
+        .publish(&env);
+
         true
     }
 
@@ -428,6 +500,16 @@ impl MarketplaceContract {
         };
         save_auction(&env, &auction);
         add_artist_auction_id(&env, &creator, auction_id);
+
+        AuctionCreatedEvent {
+            auction_id,
+            creator: creator.clone(),
+            reserve_price,
+            token: token.clone(),
+            end_time,
+        }
+        .publish(&env);
+
         auction_id
     }
 
@@ -459,6 +541,13 @@ impl MarketplaceContract {
         auction.highest_bid = amount;
         auction.highest_bidder = Some(bidder.clone());
         save_auction(&env, &auction);
+
+        BidPlacedEvent {
+            auction_id,
+            bidder: bidder.clone(),
+            bid_amount: amount,
+        }
+        .publish(&env);
     }
 
     pub fn finalize_auction(env: Env, auction_id: u64) {
@@ -486,27 +575,38 @@ impl MarketplaceContract {
             auction.creator.require_auth();
         }
 
-        if let Some(_winner) = auction.highest_bidder.clone() {
-            #[cfg(not(test))]
-            {
-                Self::distribute_payout(
-                    &env,
-                    &auction.token,
-                    auction.highest_bid,
-                    &auction.original_creator,
-                    auction.royalty_bps,
-                    &auction.creator,
-                    &auction.recipients,
-                    &_winner,
-                    false,
-                );
-            }
-            auction.status = AuctionStatus::Finalized;
-        } else {
-            auction.status = AuctionStatus::Cancelled;
-        }
+        let (finalized_winner, finalized_amount) =
+            if let Some(ref winner) = auction.highest_bidder.clone() {
+                #[cfg(not(test))]
+                {
+                    Self::distribute_payout(
+                        &env,
+                        &auction.token,
+                        auction.highest_bid,
+                        &auction.original_creator,
+                        auction.royalty_bps,
+                        &auction.creator,
+                        &auction.recipients,
+                        winner,
+                        false,
+                    );
+                }
+                auction.status = AuctionStatus::Finalized;
+                (Some(winner.clone()), auction.highest_bid)
+            } else {
+                auction.status = AuctionStatus::Cancelled;
+                (None, 0)
+            };
+
         save_auction(&env, &auction);
         release_auction_lock(&env, auction_id);
+
+        AuctionFinalizedEvent {
+            auction_id,
+            winner: finalized_winner,
+            amount: finalized_amount,
+        }
+        .publish(&env);
     }
 
     pub fn make_offer(
@@ -558,6 +658,16 @@ impl MarketplaceContract {
         let mut oo = load_offerer_offers(&env, &offerer);
         oo.push_back(offer_id);
         save_offerer_offers(&env, &offerer, &oo);
+
+        OfferMadeEvent {
+            offer_id,
+            listing_id,
+            offerer: offerer.clone(),
+            amount,
+            token,
+        }
+        .publish(&env);
+
         offer_id
     }
 
@@ -584,6 +694,13 @@ impl MarketplaceContract {
         }
         offer.status = OfferStatus::Withdrawn;
         save_offer(&env, &offer);
+
+        OfferWithdrawnEvent {
+            offer_id,
+            listing_id: offer.listing_id,
+            offerer: offerer.clone(),
+        }
+        .publish(&env);
     }
 
     pub fn reject_offer(env: Env, artist: Address, offer_id: u64) {
@@ -611,6 +728,13 @@ impl MarketplaceContract {
         }
         offer.status = OfferStatus::Rejected;
         save_offer(&env, &offer);
+
+        OfferRejectedEvent {
+            offer_id,
+            listing_id: offer.listing_id,
+            offerer: offer.offerer.clone(),
+        }
+        .publish(&env);
     }
 
     pub fn accept_offer(env: Env, artist: Address, offer_id: u64) {
@@ -642,11 +766,23 @@ impl MarketplaceContract {
                 false,
             );
         }
+        let accepted_offerer = offer.offerer.clone();
+        let accepted_amount = offer.amount;
+        let accepted_listing_id = offer.listing_id;
         offer.status = OfferStatus::Accepted;
         save_offer(&env, &offer);
         listing.status = ListingStatus::Sold;
-        listing.owner = Some(offer.offerer.clone());
+        listing.owner = Some(accepted_offerer.clone());
         save_listing(&env, &listing);
+
+        OfferAcceptedEvent {
+            offer_id,
+            listing_id: accepted_listing_id,
+            offerer: accepted_offerer.clone(),
+            amount: accepted_amount,
+        }
+        .publish(&env);
+
         let offers = load_listing_offers(&env, listing.listing_id);
         for oid in offers.iter() {
             if oid != offer_id {

--- a/contracts/soroban-marketplace/src/events.rs
+++ b/contracts/soroban-marketplace/src/events.rs
@@ -14,6 +14,8 @@ pub const OFFER_ACCEPTED: Symbol = symbol_short!("ofr_accp");
 pub const OFFER_REJECTED: Symbol = symbol_short!("ofr_rjct");
 pub const OFFER_WITHDRAWN: Symbol = symbol_short!("ofr_wdrn");
 pub const ROYALTY_PAID: Symbol = symbol_short!("roy_paid");
+pub const ADMIN_TRANSFER_PROPOSED: Symbol = symbol_short!("adm_prop");
+pub const ADMIN_TRANSFERRED: Symbol = symbol_short!("adm_xfrd");
 pub const ARTIST_REVOKED: Symbol = symbol_short!("art_rvkd");
 pub const ARTIST_REINSTATED: Symbol = symbol_short!("art_rnst");
 pub const CONTRACT_PAUSED: Symbol = symbol_short!("ctr_psd");
@@ -223,6 +225,34 @@ impl ArtistReinstatedEvent {
     #[allow(deprecated)]
     pub fn publish(self, env: &Env) {
         env.events().publish((ARTIST_REINSTATED,), self);
+    }
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferProposedEvent {
+    pub current_admin: Address,
+    pub proposed_admin: Address,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AdminTransferredEvent {
+    pub old_admin: Address,
+    pub new_admin: Address,
+}
+
+impl AdminTransferProposedEvent {
+    #[allow(deprecated)]
+    pub fn publish(self, env: &Env) {
+        env.events().publish((ADMIN_TRANSFER_PROPOSED,), self);
+    }
+}
+
+impl AdminTransferredEvent {
+    #[allow(deprecated)]
+    pub fn publish(self, env: &Env) {
+        env.events().publish((ADMIN_TRANSFERRED,), self);
     }
 }
 

--- a/contracts/soroban-marketplace/src/storage.rs
+++ b/contracts/soroban-marketplace/src/storage.rs
@@ -23,10 +23,11 @@ pub enum DataKey {
     ListingLock(u64),
     AuctionLock(u64),
     IsPaused,
+    PendingAdmin,
 }
 
-const LEDGER_TTL_BUMP: u32 = 432_000;
-const LEDGER_TTL_THRESHOLD: u32 = 144_000;
+pub const LEDGER_TTL_BUMP: u32 = 432_000;
+pub const LEDGER_TTL_THRESHOLD: u32 = 144_000;
 
 // ── Counter helpers ──────────────────────────────────────────
 
@@ -291,6 +292,27 @@ pub fn acquire_auction_lock(env: &Env, auction_id: u64) -> bool {
 pub fn release_auction_lock(env: &Env, auction_id: u64) {
     let key = DataKey::AuctionLock(auction_id);
     env.storage().persistent().remove(&key);
+}
+
+// ── Admin transfer helpers ───────────────────────────────────
+
+pub fn set_pending_admin_storage(env: &Env, pending: &Address) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::PendingAdmin, pending);
+    env.storage().persistent().extend_ttl(
+        &DataKey::PendingAdmin,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn get_pending_admin_storage(env: &Env) -> Option<Address> {
+    env.storage().persistent().get(&DataKey::PendingAdmin)
+}
+
+pub fn clear_pending_admin_storage(env: &Env) {
+    env.storage().persistent().remove(&DataKey::PendingAdmin);
 }
 
 // ── Pause/Unpause Mechanism ──────────────────────────────────

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -1,7 +1,8 @@
 use super::*;
 use crate::types::{ListingStatus, OfferStatus, Recipient};
 use soroban_sdk::{
-    bytes, symbol_short, testutils::Address as _, testutils::Ledger, vec, Address, Env,
+    bytes, symbol_short, testutils::Address as _, testutils::Events as _, testutils::Ledger,
+    vec, Address, Env, IntoVal,
 };
 
 /// Helper — deploy the contract and return (env, client, artist, buyer, contract_id).
@@ -1278,4 +1279,277 @@ fn test_update_listing_success_with_recipients() {
     let listing = client.get_listing(&id);
     assert_eq!(listing.price, 15_000_000);
     assert_eq!(listing.recipients.len(), 2);
+}
+
+// ── transfer_admin / accept_admin tests (Issue #162) ────────
+
+#[test]
+fn test_transfer_admin_two_step_succeeds() {
+    let (env, client, admin, _, _) = setup();
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+
+    // Step 1: current admin proposes new admin
+    client.transfer_admin(&admin, &new_admin);
+
+    // Admin has NOT changed yet
+    assert_eq!(client.get_admin(), Some(admin.clone()));
+
+    // Step 2: new admin accepts
+    client.accept_admin(&new_admin);
+
+    assert_eq!(client.get_admin(), Some(new_admin.clone()));
+}
+
+#[test]
+#[should_panic]
+fn test_transfer_admin_wrong_caller_panics() {
+    let (env, client, admin, _, _) = setup();
+    let impostor = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    client.set_admin(&admin);
+    // impostor tries to initiate transfer — should panic Unauthorized
+    client.transfer_admin(&impostor, &new_admin);
+}
+
+#[test]
+#[should_panic]
+fn test_accept_admin_wrong_caller_panics() {
+    let (env, client, admin, _, _) = setup();
+    let new_admin = Address::generate(&env);
+    let impostor = Address::generate(&env);
+
+    client.set_admin(&admin);
+    client.transfer_admin(&admin, &new_admin);
+    // A different address tries to accept — should panic Unauthorized
+    client.accept_admin(&impostor);
+}
+
+// ── Event emission tests (Issue #180) ────────────────────────
+
+#[test]
+fn test_buy_artwork_emits_artwork_sold_event() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.buy_artwork(&buyer, &listing_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("art_sold").into_val(&env))
+    });
+    assert!(found, "ArtworkSoldEvent was not emitted");
+}
+
+#[test]
+fn test_cancel_listing_emits_listing_cancelled_event() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.cancel_listing(&artist, &listing_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("lst_cncl").into_val(&env))
+    });
+    assert!(found, "ListingCancelledEvent was not emitted");
+}
+
+#[test]
+fn test_update_listing_emits_listing_updated_event() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.update_listing(
+        &artist,
+        &listing_id,
+        &bytes!(&env, 0x52),
+        &20_000_000,
+        &contract_id,
+        &valid_recipients(&env, &artist),
+    );
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("lst_updt").into_val(&env))
+    });
+    assert!(found, "ListingUpdatedEvent was not emitted");
+}
+
+#[test]
+fn test_make_offer_emits_offer_made_event() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("ofr_made").into_val(&env))
+    });
+    assert!(found, "OfferMadeEvent was not emitted");
+}
+
+#[test]
+fn test_accept_offer_emits_offer_accepted_event() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+    client.accept_offer(&artist, &offer_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("ofr_accp").into_val(&env))
+    });
+    assert!(found, "OfferAcceptedEvent was not emitted");
+}
+
+#[test]
+fn test_reject_offer_emits_offer_rejected_event() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+    client.reject_offer(&artist, &offer_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("ofr_rjct").into_val(&env))
+    });
+    assert!(found, "OfferRejectedEvent was not emitted");
+}
+
+#[test]
+fn test_withdraw_offer_emits_offer_withdrawn_event() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
+    let offer_token = Address::generate(&env);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
+    client.withdraw_offer(&buyer, &offer_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("ofr_wdrn").into_val(&env))
+    });
+    assert!(found, "OfferWithdrawnEvent was not emitted");
+}
+
+#[test]
+fn test_create_auction_emits_auction_created_event() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    client.create_auction(
+        &artist,
+        &bytes!(&env, 0x516d74657374),
+        &contract_id,
+        &1_000_000_i128,
+        &3600_u64,
+        &0u32,
+        &valid_recipients(&env, &artist),
+    );
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("auc_crtd").into_val(&env))
+    });
+    assert!(found, "AuctionCreatedEvent was not emitted");
+}
+
+#[test]
+fn test_place_bid_emits_bid_placed_event() {
+    let (env, client, artist, bidder, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let auction_id = client.create_auction(
+        &artist,
+        &bytes!(&env, 0x516d74657374),
+        &contract_id,
+        &1_000_000_i128,
+        &3600_u64,
+        &0u32,
+        &valid_recipients(&env, &artist),
+    );
+    client.place_bid(&bidder, &auction_id, &2_000_000_i128);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("bid_plcd").into_val(&env))
+    });
+    assert!(found, "BidPlacedEvent was not emitted");
+}
+
+#[test]
+fn test_finalize_auction_emits_auction_resolved_event() {
+    let (env, client, artist, bidder, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+
+    let auction_id = client.create_auction(
+        &artist,
+        &bytes!(&env, 0x516d74657374),
+        &contract_id,
+        &1_000_000_i128,
+        &3600_u64,
+        &0u32,
+        &valid_recipients(&env, &artist),
+    );
+    client.place_bid(&bidder, &auction_id, &2_000_000_i128);
+
+    // Advance time past end
+    env.ledger().with_mut(|l| {
+        l.timestamp += 7200;
+    });
+
+    client.finalize_auction(&auction_id);
+
+    let events = env.events().all();
+    let found = events.iter().any(|(_, topics, _)| {
+        topics
+            .iter()
+            .any(|t| t == symbol_short!("auc_rslv").into_val(&env))
+    });
+    assert!(found, "AuctionFinalizedEvent was not emitted");
 }

--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -1,5 +1,5 @@
 // ─────────────────────────────────────────────────────────────
-// app/auctions/[id]/page.tsx — Individual auction detail page
+// app/auctions/[id]/page.tsx — Auction detail page
 // ─────────────────────────────────────────────────────────────
 
 "use client";
@@ -7,22 +7,112 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Image from "next/image";
+import Link from "next/link";
 import { getAuction, stroopsToXlm, Auction } from "@/lib/contract";
 import { fetchMetadata, cidToGatewayUrl, ArtworkMetadata } from "@/lib/ipfs";
+import { getListingActivity, ActivityEvent } from "@/lib/indexer";
 import { getReadableErrorMessage } from "@/lib/errors";
 import { useWalletContext } from "@/context/WalletContext";
-import { BiddingPanel } from "@/components/BiddingPanel";
+import { usePlaceBid, useFinalizeAuction } from "@/hooks/useAuctions";
+import { GuardButton } from "@/components/WalletGuard";
 import {
   ArrowLeft,
-  ExternalLink,
+  Clock,
+  Gavel,
+  Trophy,
+  History,
+  RefreshCw,
+  AlertCircle,
+  CheckCircle2,
   User,
   Calendar,
+  Tag,
   Hash,
-  Gavel,
-  Shield,
-  Percent,
-  RefreshCw,
+  Hammer,
+  Flag,
 } from "lucide-react";
+
+// ── Countdown component ──────────────────────────────────────
+
+function Countdown({ endTime }: { endTime: number }) {
+  const [now, setNow] = useState(() => Math.floor(Date.now() / 1000));
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(Math.floor(Date.now() / 1000)), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  const remaining = Math.max(0, endTime - now);
+
+  if (remaining === 0) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full bg-red-50 px-3 py-1 text-sm font-semibold text-red-600">
+        <Flag size={13} />
+        Auction Ended
+      </span>
+    );
+  }
+
+  const d = Math.floor(remaining / 86400);
+  const h = Math.floor((remaining % 86400) / 3600);
+  const m = Math.floor((remaining % 3600) / 60);
+  const s = remaining % 60;
+
+  return (
+    <div className="flex items-center gap-3">
+      {(
+        [
+          { label: "Days", value: d },
+          { label: "Hours", value: h },
+          { label: "Min", value: m },
+          { label: "Sec", value: s },
+        ] as const
+      ).map(({ label, value }) => (
+        <div
+          key={label}
+          className="flex flex-col items-center rounded-xl bg-brand-50 px-3 py-2 min-w-[52px]"
+        >
+          <span className="font-mono text-2xl font-bold text-brand-700 leading-none">
+            {String(value).padStart(2, "0")}
+          </span>
+          <span className="mt-1 text-[10px] uppercase tracking-wide text-brand-400">
+            {label}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Bid history row ──────────────────────────────────────────
+
+function BidHistoryRow({ event }: { event: ActivityEvent }) {
+  const amountXlm = (Number(event.price) / 10_000_000).toLocaleString(
+    undefined,
+    { maximumFractionDigits: 4 }
+  );
+  const shortAddr = (addr: string) =>
+    addr.length > 12 ? `${addr.slice(0, 6)}…${addr.slice(-4)}` : addr;
+
+  return (
+    <div className="flex items-center justify-between rounded-xl border border-gray-100 bg-white px-4 py-3 text-sm">
+      <div className="flex items-center gap-2 text-gray-700 min-w-0">
+        <User size={13} className="shrink-0 text-gray-400" />
+        <span className="truncate font-mono text-xs">
+          {shortAddr(event.from)}
+        </span>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="font-semibold text-brand-600">{amountXlm} XLM</span>
+        <span className="text-xs text-gray-400">
+          Ledger {event.tx_hash.replace("ledger_", "")}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────
 
 export default function AuctionDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -31,18 +121,34 @@ export default function AuctionDetailPage() {
 
   const [auction, setAuction] = useState<Auction | null>(null);
   const [metadata, setMetadata] = useState<ArtworkMetadata | null>(null);
+  const [bidHistory, setBidHistory] = useState<ActivityEvent[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [activeTab, setActiveTab] = useState<"details" | "bids">("details");
 
-  const loadAuction = useCallback(async () => {
+  const [bidAmountXlm, setBidAmountXlm] = useState("");
+  const [bidSuccess, setBidSuccess] = useState(false);
+  const [finalizeSuccess, setFinalizeSuccess] = useState(false);
+
+  const { bid, isBidding, error: bidError } = usePlaceBid(publicKey);
+  const { finalize, isFinalizing, error: finalizeError } =
+    useFinalizeAuction(publicKey);
+
+  const loadData = useCallback(async () => {
+    if (!id) return;
     setIsLoading(true);
     setError(null);
     try {
-      const a = await getAuction(Number(id));
-      setAuction(a);
-      const m = await fetchMetadata(a.metadata_cid);
-      setMetadata(m);
-    } catch (err: unknown) {
+      const auctionData = await getAuction(Number(id));
+      setAuction(auctionData);
+
+      const [meta, history] = await Promise.all([
+        fetchMetadata(auctionData.metadata_cid).catch(() => null),
+        getListingActivity(Number(id)).catch(() => [] as ActivityEvent[]),
+      ]);
+      setMetadata(meta);
+      setBidHistory(history);
+    } catch (err) {
       setError(getReadableErrorMessage(err, "Failed to load auction"));
     } finally {
       setIsLoading(false);
@@ -50,153 +156,403 @@ export default function AuctionDetailPage() {
   }, [id]);
 
   useEffect(() => {
-    if (id) loadAuction();
-  }, [id, loadAuction]);
+    loadData();
+  }, [loadData]);
 
-  const handleRefresh = async () => {
-    try {
-      const updated = await getAuction(Number(id));
-      setAuction(updated);
-    } catch {
-      // Silently fail on refresh
+  const handleBid = async () => {
+    if (!auction) return;
+    const amountXlm = parseFloat(bidAmountXlm);
+    if (!amountXlm || amountXlm <= 0) return;
+    const ok = await bid(auction.auction_id, amountXlm);
+    if (ok) {
+      setBidSuccess(true);
+      setBidAmountXlm("");
+      setTimeout(() => setBidSuccess(false), 3000);
+      loadData();
     }
   };
 
+  const handleFinalize = async () => {
+    if (!auction) return;
+    const ok = await finalize(auction.auction_id);
+    if (ok) {
+      setFinalizeSuccess(true);
+      loadData();
+    }
+  };
+
+  const now = Math.floor(Date.now() / 1000);
+  const isExpired = auction ? now >= auction.end_time : false;
+  const isActive = auction?.status === "Active";
+  const isFinalized = auction?.status === "Finalized";
+  const isCancelled = auction?.status === "Cancelled";
+  const canFinalize = isActive && isExpired;
+  const canBid = isActive && !isExpired;
+
+  const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
+  const highestBidXlm = auction ? stroopsToXlm(auction.highest_bid) : "0";
+  const reserveXlm = auction ? stroopsToXlm(auction.reserve_price) : "0";
+
   if (isLoading) {
     return (
-      <div className="flex justify-center py-32">
-        <div className="h-10 w-10 animate-spin rounded-full border-4 border-brand-200 border-t-brand-500" />
+      <div className="min-h-screen bg-gray-50 pt-24">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <div className="animate-pulse grid gap-8 lg:grid-cols-2">
+            <div className="aspect-square rounded-3xl bg-gray-200" />
+            <div className="space-y-4 pt-4">
+              <div className="h-8 w-3/4 rounded-xl bg-gray-200" />
+              <div className="h-5 w-1/2 rounded-xl bg-gray-200" />
+              <div className="h-24 rounded-2xl bg-gray-200" />
+              <div className="h-12 rounded-2xl bg-gray-200" />
+            </div>
+          </div>
+        </div>
       </div>
     );
   }
 
   if (error || !auction) {
     return (
-      <div className="py-20 text-center">
-        <p className="text-red-500">{error ?? "Auction not found"}</p>
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4 bg-gray-50 pt-24">
+        <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 text-red-500">
+          <AlertCircle size={32} />
+        </div>
+        <h2 className="text-lg font-bold text-gray-900">
+          {error ?? "Auction not found"}
+        </h2>
         <button
-          onClick={loadAuction}
-          className="mt-4 inline-flex items-center gap-2 rounded-lg bg-brand-500 px-4 py-2 text-sm font-bold text-white hover:bg-brand-600"
+          onClick={() => router.push("/auctions")}
+          className="flex items-center gap-2 rounded-xl bg-brand-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-brand-600 transition-all"
         >
-          <RefreshCw size={14} />
-          Retry
-        </button>
-        <button
-          onClick={() => router.back()}
-          className="mt-4 text-sm text-brand-500 hover:underline"
-        >
-          Back
+          <ArrowLeft size={14} />
+          Back to Auctions
         </button>
       </div>
     );
   }
 
-  const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
-
   return (
-    <div className="min-h-screen bg-gray-50 pt-24">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
-        <button
-          onClick={() => router.back()}
-          className="mb-6 flex items-center gap-1.5 text-sm text-gray-500 hover:text-brand-600"
-        >
-          <ArrowLeft size={14} />
-          Back to auctions
-        </button>
+    <div className="min-h-screen bg-gray-50">
+      {/* Back nav */}
+      <div className="pt-20 pb-4">
+        <div className="mx-auto max-w-6xl px-4 sm:px-6">
+          <Link
+            href="/auctions"
+            className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-brand-600 transition-colors"
+          >
+            <ArrowLeft size={14} />
+            All Auctions
+          </Link>
+        </div>
+      </div>
 
-        <div className="grid gap-10 lg:grid-cols-2">
-          {/* Image */}
-          <div className="relative aspect-square overflow-hidden rounded-2xl bg-brand-50">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6 pb-16">
+        <div className="grid gap-10 lg:grid-cols-[1fr_420px]">
+          {/* Artwork image */}
+          <div className="relative aspect-square overflow-hidden rounded-3xl bg-brand-50 shadow-md">
             {imageUrl ? (
               <Image
                 src={imageUrl}
-                alt={metadata?.title ?? "Auction artwork"}
+                alt={metadata?.title ?? `Auction #${auction.auction_id}`}
                 fill
-                className="object-contain"
+                className="object-cover"
                 unoptimized
               />
             ) : (
               <div className="flex h-full items-center justify-center">
-                <Gavel size={64} className="text-brand-300" />
+                <Gavel size={64} className="text-brand-200" />
               </div>
             )}
+
+            {/* Status badge */}
+            <span
+              className={`absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${
+                isActive
+                  ? "bg-green-500 text-white"
+                  : isFinalized
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-400 text-white"
+              }`}
+            >
+              {auction.status}
+            </span>
           </div>
 
-          {/* Details */}
-          <div className="flex flex-col">
-            <h1 className="text-3xl font-display font-bold text-gray-900">
-              {metadata?.title ?? `Auction #${auction.auction_id}`}
-            </h1>
+          {/* Info panel */}
+          <div className="flex flex-col gap-6">
+            {/* Title */}
+            <div>
+              <h1 className="text-3xl font-display font-bold text-gray-900 leading-tight">
+                {metadata?.title ?? `Auction #${auction.auction_id}`}
+              </h1>
+              {metadata?.description && (
+                <p className="mt-2 text-sm text-gray-500 line-clamp-3">
+                  {metadata.description}
+                </p>
+              )}
+            </div>
 
-            {metadata?.description && (
-              <p className="mt-3 text-gray-600 leading-relaxed">
-                {metadata.description}
-              </p>
+            {/* Countdown */}
+            {isActive && (
+              <div>
+                <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-400 flex items-center gap-1">
+                  <Clock size={12} />
+                  Time Remaining
+                </p>
+                <Countdown endTime={auction.end_time} />
+              </div>
             )}
 
-            <div className="mt-6 space-y-3 text-sm text-gray-500">
-              <div className="flex items-center gap-2">
-                <User size={15} />
-                <span className="font-mono break-all">{auction.creator}</span>
+            {/* Bid summary */}
+            <div className="rounded-2xl border border-gray-100 bg-white p-5 space-y-3">
+              <div className="flex items-center justify-between">
+                <span className="flex items-center gap-1.5 text-sm text-gray-500">
+                  <Trophy size={14} className="text-brand-500" />
+                  Current Bid
+                </span>
+                <span className="text-xl font-bold text-gray-900">
+                  {Number(auction.highest_bid) > 0
+                    ? `${highestBidXlm} XLM`
+                    : "No bids yet"}
+                </span>
               </div>
-              {metadata?.year && (
-                <div className="flex items-center gap-2">
-                  <Calendar size={15} />
-                  <span>{metadata.year}</span>
-                </div>
-              )}
-              <div className="flex items-center gap-2">
-                <Hash size={15} />
-                <a
-                  href={`https://ipfs.io/ipfs/${auction.metadata_cid}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex items-center gap-1 font-mono text-brand-500 hover:underline"
-                >
-                  {auction.metadata_cid.slice(0, 20)}...
-                  <ExternalLink size={12} />
-                </a>
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-gray-500">Reserve Price</span>
+                <span className="font-medium text-gray-700">
+                  {reserveXlm} XLM
+                </span>
               </div>
-              {auction.royalty_bps > 0 && (
-                <div className="flex items-center gap-2">
-                  <Percent size={15} />
-                  <span>
-                    Royalty: {(auction.royalty_bps / 100).toFixed(2)}%
+              {auction.highest_bidder && (
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-gray-500">Highest Bidder</span>
+                  <span className="font-mono text-xs text-gray-700 truncate max-w-[180px]">
+                    {auction.highest_bidder}
                   </span>
                 </div>
               )}
-              <div className="flex items-center gap-2">
-                <Shield size={15} />
-                <span className="font-mono text-xs break-all">
-                  Original creator: {auction.original_creator.slice(0, 8)}...
-                  {auction.original_creator.slice(-4)}
-                </span>
+            </div>
+
+            {/* Place bid */}
+            {canBid && (
+              <div className="space-y-3">
+                <p className="text-xs font-semibold uppercase tracking-wide text-gray-400">
+                  Place a Bid
+                </p>
+                <div className="flex gap-2">
+                  <input
+                    type="number"
+                    min="0"
+                    step="0.0000001"
+                    placeholder={`Min. ${reserveXlm} XLM`}
+                    value={bidAmountXlm}
+                    onChange={(e) => setBidAmountXlm(e.target.value)}
+                    className="flex-1 rounded-xl border border-gray-200 bg-white px-4 py-2.5 text-sm focus:outline-none focus:ring-2 focus:ring-brand-400"
+                  />
+                  <GuardButton
+                    onClick={handleBid}
+                    disabled={isBidding || !bidAmountXlm}
+                    className="rounded-xl bg-brand-500 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-600 disabled:opacity-50 transition-all"
+                  >
+                    {isBidding ? (
+                      <RefreshCw size={14} className="animate-spin" />
+                    ) : (
+                      <span className="flex items-center gap-1.5">
+                        <Hammer size={14} /> Bid
+                      </span>
+                    )}
+                  </GuardButton>
+                </div>
+                {bidError && (
+                  <p className="text-xs text-red-500">{bidError}</p>
+                )}
+                {bidSuccess && (
+                  <p className="flex items-center gap-1 text-xs text-green-600">
+                    <CheckCircle2 size={13} /> Bid placed successfully!
+                  </p>
+                )}
+              </div>
+            )}
+
+            {/* Finalize button (expired active auctions) */}
+            {canFinalize && !finalizeSuccess && (
+              <div className="space-y-2">
+                <GuardButton
+                  onClick={handleFinalize}
+                  disabled={isFinalizing}
+                  className="w-full rounded-xl bg-midnight-900 px-5 py-3 text-sm font-bold text-white hover:opacity-90 disabled:opacity-50 transition-all"
+                >
+                  {isFinalizing ? (
+                    <span className="flex items-center justify-center gap-2">
+                      <RefreshCw size={14} className="animate-spin" />{" "}
+                      Finalizing…
+                    </span>
+                  ) : (
+                    <span className="flex items-center justify-center gap-2">
+                      <Flag size={14} /> Finalize Auction
+                    </span>
+                  )}
+                </GuardButton>
+                {finalizeError && (
+                  <p className="text-xs text-red-500">{finalizeError}</p>
+                )}
+              </div>
+            )}
+
+            {finalizeSuccess && (
+              <div className="flex items-center gap-2 rounded-xl bg-green-50 px-4 py-3 text-sm text-green-700">
+                <CheckCircle2 size={16} />
+                Auction finalized successfully!
+              </div>
+            )}
+
+            {(isFinalized || isCancelled) && !finalizeSuccess && (
+              <div
+                className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm ${
+                  isFinalized
+                    ? "bg-blue-50 text-blue-700"
+                    : "bg-gray-100 text-gray-600"
+                }`}
+              >
+                <CheckCircle2 size={16} />
+                {isFinalized
+                  ? `Won by ${
+                      auction.highest_bidder
+                        ? `${auction.highest_bidder.slice(0, 8)}…`
+                        : "unknown"
+                    } for ${highestBidXlm} XLM`
+                  : "Auction ended with no bids"}
+              </div>
+            )}
+
+            {/* Metadata details */}
+            <div className="grid grid-cols-2 gap-3 text-sm">
+              {(
+                [
+                  {
+                    icon: Hash,
+                    label: "Auction ID",
+                    value: `#${auction.auction_id}`,
+                  },
+                  {
+                    icon: User,
+                    label: "Creator",
+                    value: `${auction.creator.slice(0, 8)}…`,
+                  },
+                  {
+                    icon: Tag,
+                    label: "Artist",
+                    value: metadata?.artist ?? "—",
+                  },
+                  {
+                    icon: Calendar,
+                    label: "End Time",
+                    value: new Date(auction.end_time * 1000).toLocaleString(),
+                  },
+                ] as const
+              ).map(({ icon: Icon, label, value }) => (
+                <div
+                  key={label}
+                  className="flex items-start gap-2 rounded-xl border border-gray-100 bg-white p-3"
+                >
+                  <Icon size={13} className="mt-0.5 shrink-0 text-gray-400" />
+                  <div className="min-w-0">
+                    <p className="text-[10px] uppercase tracking-wide text-gray-400">
+                      {label}
+                    </p>
+                    <p className="truncate font-medium text-gray-700">
+                      {value}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Refresh */}
+            <button
+              onClick={loadData}
+              className="flex items-center gap-1.5 self-start text-xs text-gray-400 hover:text-brand-500 transition-colors"
+            >
+              <RefreshCw size={12} /> Refresh
+            </button>
+          </div>
+        </div>
+
+        {/* Bid History section */}
+        <div className="mt-12">
+          <div className="flex items-center gap-3 mb-4">
+            {(["details", "bids"] as const).map((t) => (
+              <button
+                key={t}
+                onClick={() => setActiveTab(t)}
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
+                  activeTab === t
+                    ? "bg-brand-500 text-white"
+                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                }`}
+              >
+                {t === "details" ? "Details" : "Bid History"}
+                {t === "bids" && (
+                  <span className="ml-1.5 text-xs opacity-70">
+                    ({bidHistory.length})
+                  </span>
+                )}
+              </button>
+            ))}
+          </div>
+
+          {activeTab === "details" && (
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 space-y-4">
+              {metadata?.description && (
+                <div>
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                    Description
+                  </h3>
+                  <p className="text-sm text-gray-700 leading-relaxed">
+                    {metadata.description}
+                  </p>
+                </div>
+              )}
+              <div className="grid grid-cols-2 sm:grid-cols-3 gap-4 text-sm">
+                {metadata?.category && (
+                  <div>
+                    <p className="text-xs text-gray-400">Category</p>
+                    <p className="font-medium text-gray-700">
+                      {metadata.category}
+                    </p>
+                  </div>
+                )}
+                {metadata?.year && (
+                  <div>
+                    <p className="text-xs text-gray-400">Year</p>
+                    <p className="font-medium text-gray-700">{metadata.year}</p>
+                  </div>
+                )}
+                <div>
+                  <p className="text-xs text-gray-400">Royalty</p>
+                  <p className="font-medium text-gray-700">
+                    {(auction.royalty_bps / 100).toFixed(1)}%
+                  </p>
+                </div>
               </div>
             </div>
+          )}
 
-            {/* Bidding Panel */}
-            <div className="mt-8">
-              <BiddingPanel
-                auction={auction}
-                onBidPlaced={handleRefresh}
-                onFinalized={handleRefresh}
-              />
+          {activeTab === "bids" && (
+            <div className="space-y-2">
+              {bidHistory.length === 0 ? (
+                <div className="flex flex-col items-center justify-center rounded-2xl border border-gray-100 bg-white py-16">
+                  <History size={32} className="text-gray-300 mb-3" />
+                  <p className="text-sm text-gray-500">
+                    No bid history available
+                  </p>
+                </div>
+              ) : (
+                bidHistory.map((event) => (
+                  <BidHistoryRow key={event.id} event={event} />
+                ))
+              )}
             </div>
-
-            {/* On-chain info */}
-            <div className="mt-6 text-xs text-gray-400 space-y-1">
-              <p>
-                Auction ID:{" "}
-                <span className="font-mono">#{auction.auction_id}</span>
-              </p>
-              <p>
-                End time:{" "}
-                <span className="font-mono">
-                  {new Date(auction.end_time * 1000).toLocaleString()}
-                </span>
-              </p>
-            </div>
-          </div>
+          )}
         </div>
       </div>
     </div>

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -36,6 +36,7 @@ vi.mock('@stellar/stellar-sdk', () => ({
     Server: class {
       getEvents() { return Promise.resolve({ events: [] }); }
       getLedgers() { return Promise.resolve({ ledgers: [{ hash: 'correct_network_hash', sequence: 100 }] }); }
+      getLatestLedger() { return Promise.resolve({ sequence: 1000 }); }
       getAccount() { return Promise.resolve({ sequence: '1' }); }
       simulateTransaction() { return Promise.resolve({ result: { retval: {} } }); }
     },

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -15,6 +15,15 @@ const CONTRACT_ID = process.env.MARKETPLACE_CONTRACT_ID || '';
 const LAUNCHPAD_CONTRACT_ID = process.env.LAUNCHPAD_CONTRACT_ID || '';
 const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '5000');
 
+// Stellar RPC enforces a maximum getEvents window of 17,280 ledgers (~24 h).
+const MAX_LEDGER_WINDOW = 17_000;
+
+// Retry back-off base in ms; doubles on each consecutive failure up to MAX_BACKOFF_MS.
+const BASE_BACKOFF_MS = 2_000;
+const MAX_BACKOFF_MS = 60_000;
+
+let consecutiveErrors = 0;
+
 const server = new rpc.Server(RPC_URL);
 
 async function fetchListingFromChain(listingId: bigint): Promise<any | null> {
@@ -397,11 +406,35 @@ export async function startPolling() {
         }
       }
 
-      // 3. Get events from lastLedger + 1
-      const startLedger = syncState.lastLedger + 1;
-      
+      // 3. Resolve start ledger, clamping to the safe RPC window on every poll
+      let networkLatestLedger: number;
+      try {
+        const latestRes = await server.getLatestLedger();
+        networkLatestLedger = latestRes.sequence;
+      } catch (err) {
+        console.error({ msg: 'Failed to fetch latest ledger', err });
+        throw err;
+      }
+
+      const windowFloor = networkLatestLedger - MAX_LEDGER_WINDOW;
+      let startLedger = syncState.lastLedger + 1;
+      if (startLedger < windowFloor) {
+        console.warn({
+          msg: 'startLedger too old — resetting to safe window floor',
+          requested: startLedger,
+          windowFloor,
+          networkLatest: networkLatestLedger,
+        });
+        startLedger = windowFloor;
+        // Persist the reset so future polls don't re-request the stale range.
+        await prisma.syncState.update({
+          where: { id: 1 },
+          data: { lastLedger: windowFloor - 1, ledgerHash: null },
+        });
+      }
+
       const response = await server.getEvents({
-        startLedger: startLedger,
+        startLedger,
         filters: [
           {
             type: 'contract',
@@ -411,8 +444,8 @@ export async function startPolling() {
       });
 
       // 4. Update metrics gauges
-      const networkLatest = response.latestLedger || syncState.lastLedger;
-      
+      const networkLatest = response.latestLedger || networkLatestLedger;
+
       // Update gauges
       latestLedgerProcessedGauge.set(syncState.lastLedger);
       networkLatestLedgerGauge.set(networkLatest);
@@ -495,10 +528,25 @@ export async function startPolling() {
         syncLatencyGauge.set(Math.max(0, networkLatest - updatedState.lastLedger));
       }
 
+      consecutiveErrors = 0;
     } catch (error) {
-      console.error('Error in polling loop:', error);
+      consecutiveErrors += 1;
+      const backoff = Math.min(
+        BASE_BACKOFF_MS * Math.pow(2, consecutiveErrors - 1),
+        MAX_BACKOFF_MS
+      );
+      console.error({
+        msg: 'Error in polling loop',
+        consecutiveErrors,
+        backoffMs: backoff,
+        error: error instanceof Error ? error.message : String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+      continue;
     }
 
+    consecutiveErrors = 0;
     await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
   }
 }


### PR DESCRIPTION
## Summary

This PR resolves four open issues across the indexer, smart contract, and frontend.

Closes #172
Closes #162
Closes #155
Closes #180

---

## Changes

### Fix #172 — Poller loses events when getEvents window exceeds 17,280 ledgers

- `indexer/src/poller.ts`: on every poll cycle, fetch the current ledger via `server.getLatestLedger()` before calling `getEvents`.
- Clamp `startLedger` to `networkLatest - 17_000` (safe margin below the 17,280 hard limit). When the clamp fires, persist the reset to `SyncState` immediately so the next poll does not re-request the same stale range.
- Replace the bare `console.error` catch block with structured JSON logging that includes `consecutiveErrors` and `backoffMs`; back-off doubles on each consecutive failure (2 s base, 60 s cap).
- Update the SDK mock in `poller.test.ts` to expose `getLatestLedger()`.

### Fix #162 — `set_admin` has no transfer mechanism

- `contracts/soroban-marketplace/src/storage.rs`: add `PendingAdmin` to `DataKey`; add `set_pending_admin_storage`, `get_pending_admin_storage`, `clear_pending_admin_storage` helpers; expose `LEDGER_TTL_BUMP` / `LEDGER_TTL_THRESHOLD` as `pub` constants.
- `contracts/soroban-marketplace/src/events.rs`: add `AdminTransferProposedEvent` and `AdminTransferredEvent` with `publish` impls.
- `contracts/soroban-marketplace/src/contract.rs`: add `transfer_admin(env, current_admin, new_admin)` (step 1 — proposes) and `accept_admin(env, new_admin)` (step 2 — accepts and overwrites admin key). Both require the respective address's auth. Admin is not changed until `accept_admin` succeeds.

### Fix #155 — Auction detail page missing bid history and countdown

- `frontend/afristore-app/src/app/auctions/[id]/page.tsx`: replace the stub page (which referenced a non-existent `BiddingPanel` component) with a fully self-contained detail page:
  - `<Countdown endTime={...}>` — live per-second countdown rendered as individual digit blocks (Days / Hours / Min / Sec).
  - Bid history tab — pulls events via `getListingActivity` from the indexer and renders each row with bidder address, amount in XLM, and ledger reference.
  - Place-bid form — guarded by `<GuardButton>` (requires connected Freighter wallet); validates amount > 0; shows inline success/error feedback; refreshes auction state after a successful bid.
  - Finalize button — rendered only when `auction.status === "Active"` and the current Unix timestamp has passed `end_time`; calls `useFinalizeAuction`; shows a success banner on completion.

### Fix #180 — Missing event emissions in contract mutations

Added `.publish(&env)` calls at the end of every affected function so the indexer's `parser.ts` TOPIC_MAP receives all events:

| Function | Event emitted |
|---|---|
| `buy_artwork` | `ArtworkSoldEvent` (`art_sold`) |
| `cancel_listing` | `ListingCancelledEvent` (`lst_cncl`) |
| `update_listing` | `ListingUpdatedEvent` (`lst_updt`) |
| `make_offer` | `OfferMadeEvent` (`ofr_made`) |
| `accept_offer` | `OfferAcceptedEvent` (`ofr_accp`) |
| `reject_offer` | `OfferRejectedEvent` (`ofr_rjct`) |
| `withdraw_offer` | `OfferWithdrawnEvent` (`ofr_wdrn`) |
| `create_auction` | `AuctionCreatedEvent` (`auc_crtd`) |
| `place_bid` | `BidPlacedEvent` (`bid_plcd`) |
| `finalize_auction` | `AuctionFinalizedEvent` (`auc_rslv`) |

Event field names match the `TOPIC_MAP` keys in `indexer/src/parser.ts` exactly.

---

## Soroban Safety Checklist

- [x] **TTL Extensions:** `PendingAdmin` persistent key has `extend_ttl` called immediately after `set`. Admin key TTL is extended on `accept_admin` via the existing `LEDGER_TTL_BUMP` constants.
- [x] **Instance TTL:** No new public entry points were added that mutate instance storage.
- [x] **Authorization:** `transfer_admin` requires `current_admin.require_auth()`; `accept_admin` requires `new_admin.require_auth()`. Neither can be called by a third party.
- [x] **Gas Efficiency:** No storage reads/writes inside loops were introduced.
- [x] **State Bloat:** No unbounded `Vec` arrays added.
- [x] **Signature Security:** No off-chain signatures introduced.
- [x] **Front-Running Protection:** No new `deploy_v2` usage.
- [x] **Error Handling:** All new paths use `panic_with_error!` with named `MarketplaceError` variants; no silent `.unwrap_or()` fallbacks on balances.

## Testing

- [x] Added unit tests for `transfer_admin` / `accept_admin` two-step flow (success, wrong-caller-proposes panics, wrong-caller-accepts panics).
- [x] Added unit tests for all ten new event emissions — each test calls the mutating function and asserts the expected topic symbol appears in `env.events().all()`.
- [x] All existing tests remain unmodified and continue to pass.