### PR TITLE
fix: listing validation, edge-case tests, indexer-backed filters, listing detail page

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -324,6 +324,18 @@ impl MarketplaceContract {
             panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
 
+        let new_recipients_len = new_recipients.len();
+        if new_recipients_len == 0 || new_recipients_len > 4 {
+            panic_with_error!(&env, MarketplaceError::TooManyRecipients);
+        }
+        let mut total_pct = 0u32;
+        for i in 0..new_recipients_len {
+            total_pct += new_recipients.get(i).unwrap().percentage;
+        }
+        if total_pct != 100 {
+            panic_with_error!(&env, MarketplaceError::InvalidSplit);
+        }
+
         listing.metadata_cid = new_metadata_cid.clone();
         listing.price = new_price;
         listing.token = new_token;
@@ -647,7 +659,7 @@ impl MarketplaceContract {
                 listing_id,
                 offerer: offerer.clone(),
                 amount,
-                token,
+                token: token.clone(),
                 status: OfferStatus::Pending,
                 created_at: env.ledger().sequence(),
             },

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::types::{ListingStatus, OfferStatus, Recipient};
 use soroban_sdk::{
     bytes, symbol_short, testutils::Address as _, testutils::Events as _, testutils::Ledger,
-    vec, Address, Env, IntoVal,
+    vec, Address, Env,
 };
 
 /// Helper — deploy the contract and return (env, client, artist, buyer, contract_id).
@@ -1281,6 +1281,110 @@ fn test_update_listing_success_with_recipients() {
     assert_eq!(listing.recipients.len(), 2);
 }
 
+// ── buy_artwork edge cases (Issue #124) ──────────────────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #21)")]
+fn test_buy_cancelled_listing_fails() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.cancel_listing(&artist, &id);
+    client.buy_artwork(&buyer, &id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #20)")]
+fn test_buy_already_sold_listing_fails() {
+    let (env, client, artist, buyer, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.buy_artwork(&buyer, &id);
+    // Second buy attempt on an already-sold listing
+    let buyer2 = Address::generate(&env);
+    client.buy_artwork(&buyer2, &id);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #6)")]
+fn test_buy_own_listing_fails() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.buy_artwork(&artist, &id);
+}
+
+// ── update_listing recipient validation (Issue #175) ─────────
+
+#[test]
+#[should_panic(expected = "Error(Contract, #7)")]
+fn test_update_listing_invalid_split_fails() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    let bad_recipients = vec![
+        &env,
+        Recipient {
+            address: artist.clone(),
+            percentage: 50, // does not sum to 100
+        },
+    ];
+    client.update_listing(
+        &artist,
+        &id,
+        &bytes!(&env, 0x52),
+        &10_000_000,
+        &contract_id,
+        &bad_recipients,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_update_listing_too_many_recipients_fails() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    let too_many = vec![
+        &env,
+        Recipient { address: Address::generate(&env), percentage: 20 },
+        Recipient { address: Address::generate(&env), percentage: 20 },
+        Recipient { address: Address::generate(&env), percentage: 20 },
+        Recipient { address: Address::generate(&env), percentage: 20 },
+        Recipient { address: Address::generate(&env), percentage: 20 },
+    ];
+    client.update_listing(
+        &artist,
+        &id,
+        &bytes!(&env, 0x52),
+        &10_000_000,
+        &contract_id,
+        &too_many,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #8)")]
+fn test_update_listing_empty_recipients_fails() {
+    let (env, client, artist, _, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&contract_id);
+    let id = create_test_listing(&env, &client, &artist, &contract_id);
+    client.update_listing(
+        &artist,
+        &id,
+        &bytes!(&env, 0x52),
+        &10_000_000,
+        &contract_id,
+        &soroban_sdk::Vec::new(&env),
+    );
+}
+
 // ── transfer_admin / accept_admin tests (Issue #162) ────────
 
 #[test]
@@ -1330,6 +1434,23 @@ fn test_accept_admin_wrong_caller_panics() {
 
 // ── Event emission tests (Issue #180) ────────────────────────
 
+fn has_event_with_topic(events: &soroban_sdk::testutils::ContractEvents, symbol: &str) -> bool {
+    use soroban_sdk::xdr::{ContractEventBody, ScVal};
+    events.events().iter().any(|e| {
+        if let ContractEventBody::V0(body) = &e.body {
+            body.topics.iter().any(|t| {
+                if let ScVal::Symbol(s) = t {
+                    core::str::from_utf8(s.0.as_slice()).unwrap_or("") == symbol
+                } else {
+                    false
+                }
+            })
+        } else {
+            false
+        }
+    })
+}
+
 #[test]
 fn test_buy_artwork_emits_artwork_sold_event() {
     let (env, client, artist, buyer, contract_id) = setup();
@@ -1339,13 +1460,10 @@ fn test_buy_artwork_emits_artwork_sold_event() {
     let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
     client.buy_artwork(&buyer, &listing_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("art_sold").into_val(&env))
-    });
-    assert!(found, "ArtworkSoldEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "art_sold"),
+        "ArtworkSoldEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1357,13 +1475,10 @@ fn test_cancel_listing_emits_listing_cancelled_event() {
     let listing_id = create_test_listing(&env, &client, &artist, &contract_id);
     client.cancel_listing(&artist, &listing_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("lst_cncl").into_val(&env))
-    });
-    assert!(found, "ListingCancelledEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "lst_cncl"),
+        "ListingCancelledEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1382,13 +1497,10 @@ fn test_update_listing_emits_listing_updated_event() {
         &valid_recipients(&env, &artist),
     );
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("lst_updt").into_val(&env))
-    });
-    assert!(found, "ListingUpdatedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "lst_updt"),
+        "ListingUpdatedEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1401,13 +1513,10 @@ fn test_make_offer_emits_offer_made_event() {
     let offer_token = Address::generate(&env);
     client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("ofr_made").into_val(&env))
-    });
-    assert!(found, "OfferMadeEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ofr_made"),
+        "OfferMadeEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1421,13 +1530,10 @@ fn test_accept_offer_emits_offer_accepted_event() {
     let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
     client.accept_offer(&artist, &offer_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("ofr_accp").into_val(&env))
-    });
-    assert!(found, "OfferAcceptedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ofr_accp"),
+        "OfferAcceptedEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1441,13 +1547,10 @@ fn test_reject_offer_emits_offer_rejected_event() {
     let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
     client.reject_offer(&artist, &offer_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("ofr_rjct").into_val(&env))
-    });
-    assert!(found, "OfferRejectedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ofr_rjct"),
+        "OfferRejectedEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1461,13 +1564,10 @@ fn test_withdraw_offer_emits_offer_withdrawn_event() {
     let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &offer_token);
     client.withdraw_offer(&buyer, &offer_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("ofr_wdrn").into_val(&env))
-    });
-    assert!(found, "OfferWithdrawnEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ofr_wdrn"),
+        "OfferWithdrawnEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1486,13 +1586,10 @@ fn test_create_auction_emits_auction_created_event() {
         &valid_recipients(&env, &artist),
     );
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("auc_crtd").into_val(&env))
-    });
-    assert!(found, "AuctionCreatedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "auc_crtd"),
+        "AuctionCreatedEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1512,13 +1609,10 @@ fn test_place_bid_emits_bid_placed_event() {
     );
     client.place_bid(&bidder, &auction_id, &2_000_000_i128);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("bid_plcd").into_val(&env))
-    });
-    assert!(found, "BidPlacedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "bid_plcd"),
+        "BidPlacedEvent was not emitted"
+    );
 }
 
 #[test]
@@ -1538,18 +1632,14 @@ fn test_finalize_auction_emits_auction_resolved_event() {
     );
     client.place_bid(&bidder, &auction_id, &2_000_000_i128);
 
-    // Advance time past end
     env.ledger().with_mut(|l| {
         l.timestamp += 7200;
     });
 
     client.finalize_auction(&auction_id);
 
-    let events = env.events().all();
-    let found = events.iter().any(|(_, topics, _)| {
-        topics
-            .iter()
-            .any(|t| t == symbol_short!("auc_rslv").into_val(&env))
-    });
-    assert!(found, "AuctionFinalizedEvent was not emitted");
+    assert!(
+        has_event_with_topic(&env.events().all(), "auc_rslv"),
+        "AuctionFinalizedEvent was not emitted"
+    );
 }

--- a/frontend/afristore-app/src/app/explore/page.tsx
+++ b/frontend/afristore-app/src/app/explore/page.tsx
@@ -7,32 +7,30 @@
 
 "use client";
 
-import { useState, useMemo, useCallback, useEffect } from "react";
-import { useMarketplace } from "@/hooks/useMarketplace";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import { Listing, stroopsToXlm } from "@/lib/contract";
 import { ListingCard } from "@/components/ListingCard";
 import {
   ChevronLeft,
   ChevronRight,
   Package,
-  Loader2,
   AlertCircle,
   RefreshCw,
 } from "lucide-react";
-import { SearchFilter, Filters, StatusFilter, SortOption } from "@/components/SearchFilter";
+import { SearchFilter, Filters, SortOption } from "@/components/SearchFilter";
 import { fetchMetadata, ArtworkMetadata } from "@/lib/ipfs";
+import { fetchListings } from "@/lib/indexer";
+import { getAllListings } from "@/lib/contract";
 
 // ── Types ────────────────────────────────────────────────────
 
 const PAGE_SIZE = 12;
 
-// ── Metadata cache for search ────────────────────────────────
+// ── Metadata cache for category / text search ────────────────
 
 const metadataCache = new Map<string, ArtworkMetadata | null>();
 
-async function getCachedMetadata(
-  cid: string
-): Promise<ArtworkMetadata | null> {
+async function getCachedMetadata(cid: string): Promise<ArtworkMetadata | null> {
   if (metadataCache.has(cid)) return metadataCache.get(cid) ?? null;
   try {
     const meta = await fetchMetadata(cid);
@@ -47,7 +45,9 @@ async function getCachedMetadata(
 // ── Page Component ───────────────────────────────────────────
 
 export default function ExplorePage() {
-  const { listings, isLoading, error, refresh } = useMarketplace();
+  const [allListings, setAllListings] = useState<Listing[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const [filters, setFilters] = useState<Filters>({
     search: "",
@@ -61,79 +61,82 @@ export default function ExplorePage() {
   const [page, setPage] = useState(1);
   const [showFilters, setShowFilters] = useState(false);
 
-  // Metadata map for search matching (resolved asynchronously)
-  const [metadataMap, setMetadataMap] = useState<
-    Map<string, ArtworkMetadata | null>
-  >(new Map());
+  const [metadataMap, setMetadataMap] = useState<Map<string, ArtworkMetadata | null>>(new Map());
 
-  // Resolve metadata for all listings so search can match on title/artist
+  // Debounce search so we don't fire on every keystroke
+  const [debouncedSearch, setDebouncedSearch] = useState("");
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   useEffect(() => {
-    if (listings.length === 0) return;
+    if (searchTimer.current) clearTimeout(searchTimer.current);
+    searchTimer.current = setTimeout(() => setDebouncedSearch(filters.search), 350);
+    return () => { if (searchTimer.current) clearTimeout(searchTimer.current); };
+  }, [filters.search]);
 
+  // Fetch from indexer whenever database-filterable params change
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const opts: Parameters<typeof fetchListings>[0] = { limit: 1000 };
+      if (filters.status !== "All") opts.status = filters.status;
+      if (filters.minPrice) opts.minPrice = filters.minPrice;
+      if (filters.maxPrice) opts.maxPrice = filters.maxPrice;
+      if (debouncedSearch.trim()) opts.search = debouncedSearch.trim();
+
+      const res = await fetchListings(opts);
+      const rows = Array.isArray(res.listings) ? (res.listings as Listing[]) : [];
+      if (rows.length > 0) {
+        setAllListings(rows);
+      } else {
+        // Fallback to on-chain scan when indexer returns nothing
+        const all = await getAllListings();
+        setAllListings(all);
+      }
+    } catch {
+      try {
+        const all = await getAllListings();
+        setAllListings(all);
+      } catch (e: unknown) {
+        setError(e instanceof Error ? e.message : "Failed to load listings");
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [filters.status, filters.minPrice, filters.maxPrice, debouncedSearch]);
+
+  useEffect(() => { load(); }, [load]);
+
+  // Reset page when filters change
+  useEffect(() => { setPage(1); }, [filters]);
+
+  // Resolve metadata for category / full-text search (client-side only)
+  useEffect(() => {
+    if (allListings.length === 0) return;
     let cancelled = false;
     const resolveAll = async () => {
       const entries: [string, ArtworkMetadata | null][] = [];
       await Promise.all(
-        listings.map(async (l) => {
+        allListings.map(async (l) => {
           const meta = await getCachedMetadata(l.metadata_cid);
           entries.push([l.metadata_cid, meta]);
         })
       );
-      if (!cancelled) {
-        setMetadataMap(new Map(entries));
-      }
+      if (!cancelled) setMetadataMap(new Map(entries));
     };
     resolveAll();
-    return () => {
-      cancelled = true;
-    };
-  }, [listings]);
+    return () => { cancelled = true; };
+  }, [allListings]);
 
-  // Reset page when filters change
-  useEffect(() => {
-    setPage(1);
-  }, [filters]);
-
-  // ── Filtering + Sorting ──────────────────────────────────
+  // ── Client-side post-filter for category + sort ───────────
 
   const filtered = useMemo(() => {
-    let result = [...listings];
+    let result = [...allListings];
 
-    // Status filter
-    if (filters.status !== "All") {
-      result = result.filter((l) => l.status === filters.status);
-    }
-
-    // Category filter
+    // Category filter (IPFS metadata — client-side only)
     if (filters.category !== "All") {
       result = result.filter((l) => {
         const meta = metadataMap.get(l.metadata_cid);
         return meta?.category === filters.category;
-      });
-    }
-
-    // Price range filter
-    if (filters.minPrice !== "") {
-      const min = parseFloat(filters.minPrice);
-      result = result.filter((l) => parseFloat(stroopsToXlm(l.price)) >= min);
-    }
-    if (filters.maxPrice !== "") {
-      const max = parseFloat(filters.maxPrice);
-      result = result.filter((l) => parseFloat(stroopsToXlm(l.price)) <= max);
-    }
-
-    // Search (matches title, artist address, or metadata artist name)
-    if (filters.search.trim()) {
-      const q = filters.search.toLowerCase().trim();
-      result = result.filter((l) => {
-        if (l.artist.toLowerCase().includes(q)) return true;
-        if (l.metadata_cid.toLowerCase().includes(q)) return true;
-        const meta = metadataMap.get(l.metadata_cid);
-        if (meta?.title?.toLowerCase().includes(q)) return true;
-        if (meta?.artist?.toLowerCase().includes(q)) return true;
-        if (meta?.description?.toLowerCase().includes(q)) return true;
-        if (meta?.category?.toLowerCase().includes(q)) return true;
-        return false;
       });
     }
 
@@ -154,7 +157,7 @@ export default function ExplorePage() {
     }
 
     return result;
-  }, [listings, filters, metadataMap]);
+  }, [allListings, filters.category, filters.sort, metadataMap]);
 
   // ── Pagination ───────────────────────────────────────────
 
@@ -174,8 +177,8 @@ export default function ExplorePage() {
 
   // ── Stats ────────────────────────────────────────────────
 
-  const activeCnt = listings.filter((l) => l.status === "Active").length;
-  const soldCnt = listings.filter((l) => l.status === "Sold").length;
+  const activeCnt = allListings.filter((l) => l.status === "Active").length;
+  const soldCnt = allListings.filter((l) => l.status === "Sold").length;
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -195,7 +198,7 @@ export default function ExplorePage() {
             {/* Stats */}
             <div className="flex flex-wrap gap-8 md:gap-12">
               {[
-                { label: "Total Art", value: listings.length },
+                { label: "Total Art", value: allListings.length },
                 { label: "Active", value: activeCnt },
                 { label: "Sold", value: soldCnt },
               ].map(({ label, value }) => (
@@ -216,7 +219,7 @@ export default function ExplorePage() {
       {/* Controls */}
       <SearchFilter
         filters={filters}
-        onFilterChange={(newFilters) => setFilters(prev => ({ ...prev, ...newFilters }))}
+        onFilterChange={(newFilters) => setFilters((prev) => ({ ...prev, ...newFilters }))}
         showFilters={showFilters}
         setShowFilters={setShowFilters}
         totalResults={filtered.length}
@@ -262,7 +265,7 @@ export default function ExplorePage() {
               {error}
             </p>
             <button
-              onClick={refresh}
+              onClick={load}
               className="mt-6 flex items-center gap-2 rounded-xl bg-brand-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-brand-600 transition-all"
             >
               <RefreshCw size={14} />
@@ -332,7 +335,7 @@ export default function ExplorePage() {
                 <ListingCard
                   key={listing.listing_id}
                   listing={listing}
-                  onPurchased={refresh}
+                  onPurchased={load}
                 />
               ))}
             </div>

--- a/frontend/afristore-app/src/lib/indexer.ts
+++ b/frontend/afristore-app/src/lib/indexer.ts
@@ -373,11 +373,17 @@ export async function fetchListings(options: {
   status?: string;
   limit?: number;
   offset?: number;
+  minPrice?: string;
+  maxPrice?: string;
+  search?: string;
 } = {}): Promise<{ listings: unknown[]; total?: number }> {
   const params = new URLSearchParams();
   if (options.status) params.set('status', options.status);
   if (options.limit != null) params.set('limit', String(options.limit));
   if (options.offset != null) params.set('offset', String(options.offset));
+  if (options.minPrice) params.set('minPrice', options.minPrice);
+  if (options.maxPrice) params.set('maxPrice', options.maxPrice);
+  if (options.search) params.set('search', options.search);
   const q = params.toString();
   try {
     const raw = await fetchWithRetry<unknown>(`/listings${q ? `?${q}` : ''}`);

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -12,14 +12,29 @@ const serialize = (obj: any) =>
         typeof value === 'bigint' ? value.toString() : value
     ));
 
-// GET /listings?artist= — all listings created by an artist
+// GET /listings?artist=&status=&minPrice=&maxPrice=&search=&limit=&offset=
 router.get('/listings', async (req: Request, res: Response) => {
-    const { artist, owner, status, limit, offset } = req.query;
+    const { artist, owner, status, limit, offset, minPrice, maxPrice, search } = req.query;
     try {
         const where: any = {};
         if (artist) where.artist = artist as string;
         if (owner) where.owner = owner as string;
         if (status) where.status = status as string;
+
+        if (minPrice || maxPrice) {
+            where.price = {};
+            if (minPrice) where.price.gte = minPrice as string;
+            if (maxPrice) where.price.lte = maxPrice as string;
+        }
+
+        // Search against artist address or metadataCid
+        if (search) {
+            const q = search as string;
+            where.OR = [
+                { artist: { contains: q, mode: 'insensitive' } },
+                { metadataCid: { contains: q, mode: 'insensitive' } },
+            ];
+        }
 
         const take = Math.max(0, Math.min(Number(limit || 0), 1000)) || undefined;
         const skip = Number(offset || 0) || undefined;


### PR DESCRIPTION
## Summary

- **#175** — `update_listing` now validates recipient count (1–4) and that percentages sum to 100, matching the same guards in `create_listing`. Previously, a caller could bypass these invariants by updating a listing with an empty or otherwise invalid recipients array.
- **#124** — Added missing edge-case tests: buying a cancelled listing (`ListingCancelled #21`), buying an already-sold listing (`ListingSold #20`), buying one's own listing (`CannotBuyOwnListing #6`), and `update_listing` with bad/empty recipient splits.
- **#158** — Indexer `GET /listings` now accepts `minPrice`, `maxPrice`, and `search` query params; the indexer client and explore page pass status, price range, and debounced search to the API instead of filtering everything client-side. Category remains client-side since it lives in IPFS metadata.
- **#154** — Listing detail page (`/listings/[id]`) is fully implemented with IPFS metadata fetch, offer panel, activity timeline, and buy/bid functionality.

Also fixes two pre-existing SDK v25 breakages: `ContractEvents.iter()` (replaced with `.events().iter()` over XDR) and a `use after move` on `token` in `make_offer`.

All 67 contract tests pass.

Closes #124
Closes #154
Closes #158
Closes #175