### PR TITLE
Fix/tests issues 221 224

### DIFF
--- a/contracts/collection_nft_erc721/src/test.rs
+++ b/contracts/collection_nft_erc721/src/test.rs
@@ -2,7 +2,7 @@ extern crate std;
 
 use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, Env, String};
 
-use crate::{DataKey, NormalNFT721, NormalNFT721Client};
+use crate::{DataKey, Error, NormalNFT721, NormalNFT721Client};
 
 fn jump_ledger(env: &Env, delta: u32) {
     env.ledger().with_mut(|li| {
@@ -37,6 +37,8 @@ fn setup() -> (
 
     (env, client, contract_id, creator)
 }
+
+// ── TTL tests (pre-existing) ──────────────────────────────────────────────────
 
 #[test]
 fn instance_ttl_is_extended_on_mint() {
@@ -112,4 +114,421 @@ fn persistent_ttl_is_extended_on_burn_balance_key() {
     assert!(!owner_has);
     // but BalanceOf must still be kept alive.
     assert!(alice_balance_has);
+}
+
+// ── Query functions ───────────────────────────────────────────────────────────
+
+#[test]
+fn name_and_symbol_are_stored_correctly() {
+    let (_, client, _, _) = setup();
+    assert_eq!(client.name(), String::from_str(&client.env, "Test Collection 721"));
+    assert_eq!(client.symbol(), String::from_str(&client.env, "T721"));
+}
+
+#[test]
+fn total_supply_starts_at_zero() {
+    let (_, client, _, _) = setup();
+    assert_eq!(client.total_supply(), 0u64);
+}
+
+#[test]
+fn max_supply_reflects_initialized_value() {
+    let (_, client, _, _) = setup();
+    assert_eq!(client.max_supply(), 1_000u64);
+}
+
+#[test]
+fn balance_of_returns_zero_for_address_with_no_tokens() {
+    let (env, client, _, _) = setup();
+    let nobody = Address::generate(&env);
+    assert_eq!(client.balance_of(&nobody), 0u64);
+}
+
+#[test]
+fn royalty_info_matches_initialized_values() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    env.mock_all_auths();
+
+    let contract_id = env.register(NormalNFT721, ());
+    let client = NormalNFT721Client::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let royalty_receiver = Address::generate(&env);
+
+    client.initialize(
+        &creator,
+        &String::from_str(&env, "Royalty Test"),
+        &String::from_str(&env, "RT"),
+        &100u64,
+        &750u32,
+        &royalty_receiver,
+    );
+
+    let (recv, bps) = client.royalty_info();
+    assert_eq!(recv, royalty_receiver);
+    assert_eq!(bps, 750u32);
+}
+
+// ── Minting ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn mint_increments_total_supply_and_balance() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+
+    assert_eq!(client.total_supply(), 0);
+    let id0 = client.mint(&alice, &String::from_str(&env, "uri-0"));
+    assert_eq!(client.total_supply(), 1);
+    assert_eq!(client.balance_of(&alice), 1);
+
+    let id1 = client.mint(&alice, &String::from_str(&env, "uri-1"));
+    assert_eq!(client.total_supply(), 2);
+    assert_eq!(client.balance_of(&alice), 2);
+    assert_eq!(id0, 0u64);
+    assert_eq!(id1, 1u64);
+}
+
+#[test]
+fn mint_sets_owner_and_token_uri() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "ipfs://Qm123"));
+    assert_eq!(client.owner_of(&id), alice);
+    assert_eq!(client.token_uri(&id), String::from_str(&env, "ipfs://Qm123"));
+}
+
+#[test]
+fn mint_to_multiple_addresses_tracks_balances_independently() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.mint(&alice, &String::from_str(&env, "alice-uri"));
+    client.mint(&bob, &String::from_str(&env, "bob-uri-1"));
+    client.mint(&bob, &String::from_str(&env, "bob-uri-2"));
+
+    assert_eq!(client.balance_of(&alice), 1);
+    assert_eq!(client.balance_of(&bob), 2);
+    assert_eq!(client.total_supply(), 3);
+}
+
+// ── Max supply enforcement ────────────────────────────────────────────────────
+
+#[test]
+fn mint_fails_when_max_supply_is_reached() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    env.mock_all_auths();
+
+    let contract_id = env.register(NormalNFT721, ());
+    let client = NormalNFT721Client::new(&env, &contract_id);
+    let creator = Address::generate(&env);
+    let receiver = Address::generate(&env);
+
+    // Max supply = 2
+    client.initialize(
+        &creator,
+        &String::from_str(&env, "Small Collection"),
+        &String::from_str(&env, "SC"),
+        &2u64,
+        &0u32,
+        &receiver,
+    );
+
+    let alice = Address::generate(&env);
+    client.mint(&alice, &String::from_str(&env, "uri-0"));
+    client.mint(&alice, &String::from_str(&env, "uri-1"));
+
+    // Third mint should fail
+    let result = client.try_mint(&alice, &String::from_str(&env, "uri-2"));
+    assert_eq!(result, Err(Ok(Error::MaxSupplyReached)));
+}
+
+#[test]
+fn cannot_initialize_twice() {
+    let (env, client, _, creator) = setup();
+    let receiver = Address::generate(&env);
+
+    let result = client.try_initialize(
+        &creator,
+        &String::from_str(&env, "Again"),
+        &String::from_str(&env, "AG"),
+        &100u64,
+        &0u32,
+        &receiver,
+    );
+    assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
+}
+
+// ── Transfers ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn transfer_moves_ownership_and_updates_balances() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    assert_eq!(client.owner_of(&id), alice);
+    assert_eq!(client.balance_of(&alice), 1);
+    assert_eq!(client.balance_of(&bob), 0);
+
+    client.transfer(&alice, &bob, &id);
+
+    assert_eq!(client.owner_of(&id), bob);
+    assert_eq!(client.balance_of(&alice), 0);
+    assert_eq!(client.balance_of(&bob), 1);
+}
+
+#[test]
+fn transfer_fails_when_called_by_non_owner() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let eve = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+
+    // Eve is not the owner and has no approval
+    let result = client.try_transfer(&eve, &alice, &id);
+    assert!(result.is_err());
+}
+
+#[test]
+fn transfer_clears_single_token_approval() {
+    let (env, client, contract_id, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let charlie = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.approve(&alice, &charlie, &id);
+
+    // Approval is set before transfer
+    let approved_before = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::Approved(id))
+    });
+    assert!(approved_before.is_some());
+
+    client.transfer(&alice, &bob, &id);
+
+    // Approval must be cleared after transfer
+    let approved_after = env.as_contract(&contract_id, || {
+        env.storage()
+            .persistent()
+            .get::<DataKey, Address>(&DataKey::Approved(id))
+    });
+    assert!(approved_after.is_none());
+}
+
+#[test]
+fn transfer_from_by_approved_spender_succeeds() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.approve(&alice, &spender, &id);
+
+    client.transfer_from(&spender, &alice, &bob, &id);
+    assert_eq!(client.owner_of(&id), bob);
+}
+
+#[test]
+fn transfer_from_by_operator_succeeds() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.set_approval_for_all(&alice, &operator, &true);
+
+    client.transfer_from(&operator, &alice, &bob, &id);
+    assert_eq!(client.owner_of(&id), bob);
+}
+
+#[test]
+fn transfer_from_fails_without_approval() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+    let eve = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    let result = client.try_transfer_from(&eve, &alice, &bob, &id);
+    assert_eq!(result, Err(Ok(Error::NotApproved)));
+}
+
+// ── Approvals ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn approve_sets_single_token_approval() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    assert_eq!(client.get_approved(&id), None);
+
+    client.approve(&alice, &bob, &id);
+    assert_eq!(client.get_approved(&id), Some(bob));
+}
+
+#[test]
+fn approve_by_non_owner_fails() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let eve = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    let result = client.try_approve(&eve, &bob, &id);
+    assert_eq!(result, Err(Ok(Error::NotApproved)));
+}
+
+#[test]
+fn set_approval_for_all_and_is_approved_for_all() {
+    let (env, client, _, _) = setup();
+    let owner = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    assert!(!client.is_approved_for_all(&owner, &operator));
+    client.set_approval_for_all(&owner, &operator, &true);
+    assert!(client.is_approved_for_all(&owner, &operator));
+
+    client.set_approval_for_all(&owner, &operator, &false);
+    assert!(!client.is_approved_for_all(&owner, &operator));
+}
+
+#[test]
+fn operator_can_approve_on_behalf_of_owner() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let charlie = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.set_approval_for_all(&alice, &operator, &true);
+
+    // Operator should be able to call approve() for alice's token
+    client.approve(&operator, &charlie, &id);
+    assert_eq!(client.get_approved(&id), Some(charlie));
+}
+
+// ── Burns ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn burn_removes_token_and_decrements_supply_and_balance() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    assert_eq!(client.total_supply(), 1);
+    assert_eq!(client.balance_of(&alice), 1);
+
+    client.approve(&alice, &alice, &id);
+    client.burn(&alice, &id);
+
+    assert_eq!(client.total_supply(), 0);
+    assert_eq!(client.balance_of(&alice), 0);
+
+    // ownerOf should now return TokenNotFound
+    let result = client.try_owner_of(&id);
+    assert_eq!(result, Err(Ok(Error::TokenNotFound)));
+}
+
+#[test]
+fn burn_by_non_owner_without_approval_fails() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let eve = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    let result = client.try_burn(&eve, &id);
+    assert_eq!(result, Err(Ok(Error::NotApproved)));
+}
+
+#[test]
+fn burn_by_approved_spender_succeeds() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.approve(&alice, &spender, &id);
+    client.burn(&spender, &id);
+
+    let result = client.try_owner_of(&id);
+    assert_eq!(result, Err(Ok(Error::TokenNotFound)));
+}
+
+#[test]
+fn burn_by_operator_succeeds() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    let id = client.mint(&alice, &String::from_str(&env, "uri"));
+    client.set_approval_for_all(&alice, &operator, &true);
+    client.burn(&operator, &id);
+
+    let result = client.try_owner_of(&id);
+    assert_eq!(result, Err(Ok(Error::TokenNotFound)));
+}
+
+#[test]
+fn burn_nonexistent_token_fails() {
+    let (_, client, _, _) = setup();
+    let caller = soroban_sdk::Address::generate(&client.env);
+    let result = client.try_burn(&caller, &999u64);
+    assert_eq!(result, Err(Ok(Error::TokenNotFound)));
+}
+
+// ── Ownership management ──────────────────────────────────────────────────────
+
+#[test]
+fn transfer_ownership_updates_creator() {
+    let (env, client, _, creator) = setup();
+    let new_creator = Address::generate(&env);
+
+    // original creator can transfer
+    client.transfer_ownership(&new_creator);
+    assert_eq!(client.creator(), new_creator);
+
+    // new creator can mint
+    let alice = Address::generate(&env);
+    let id = client.mint(&alice, &String::from_str(&env, "new-uri"));
+    assert_eq!(client.owner_of(&id), alice);
+    let _ = creator; // suppress unused variable warning
+}
+
+#[test]
+fn update_royalty_changes_receiver_and_bps() {
+    let (env, client, _, _) = setup();
+    let new_receiver = Address::generate(&env);
+
+    client.update_royalty(&new_receiver, &250u32);
+    let (recv, bps) = client.royalty_info();
+    assert_eq!(recv, new_receiver);
+    assert_eq!(bps, 250u32);
+}
+
+// ── next_token_id ─────────────────────────────────────────────────────────────
+
+#[test]
+fn next_token_id_advances_with_each_mint() {
+    let (env, client, _, _) = setup();
+    let alice = Address::generate(&env);
+
+    assert_eq!(client.next_token_id(), 0u64);
+    client.mint(&alice, &String::from_str(&env, "uri-0"));
+    assert_eq!(client.next_token_id(), 1u64);
+    client.mint(&alice, &String::from_str(&env, "uri-1"));
+    assert_eq!(client.next_token_id(), 2u64);
 }

--- a/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
+++ b/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
@@ -1,0 +1,130 @@
+/**
+ * Component tests for BiddingPanel.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockBid = jest.fn();
+const mockFinalize = jest.fn();
+
+jest.mock('@/context/WalletContext', () => ({
+  useWalletContext: () => ({ publicKey: 'GBIDDER123' }),
+}));
+
+jest.mock('@/hooks/useAuctions', () => ({
+  usePlaceBid: () => ({ bid: mockBid, isBidding: false, error: null }),
+  useFinalizeAuction: () => ({ finalize: mockFinalize, isFinalizing: false, error: null }),
+}));
+
+jest.mock('@/components/WalletGuard', () => ({
+  GuardButton: ({
+    children,
+    onAction,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onAction: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onAction} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('@/lib/contract', () => ({
+  stroopsToXlm: (v: bigint) => String(Number(v) / 10_000_000),
+}));
+
+jest.mock('lucide-react', () =>
+  Object.fromEntries(
+    ['Gavel', 'Clock', 'Trophy', 'User', 'AlertCircle', 'CheckCircle', 'Loader2']
+      .map((name) => [name, () => <span />])
+  )
+);
+
+import { BiddingPanel } from '@/components/BiddingPanel';
+
+function makeAuction(overrides = {}) {
+  return {
+    auction_id: 1,
+    artist: 'GARTIST',
+    metadata_cid: 'Qm',
+    reserve_price: 10_000_000n, // 1 XLM
+    highest_bid: 0n,
+    highest_bidder: null,
+    end_time: Math.floor(Date.now() / 1000) + 3600, // 1 hour from now
+    status: 'Active',
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('BiddingPanel', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the reserve price label', () => {
+    render(<BiddingPanel auction={makeAuction()} />);
+    expect(screen.getByText(/reserve price/i)).toBeInTheDocument();
+  });
+
+  it('renders the bid input field for active auctions', () => {
+    render(<BiddingPanel auction={makeAuction()} />);
+    expect(screen.getByPlaceholderText(/min/i)).toBeInTheDocument();
+  });
+
+  it('calls bid with correct amount when Place Bid is clicked', async () => {
+    mockBid.mockResolvedValueOnce(true);
+    const onBidPlaced = jest.fn();
+    const user = userEvent.setup();
+
+    render(<BiddingPanel auction={makeAuction()} onBidPlaced={onBidPlaced} />);
+    await user.clear(screen.getByPlaceholderText(/min/i));
+    await user.type(screen.getByPlaceholderText(/min/i), '2');
+    await user.click(screen.getByRole('button', { name: /place bid/i }));
+
+    await waitFor(() => expect(mockBid).toHaveBeenCalledWith(1, 2));
+    await waitFor(() => expect(onBidPlaced).toHaveBeenCalled());
+  });
+
+  it('shows current highest bid label when one exists', () => {
+    render(
+      <BiddingPanel auction={makeAuction({ highest_bid: 20_000_000n, highest_bidder: 'GBIDDER' })} />
+    );
+    expect(screen.getByText(/highest bid/i)).toBeInTheDocument();
+  });
+
+  it('shows Finalize button for expired auctions', () => {
+    render(
+      <BiddingPanel
+        auction={makeAuction({ end_time: 1, status: 'Active' })}
+      />
+    );
+    expect(screen.getByRole('button', { name: /finalize/i })).toBeInTheDocument();
+  });
+
+  it('calls finalize when Finalize Auction is clicked', async () => {
+    mockFinalize.mockResolvedValueOnce(true);
+    const onFinalized = jest.fn();
+    const user = userEvent.setup();
+
+    render(
+      <BiddingPanel
+        auction={makeAuction({ end_time: 1 })}
+        onFinalized={onFinalized}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /finalize/i }));
+    await waitFor(() => expect(mockFinalize).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(onFinalized).toHaveBeenCalled());
+  });
+
+  it('shows Finalized badge for completed auctions', () => {
+    render(<BiddingPanel auction={makeAuction({ status: 'Finalized' })} />);
+    expect(screen.getByText(/finalized/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/afristore-app/src/__tests__/CheckoutModal.test.tsx
+++ b/frontend/afristore-app/src/__tests__/CheckoutModal.test.tsx
@@ -1,20 +1,127 @@
+/**
+ * Component tests for CheckoutModal.
+ */
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// posthog is used inside the component
+jest.mock('posthog-js', () => ({ capture: jest.fn() }));
+
+jest.mock('lucide-react', () =>
+  Object.fromEntries(
+    ['X', 'CreditCard', 'Wallet', 'CheckCircle2', 'Loader2',
+      'DollarSign', 'Lock', 'ArrowRight']
+      .map((name) => [name, () => <span />])
+  )
+);
+
+// Stub out the fiat relay fetch so we control its response
+const mockFetch = jest.fn();
+globalThis.fetch = mockFetch;
+
 import { CheckoutModal } from '@/components/CheckoutModal';
 
 const sampleListing = {
   listing_id: 1,
-  price: 10000000n, // 1 XLM in stroops
+  price: 10_000_000n, // 1 XLM in stroops
   metadata_cid: 'QmTest',
   status: 'Active',
   artist: 'GARTIST',
 } as any;
 
 describe('CheckoutModal', () => {
-  it('calls onCryptoPurchase and onClose when crypto purchase succeeds', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ── Visibility ──────────────────────────────────────────────────────────────
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <CheckoutModal
+        isOpen={false}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the modal when isOpen is true', () => {
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    expect(screen.getByText(/checkout/i)).toBeInTheDocument();
+  });
+
+  it('displays the price in XLM', () => {
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    expect(screen.getAllByText(/1\s*XLM/i).length).toBeGreaterThan(0);
+  });
+
+  it('calls onClose when backdrop is clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={onClose}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    const backdrop = container.querySelector('.absolute.inset-0');
+    if (backdrop) {
+      await user.click(backdrop);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('calls onClose when the X button is clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={onClose}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    // The close button contains an X icon span
+    const closeBtn = screen.getAllByRole('button').find(
+      (b) => b.querySelector('span') && !b.textContent?.trim()
+    );
+    if (closeBtn) await user.click(closeBtn);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  // ── Crypto flow ─────────────────────────────────────────────────────────────
+
+  it('calls onCryptoPurchase and onClose on successful crypto purchase', async () => {
     const onClose = jest.fn();
     const onPurchased = jest.fn();
     const onCryptoPurchase = jest.fn().mockResolvedValue(true);
+    const user = userEvent.setup();
 
     render(
       <CheckoutModal
@@ -27,11 +134,132 @@ describe('CheckoutModal', () => {
       />
     );
 
-    // Click the Pay button
-    const payButton = screen.getByRole('button', { name: /Pay/i });
-    fireEvent.click(payButton);
-
+    await user.click(screen.getByRole('button', { name: /pay.*xlm/i }));
     await waitFor(() => expect(onCryptoPurchase).toHaveBeenCalled());
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+    expect(onPurchased).toHaveBeenCalled();
+  });
+
+  it('does not close on failed crypto purchase', async () => {
+    const onClose = jest.fn();
+    const onCryptoPurchase = jest.fn().mockResolvedValue(false);
+    const user = userEvent.setup();
+
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={onClose}
+        listing={sampleListing}
+        onCryptoPurchase={onCryptoPurchase}
+        isBuyingCrypto={false}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: /pay.*xlm/i }));
+    await waitFor(() => expect(onCryptoPurchase).toHaveBeenCalled());
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading spinner when isBuyingCrypto is true', () => {
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={true}
+      />
+    );
+    expect(screen.getByText(/processing/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /processing/i })).toBeDisabled();
+  });
+
+  // ── Fiat flow ───────────────────────────────────────────────────────────────
+
+  it('switches to Credit Card tab when clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /credit card/i }));
+    expect(screen.getByRole('button', { name: /enter card details/i })).toBeInTheDocument();
+  });
+
+  it('shows card input fields after clicking Enter Card Details', async () => {
+    const user = userEvent.setup();
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /credit card/i }));
+    await user.click(screen.getByRole('button', { name: /enter card details/i }));
+    expect(screen.getByPlaceholderText(/1234 5678/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/MM \/ YY/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/^123$/i)).toBeInTheDocument();
+  });
+
+  it('shows success state after successful fiat purchase', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true });
+    const user = userEvent.setup();
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /credit card/i }));
+    await user.click(screen.getByRole('button', { name: /enter card details/i }));
+
+    await user.type(screen.getByPlaceholderText(/1234 5678/i), '4111 1111 1111 1111');
+    await user.type(screen.getByPlaceholderText(/MM \/ YY/i), '12/25');
+    await user.type(screen.getByPlaceholderText(/^123$/i), '123');
+
+    await user.click(screen.getByRole('button', { name: /pay \$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/payment successful/i)).toBeInTheDocument()
+    );
+  });
+
+  it('shows error message when fiat relay fails', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 402,
+      json: () => Promise.resolve({ error: 'Card declined' }),
+    });
+    const user = userEvent.setup();
+    render(
+      <CheckoutModal
+        isOpen={true}
+        onClose={jest.fn()}
+        listing={sampleListing}
+        onCryptoPurchase={jest.fn()}
+        isBuyingCrypto={false}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /credit card/i }));
+    await user.click(screen.getByRole('button', { name: /enter card details/i }));
+
+    await user.type(screen.getByPlaceholderText(/1234 5678/i), '4111 1111 1111 1111');
+    await user.type(screen.getByPlaceholderText(/MM \/ YY/i), '12/25');
+    await user.type(screen.getByPlaceholderText(/^123$/i), '123');
+
+    await user.click(screen.getByRole('button', { name: /pay \$/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/card declined/i)).toBeInTheDocument()
+    );
   });
 });

--- a/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
+++ b/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Component tests for CollectionForm.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockDeploy = jest.fn();
+let mockPublicKey: string | null = 'GPUBKEY';
+
+jest.mock('@/context/WalletContext', () => ({
+  useWalletContext: () => ({ publicKey: mockPublicKey }),
+}));
+
+jest.mock('@/hooks/useLaunchpad', () => ({
+  useDeployCollection: () => ({ deploy: mockDeploy, isDeploying: false, error: null }),
+}));
+
+jest.mock('@/hooks/useSupportedTokens', () => ({
+  useSupportedTokens: () => ({ tokens: [{ address: 'CTOKEN', code: 'XLM', issuer: '' }] }),
+}));
+
+jest.mock('@/lib/token-support', () => ({
+  getDefaultSupportedToken: (tokens: { address: string }[]) => tokens[0],
+}));
+
+jest.mock('@/config/tokens', () => ({
+  DEFAULT_TOKEN: { address: 'CTOKEN' },
+}));
+
+jest.mock('@/lib/launchpad', () => ({}));
+
+jest.mock('@/components/WalletGuard', () => ({
+  GuardButton: ({
+    children,
+    onAction,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onAction?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="submit" onClick={onAction} disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+jest.mock('lucide-react', () =>
+  Object.fromEntries(
+    ['Loader2', 'Rocket', 'CheckCircle', 'ArrowRight']
+      .map((name) => [name, () => <span />])
+  )
+);
+
+import { CollectionForm } from '@/components/CollectionForm';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CollectionForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPublicKey = 'GPUBKEY';
+  });
+
+  it('renders the collection name input', () => {
+    render(<CollectionForm />);
+    expect(screen.getByPlaceholderText(/african legends/i)).toBeInTheDocument();
+  });
+
+  it('renders the symbol input', () => {
+    render(<CollectionForm />);
+    expect(screen.getByPlaceholderText(/AFRL/i)).toBeInTheDocument();
+  });
+
+  it('renders a deploy/launch button', () => {
+    render(<CollectionForm />);
+    expect(screen.getByRole('button', { name: /deploy|launch/i })).toBeInTheDocument();
+  });
+
+  it('calls deploy when form is submitted with valid data', async () => {
+    mockDeploy.mockResolvedValueOnce(null);
+    const user = userEvent.setup();
+    render(<CollectionForm />);
+
+    const nameInput = screen.getByPlaceholderText(/african legends/i);
+    const symbolInput = screen.getByPlaceholderText(/AFRL/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, 'My Collection');
+    await user.clear(symbolInput);
+    await user.type(symbolInput, 'MC');
+
+    await user.click(screen.getByRole('button', { name: /deploy|launch/i }));
+    await waitFor(() => expect(mockDeploy).toHaveBeenCalled());
+  });
+
+  it('shows success state with deployed address', async () => {
+    mockDeploy.mockResolvedValueOnce('CDEPLOYED_ADDRESS_123');
+    const user = userEvent.setup();
+    render(<CollectionForm />);
+
+    await user.type(screen.getByPlaceholderText(/african legends/i), 'My Collection');
+    await user.type(screen.getByPlaceholderText(/AFRL/i), 'MC');
+    await user.click(screen.getByRole('button', { name: /deploy|launch/i }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/collection deployed/i)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/CDEPLOYED_ADDRESS_123/)).toBeInTheDocument();
+  });
+
+  it('renders the Royalty (BPS) label', () => {
+    render(<CollectionForm />);
+    expect(screen.getByText(/royalty.*bps/i)).toBeInTheDocument();
+  });
+
+  it('renders the Max Supply label', () => {
+    render(<CollectionForm />);
+    expect(screen.getByText(/max supply/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/afristore-app/src/__tests__/ConnectWalletModal.test.tsx
+++ b/frontend/afristore-app/src/__tests__/ConnectWalletModal.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Component tests for ConnectWalletModal.
+ */
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockConnect = jest.fn();
+const mockRefresh = jest.fn();
+let mockStatus = 'DISCONNECTED';
+let mockIsConnecting = false;
+let mockError: string | null = null;
+let mockPublicKey: string | null = null;
+
+jest.mock('@/context/WalletContext', () => ({
+  useWalletContext: () => ({
+    status: mockStatus,
+    connect: mockConnect,
+    isConnecting: mockIsConnecting,
+    error: mockError,
+    publicKey: mockPublicKey,
+    refresh: mockRefresh,
+  }),
+}));
+
+jest.mock('@/components/MagicWalletModal', () => ({
+  MagicWalletModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="magic-modal" /> : null,
+}));
+
+jest.mock('@/lib/config', () => ({
+  config: { network: 'testnet' },
+}));
+
+jest.mock('posthog-js', () => ({
+  capture: jest.fn(),
+}));
+
+jest.mock('lucide-react', () =>
+  Object.fromEntries(
+    ['X', 'Wallet', 'ExternalLink', 'ShieldCheck', 'AlertTriangle',
+      'ArrowRight', 'Loader2', 'CheckCircle2', 'Mail']
+      .map((name) => [name, () => <span />])
+  )
+);
+
+import { ConnectWalletModal } from '@/components/ConnectWalletModal';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ConnectWalletModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStatus = 'DISCONNECTED';
+    mockIsConnecting = false;
+    mockError = null;
+    mockPublicKey = null;
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <ConnectWalletModal isOpen={false} onClose={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the modal with Freighter option', () => {
+    render(<ConnectWalletModal isOpen={true} onClose={jest.fn()} />);
+    expect(screen.getByText(/freighter wallet/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when the backdrop is clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <ConnectWalletModal isOpen={true} onClose={onClose} />
+    );
+    const backdrop = container.querySelector('.absolute.inset-0');
+    if (backdrop) {
+      await user.click(backdrop);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+
+  it('calls connect when the Freighter Wallet button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ConnectWalletModal isOpen={true} onClose={jest.fn()} />);
+    // The Freighter button contains "Freighter Wallet" text
+    const connectBtn = screen.getByRole('button', { name: /freighter wallet/i });
+    await user.click(connectBtn);
+    expect(mockConnect).toHaveBeenCalled();
+  });
+
+  it('shows error message when error is set', () => {
+    mockError = 'Connection rejected';
+    render(<ConnectWalletModal isOpen={true} onClose={jest.fn()} />);
+    expect(screen.getByText(/connection rejected/i)).toBeInTheDocument();
+  });
+
+  it('shows Magic Wallet as coming soon', () => {
+    render(<ConnectWalletModal isOpen={true} onClose={jest.fn()} />);
+    expect(screen.getByText(/magic wallet/i)).toBeInTheDocument();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
+++ b/frontend/afristore-app/src/__tests__/ListingCard.test.tsx
@@ -84,6 +84,34 @@ jest.mock('@/components/WalletGuard', () => ({
   ),
 }));
 
+// CheckoutModal — call onCryptoPurchase immediately when opened so tests
+// that click "Buy Now" can still assert buy() was invoked without rendering
+// the full modal UI.
+jest.mock('@/components/CheckoutModal', () => ({
+  CheckoutModal: ({
+    isOpen,
+    onCryptoPurchase,
+  }: {
+    isOpen: boolean;
+    onCryptoPurchase: () => Promise<boolean>;
+    onClose: () => void;
+    onPurchased?: () => void;
+    isBuyingCrypto: boolean;
+    listing: unknown;
+  }) => {
+    if (!isOpen) return null;
+    // Render a confirm button so the test can trigger the purchase
+    return (
+      <button
+        data-testid="checkout-confirm"
+        onClick={() => onCryptoPurchase()}
+      >
+        Confirm Purchase
+      </button>
+    );
+  },
+}));
+
 import { ListingCard } from '@/components/ListingCard';
 import type { Listing } from '@/lib/contract';
 
@@ -189,15 +217,23 @@ describe('ListingCard', () => {
     });
   });
 
-  it('calls buy with the listing id when Buy Now is clicked', async () => {
+  it('calls buy with the listing id when Buy Now is clicked through checkout modal', async () => {
     const user = userEvent.setup();
     render(<ListingCard listing={makeListing({ listing_id: 7 })} />);
     await waitFor(() =>
       expect(screen.queryByRole('button', { name: /buy now/i })).toBeInTheDocument()
     );
 
+    // Click "Buy Now" — this opens the CheckoutModal
     await user.click(screen.getByRole('button', { name: /buy now/i }));
-    expect(mockBuy).toHaveBeenCalledWith(7);
+
+    // Confirm purchase through the mocked modal
+    await waitFor(() =>
+      expect(screen.getByTestId('checkout-confirm')).toBeInTheDocument()
+    );
+    await user.click(screen.getByTestId('checkout-confirm'));
+
+    await waitFor(() => expect(mockBuy).toHaveBeenCalledWith(7));
   });
 
   it('links the image to the listing detail page', async () => {

--- a/frontend/afristore-app/src/__tests__/MagicWalletModal.test.tsx
+++ b/frontend/afristore-app/src/__tests__/MagicWalletModal.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Component tests for MagicWalletModal.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockLoginWithEmail = jest.fn();
+const mockLoginWithPasskey = jest.fn();
+const mockLogout = jest.fn();
+const mockRefresh = jest.fn();
+
+let mockStatus = 'DISCONNECTED';
+let mockError: string | null = null;
+let mockEmail: string | null = null;
+let mockPublicAddress: string | null = null;
+
+jest.mock('@/hooks/useMagicWallet', () => ({
+  useMagicWallet: () => ({
+    status: mockStatus,
+    isConnecting: false,
+    error: mockError,
+    email: mockEmail,
+    publicAddress: mockPublicAddress,
+    loginWithEmail: mockLoginWithEmail,
+    loginWithPasskey: mockLoginWithPasskey,
+    logout: mockLogout,
+    refresh: mockRefresh,
+  }),
+}));
+
+jest.mock('lucide-react', () =>
+  Object.fromEntries(
+    ['X', 'Mail', 'Fingerprint', 'ExternalLink', 'AlertTriangle',
+      'ArrowRight', 'Loader2', 'CheckCircle2']
+      .map((name) => [name, () => <span />])
+  )
+);
+
+import { MagicWalletModal } from '@/components/MagicWalletModal';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('MagicWalletModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockStatus = 'DISCONNECTED';
+    mockError = null;
+    mockEmail = null;
+    mockPublicAddress = null;
+  });
+
+  it('renders nothing when isOpen is false', () => {
+    const { container } = render(
+      <MagicWalletModal isOpen={false} onClose={jest.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders modal content when isOpen is true', () => {
+    render(<MagicWalletModal isOpen={true} onClose={jest.fn()} />);
+    // The modal shows "Magic" in the title
+    expect(screen.getByText('Magic')).toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    render(<MagicWalletModal isOpen={true} onClose={onClose} />);
+    // The X close button is the first button
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[0]);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('shows email input form when Email Magic Link is clicked', async () => {
+    const user = userEvent.setup();
+    render(<MagicWalletModal isOpen={true} onClose={jest.fn()} />);
+    // "Email Magic Link" button triggers setShowEmailForm(true)
+    await user.click(screen.getByRole('button', { name: /email magic link/i }));
+    await waitFor(() =>
+      expect(screen.getByPlaceholderText(/you@example\.com/i)).toBeInTheDocument()
+    );
+  });
+
+  it('calls loginWithEmail when email form is submitted', async () => {
+    mockLoginWithEmail.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<MagicWalletModal isOpen={true} onClose={jest.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /email magic link/i }));
+    const input = await screen.findByPlaceholderText(/you@example\.com/i);
+    await user.type(input, 'user@test.com');
+    // Submit button text is "Send Magic Link" or similar
+    const submitBtn = screen.getByRole('button', { name: /send magic link|continue/i });
+    await user.click(submitBtn);
+
+    await waitFor(() =>
+      expect(mockLoginWithEmail).toHaveBeenCalledWith('user@test.com')
+    );
+  });
+
+  it('calls loginWithPasskey when Passkey Login is clicked', async () => {
+    mockLoginWithPasskey.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<MagicWalletModal isOpen={true} onClose={jest.fn()} />);
+
+    const passkeyBtn = screen.getByRole('button', { name: /passkey login/i });
+    await user.click(passkeyBtn);
+    await waitFor(() => expect(mockLoginWithPasskey).toHaveBeenCalled());
+  });
+
+  it('displays error message when login fails', async () => {
+    mockError = 'Login failed';
+    render(<MagicWalletModal isOpen={true} onClose={jest.fn()} />);
+    expect(screen.getByText(/login failed/i)).toBeInTheDocument();
+  });
+
+  it('calls onClose when backdrop is clicked', async () => {
+    const onClose = jest.fn();
+    const user = userEvent.setup();
+    const { container } = render(
+      <MagicWalletModal isOpen={true} onClose={onClose} />
+    );
+    // The backdrop is the first absolutely-positioned overlay div
+    const backdrop = container.querySelector('.absolute.inset-0');
+    if (backdrop) {
+      await user.click(backdrop);
+      expect(onClose).toHaveBeenCalled();
+    }
+  });
+});

--- a/frontend/afristore-app/src/__tests__/SearchFilter.test.tsx
+++ b/frontend/afristore-app/src/__tests__/SearchFilter.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Component tests for SearchFilter.
+ */
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// lucide-react icons can cause issues in jsdom — mock them
+jest.mock('lucide-react', () => ({
+  Search: () => <span data-testid="icon-search" />,
+  SlidersHorizontal: () => <span />,
+  ArrowUpDown: () => <span />,
+  X: () => <span data-testid="icon-x" />,
+  Filter: () => <span />,
+}));
+
+import { SearchFilter } from '@/components/SearchFilter';
+import type { Filters } from '@/components/SearchFilter';
+
+const DEFAULT_FILTERS: Filters = {
+  search: '',
+  status: 'All',
+  category: 'All',
+  minPrice: '',
+  maxPrice: '',
+  sort: 'newest',
+};
+
+describe('SearchFilter', () => {
+  it('renders the search input', () => {
+    const onChange = jest.fn();
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={onChange}
+        showFilters={false}
+        setShowFilters={jest.fn()}
+        totalResults={5}
+      />
+    );
+    expect(screen.getByPlaceholderText(/search/i)).toBeInTheDocument();
+  });
+
+  it('calls onFilterChange with updated search text', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={onChange}
+        showFilters={false}
+        setShowFilters={jest.fn()}
+        totalResults={5}
+      />
+    );
+    await user.type(screen.getByPlaceholderText(/search/i), 'landscape');
+    expect(onChange).toHaveBeenCalledWith({ search: 'l' });
+  });
+
+  it('calls setShowFilters when filter toggle button is clicked', async () => {
+    const setShowFilters = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={jest.fn()}
+        showFilters={false}
+        setShowFilters={setShowFilters}
+        totalResults={0}
+      />
+    );
+    // Click the "Filters" toggle button
+    const filterBtn = screen.getByRole('button', { name: /filter/i });
+    await user.click(filterBtn);
+    expect(setShowFilters).toHaveBeenCalledWith(true);
+  });
+
+  it('shows status filter buttons when showFilters is true', () => {
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={jest.fn()}
+        showFilters={true}
+        setShowFilters={jest.fn()}
+        totalResults={0}
+      />
+    );
+    expect(screen.getByRole('button', { name: /active/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /sold/i })).toBeInTheDocument();
+  });
+
+  it('calls onFilterChange with status when status button is clicked', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={onChange}
+        showFilters={true}
+        setShowFilters={jest.fn()}
+        totalResults={0}
+      />
+    );
+    await user.click(screen.getByRole('button', { name: /^active$/i }));
+    expect(onChange).toHaveBeenCalledWith({ status: 'Active' });
+  });
+
+  it('shows the total results count', () => {
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={jest.fn()}
+        showFilters={false}
+        setShowFilters={jest.fn()}
+        totalResults={42}
+      />
+    );
+    expect(screen.getByText(/42/)).toBeInTheDocument();
+  });
+
+  it('shows Reset All Filters button when filters are active', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <SearchFilter
+        filters={{ ...DEFAULT_FILTERS, search: 'test' }}
+        onFilterChange={onChange}
+        showFilters={false}
+        setShowFilters={jest.fn()}
+        totalResults={0}
+      />
+    );
+    const clearBtn = screen.getByRole('button', { name: /reset all filters/i });
+    expect(clearBtn).toBeInTheDocument();
+    await user.click(clearBtn);
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+  });
+
+  it('does not show Reset All Filters button when no filters are active', () => {
+    render(
+      <SearchFilter
+        filters={DEFAULT_FILTERS}
+        onFilterChange={jest.fn()}
+        showFilters={false}
+        setShowFilters={jest.fn()}
+        totalResults={0}
+      />
+    );
+    expect(screen.queryByRole('button', { name: /reset all filters/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/afristore-app/src/__tests__/WalletGuard.test.tsx
+++ b/frontend/afristore-app/src/__tests__/WalletGuard.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Component tests for WalletGuard and GuardButton.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockWalletContext = {
+  isConnected: true,
+  isWrongNetwork: false,
+  status: 'connected' as const,
+  publicKey: 'GPUBKEY',
+  connect: jest.fn(),
+  disconnect: jest.fn(),
+  refresh: jest.fn(),
+  isInstalled: true,
+  isConnecting: false,
+  error: null,
+  networkPassphrase: null,
+};
+
+jest.mock('@/context/WalletContext', () => ({
+  useWalletContext: () => mockWalletContext,
+}));
+
+// ConnectWalletModal — render nothing to keep tests simple
+jest.mock('@/components/ConnectWalletModal', () => ({
+  ConnectWalletModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="connect-modal" /> : null,
+}));
+
+jest.mock('lucide-react', () => ({
+  Wallet: () => <span />,
+  AlertTriangle: () => <span />,
+}));
+
+import { WalletGuard, GuardButton } from '@/components/WalletGuard';
+
+// ── WalletGuard ───────────────────────────────────────────────────────────────
+
+describe('WalletGuard', () => {
+  beforeEach(() => {
+    mockWalletContext.isConnected = true;
+    mockWalletContext.isWrongNetwork = false;
+    jest.clearAllMocks();
+  });
+
+  it('renders children when wallet is connected', () => {
+    render(
+      <WalletGuard>
+        <span data-testid="child">Protected Content</span>
+      </WalletGuard>
+    );
+    expect(screen.getByTestId('child')).toBeInTheDocument();
+  });
+
+  it('renders the default fallback (Connect Wallet) when disconnected', () => {
+    mockWalletContext.isConnected = false;
+    render(
+      <WalletGuard>
+        <span data-testid="child">Protected Content</span>
+      </WalletGuard>
+    );
+    expect(screen.getByRole('button', { name: /connect wallet/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('child')).not.toBeInTheDocument();
+  });
+
+  it('renders custom fallback when provided and disconnected', () => {
+    mockWalletContext.isConnected = false;
+    render(
+      <WalletGuard fallback={<span data-testid="custom-fallback">Login</span>}>
+        <span>Protected</span>
+      </WalletGuard>
+    );
+    expect(screen.getByTestId('custom-fallback')).toBeInTheDocument();
+  });
+
+  it('opens ConnectWalletModal when Connect Wallet button is clicked while disconnected', async () => {
+    mockWalletContext.isConnected = false;
+    const user = userEvent.setup();
+    render(
+      <WalletGuard>
+        <span>Protected</span>
+      </WalletGuard>
+    );
+    await user.click(screen.getByRole('button', { name: /connect wallet/i }));
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-modal')).toBeInTheDocument()
+    );
+  });
+});
+
+// ── GuardButton ───────────────────────────────────────────────────────────────
+
+describe('GuardButton', () => {
+  beforeEach(() => {
+    mockWalletContext.isConnected = true;
+    mockWalletContext.isWrongNetwork = false;
+    jest.clearAllMocks();
+  });
+
+  it('calls onAction when wallet is connected', async () => {
+    const onAction = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <GuardButton onAction={onAction}>Buy Now</GuardButton>
+    );
+    await user.click(screen.getByRole('button', { name: /buy now/i }));
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it('opens ConnectWalletModal and does NOT call onAction when wallet is disconnected', async () => {
+    mockWalletContext.isConnected = false;
+    const onAction = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <GuardButton onAction={onAction}>Buy Now</GuardButton>
+    );
+    await user.click(screen.getByRole('button', { name: /buy now/i }));
+    expect(onAction).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-modal')).toBeInTheDocument()
+    );
+  });
+
+  it('opens ConnectWalletModal when wallet is on wrong network', async () => {
+    mockWalletContext.isConnected = true;
+    mockWalletContext.isWrongNetwork = true;
+    const onAction = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <GuardButton onAction={onAction}>Buy Now</GuardButton>
+    );
+    await user.click(screen.getByRole('button', { name: /buy now/i }));
+    expect(onAction).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(screen.getByTestId('connect-modal')).toBeInTheDocument()
+    );
+  });
+
+  it('respects the disabled prop', () => {
+    render(
+      <GuardButton onAction={jest.fn()} disabled>
+        Disabled
+      </GuardButton>
+    );
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useAdmin.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useAdmin.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * Unit tests for useAdmin.ts hooks.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetTotalListings = jest.fn();
+const mockGetAllListings = jest.fn();
+const mockGetTreasury = jest.fn();
+const mockGetProtocolFee = jest.fn();
+const mockGetAdmin = jest.fn();
+const mockRevokeArtist = jest.fn();
+const mockReinstateArtist = jest.fn();
+const mockIsArtistRevoked = jest.fn();
+const mockAddTokenToWhitelist = jest.fn();
+const mockRemoveTokenFromWhitelist = jest.fn();
+const mockGetTokenWhitelist = jest.fn();
+
+jest.mock('@/lib/contract', () => ({
+  getTotalListings: (...args: unknown[]) => mockGetTotalListings(...args),
+  getAllListings: (...args: unknown[]) => mockGetAllListings(...args),
+  getTreasury: (...args: unknown[]) => mockGetTreasury(...args),
+  getProtocolFee: (...args: unknown[]) => mockGetProtocolFee(...args),
+  getAdmin: (...args: unknown[]) => mockGetAdmin(...args),
+  revokeArtist: (...args: unknown[]) => mockRevokeArtist(...args),
+  reinstateArtist: (...args: unknown[]) => mockReinstateArtist(...args),
+  isArtistRevoked: (...args: unknown[]) => mockIsArtistRevoked(...args),
+  addTokenToWhitelist: (...args: unknown[]) => mockAddTokenToWhitelist(...args),
+  removeTokenFromWhitelist: (...args: unknown[]) => mockRemoveTokenFromWhitelist(...args),
+  getTokenWhitelist: (...args: unknown[]) => mockGetTokenWhitelist(...args),
+}));
+
+// Horizon.Server mock — not needed for these tests
+jest.mock('@stellar/stellar-sdk', () => ({
+  Horizon: {
+    Server: jest.fn().mockImplementation(() => ({
+      loadAccount: jest.fn().mockResolvedValue({ balances: [] }),
+    })),
+  },
+}));
+
+jest.mock('@/lib/config', () => ({
+  config: { horizonUrl: 'https://horizon-testnet.stellar.org' },
+}));
+
+import {
+  useAdminStats,
+  useModeration,
+  useTokenManagement,
+  useAdminCheck,
+} from '@/hooks/useAdmin';
+
+// ── useAdminStats ─────────────────────────────────────────────────────────────
+
+describe('useAdminStats', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('loads stats successfully', async () => {
+    mockGetTotalListings.mockResolvedValueOnce(10);
+    mockGetAllListings.mockResolvedValueOnce([
+      { artist: 'GA' },
+      { artist: 'GB' },
+      { artist: 'GA' }, // duplicate — unique count = 2
+    ]);
+    mockGetProtocolFee.mockResolvedValueOnce(250);
+    mockGetTreasury.mockResolvedValueOnce('GTREASURY');
+
+    function Comp() {
+      const { stats, isLoading } = useAdminStats();
+      if (isLoading || !stats) return <span data-testid="loading">yes</span>;
+      return (
+        <div>
+          <span data-testid="listings">{stats.totalListings}</span>
+          <span data-testid="users">{stats.totalUsers}</span>
+          <span data-testid="fee">{stats.protocolFeeBps}</span>
+          <span data-testid="treasury">{stats.treasuryAddress}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.queryByTestId('loading')).not.toBeInTheDocument());
+    expect(screen.getByTestId('listings').textContent).toBe('10');
+    expect(screen.getByTestId('users').textContent).toBe('2');
+    expect(screen.getByTestId('fee').textContent).toBe('250');
+    expect(screen.getByTestId('treasury').textContent).toBe('GTREASURY');
+  });
+
+  it('sets error when contract call fails', async () => {
+    mockGetTotalListings.mockRejectedValueOnce(new Error('chain down'));
+
+    function Comp() {
+      const { error } = useAdminStats();
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+});
+
+// ── useModeration ─────────────────────────────────────────────────────────────
+
+describe('useModeration', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('revoke does nothing when adminPublicKey is null', async () => {
+    function Comp() {
+      const { revoke } = useModeration(null);
+      const [done, setDone] = React.useState(false);
+      return (
+        <div>
+          <button onClick={async () => { await revoke('GARTIST'); setDone(true); }}>r</button>
+          <span data-testid="done">{String(done)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('done').textContent).toBe('true'));
+    expect(mockRevokeArtist).not.toHaveBeenCalled();
+  });
+
+  it('calls revokeArtist with correct args', async () => {
+    mockRevokeArtist.mockResolvedValueOnce(undefined);
+    function Comp() {
+      const { revoke } = useModeration('GADMIN');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await revoke('GARTIST') as boolean)}>r</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockRevokeArtist).toHaveBeenCalledWith('GADMIN', 'GARTIST');
+  });
+
+  it('calls reinstateArtist with correct args', async () => {
+    mockReinstateArtist.mockResolvedValueOnce(undefined);
+    function Comp() {
+      const { reinstate } = useModeration('GADMIN');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await reinstate('GARTIST') as boolean)}>re</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockReinstateArtist).toHaveBeenCalledWith('GADMIN', 'GARTIST');
+  });
+
+  it('checkStatus returns revoked flag from contract', async () => {
+    mockIsArtistRevoked.mockResolvedValueOnce(true);
+    function Comp() {
+      const { checkStatus } = useModeration('GADMIN');
+      const [status, setStatus] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setStatus(await checkStatus('GARTIST'))}>c</button>
+          <span data-testid="status">{String(status)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('status').textContent).toBe('true'));
+  });
+});
+
+// ── useTokenManagement ────────────────────────────────────────────────────────
+
+describe('useTokenManagement', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('loads the token whitelist on mount', async () => {
+    mockGetTokenWhitelist.mockResolvedValueOnce(['CTOKENA', 'CTOKENB']);
+
+    function Comp() {
+      const { whitelistedTokens } = useTokenManagement('GADMIN');
+      return <span data-testid="tokens">{whitelistedTokens.join(',')}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('tokens').textContent).toBe('CTOKENA,CTOKENB')
+    );
+  });
+
+  it('adds a token optimistically and confirms on success', async () => {
+    mockGetTokenWhitelist.mockResolvedValueOnce([]);
+    mockAddTokenToWhitelist.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { whitelistedTokens, whitelist } = useTokenManagement('GADMIN');
+      return (
+        <div>
+          <button onClick={() => whitelist('CNEWTOKEN')}>add</button>
+          <span data-testid="tokens">{whitelistedTokens.join(',')}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('tokens').textContent).toBe(''));
+    await user.click(screen.getByRole('button'));
+    await waitFor(() =>
+      expect(screen.getByTestId('tokens').textContent).toBe('CNEWTOKEN')
+    );
+  });
+
+  it('rolls back token addition on contract failure', async () => {
+    mockGetTokenWhitelist.mockResolvedValueOnce(['CEXISTING']);
+    mockAddTokenToWhitelist.mockRejectedValueOnce(new Error('failed'));
+
+    function Comp() {
+      const { whitelistedTokens, whitelist } = useTokenManagement('GADMIN');
+      return (
+        <div>
+          <button onClick={() => whitelist('CFAIL')}>add</button>
+          <span data-testid="tokens">{whitelistedTokens.join(',')}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('tokens').textContent).toBe('CEXISTING'));
+    await user.click(screen.getByRole('button'));
+    // After rollback, should revert to the original list
+    await waitFor(() =>
+      expect(screen.getByTestId('tokens').textContent).toBe('CEXISTING')
+    );
+  });
+});
+
+// ── useAdminCheck ─────────────────────────────────────────────────────────────
+
+describe('useAdminCheck', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns isAdmin=false when publicKey is null', async () => {
+    function Comp() {
+      const { isAdmin, isLoading } = useAdminCheck(null);
+      return (
+        <div>
+          <span data-testid="admin">{String(isAdmin)}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+    expect(screen.getByTestId('admin').textContent).toBe('false');
+  });
+
+  it('returns isAdmin=true when publicKey matches admin address', async () => {
+    mockGetAdmin.mockResolvedValueOnce('GADMIN');
+    function Comp() {
+      const { isAdmin, isLoading } = useAdminCheck('GADMIN');
+      return (
+        <div>
+          <span data-testid="admin">{String(isAdmin)}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('loading').textContent).toBe('false'));
+    expect(screen.getByTestId('admin').textContent).toBe('true');
+  });
+
+  it('returns isAdmin=false when publicKey does not match', async () => {
+    mockGetAdmin.mockResolvedValueOnce('GADMIN');
+    function Comp() {
+      const { isAdmin } = useAdminCheck('GNOTADMIN');
+      return <span data-testid="admin">{String(isAdmin)}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('admin').textContent).toBe('false'));
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useAuctions.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useAuctions.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * Unit tests for useAuctions.ts hooks.
+ * All blockchain / indexer calls are mocked.
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetAllAuctions = jest.fn();
+const mockGetAuction = jest.fn();
+const mockGetArtistAuctions = jest.fn();
+const mockCreateAuction = jest.fn();
+const mockPlaceBid = jest.fn();
+const mockFinalizeAuction = jest.fn();
+
+jest.mock('@/lib/contract', () => ({
+  getAllAuctions: (...args: unknown[]) => mockGetAllAuctions(...args),
+  getAuction: (...args: unknown[]) => mockGetAuction(...args),
+  getArtistAuctions: (...args: unknown[]) => mockGetArtistAuctions(...args),
+  createAuction: (...args: unknown[]) => mockCreateAuction(...args),
+  placeBid: (...args: unknown[]) => mockPlaceBid(...args),
+  finalizeAuction: (...args: unknown[]) => mockFinalizeAuction(...args),
+}));
+
+jest.mock('@/lib/indexer', () => ({
+  fetchAuctions: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('@/lib/ipfs', () => ({
+  uploadImageToIPFS: jest.fn().mockResolvedValue({ cid: 'QmImage' }),
+  uploadMetadataToIPFS: jest.fn().mockResolvedValue({ cid: 'QmMeta' }),
+}));
+
+jest.mock('@/lib/errors', () => ({
+  getReadableErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+jest.mock('@/hooks/useTransientErrorToast', () => ({
+  useTransientErrorToast: jest.fn(),
+}));
+
+import {
+  useAuctions,
+  useArtistAuctions,
+  useCreateAuction,
+  usePlaceBid,
+  useFinalizeAuction,
+} from '@/hooks/useAuctions';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeAuction(id: number) {
+  return {
+    auction_id: id,
+    artist: 'GARTIST',
+    metadata_cid: 'Qm',
+    reserve_price: 10_000_000n,
+    highest_bid: 0n,
+    highest_bidder: null,
+    end_time: 9999,
+    status: 'Active',
+  };
+}
+
+// ── useAuctions ───────────────────────────────────────────────────────────────
+
+describe('useAuctions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('loads auctions from the indexer', async () => {
+    const { fetchAuctions } = jest.requireMock('@/lib/indexer');
+    fetchAuctions.mockResolvedValueOnce([makeAuction(1), makeAuction(2)]);
+
+    function Comp() {
+      const { auctions, isLoading } = useAuctions();
+      return (
+        <div>
+          <span data-testid="count">{auctions.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+
+  it('falls back to on-chain when indexer throws', async () => {
+    const { fetchAuctions } = jest.requireMock('@/lib/indexer');
+    fetchAuctions.mockRejectedValueOnce(new Error('indexer down'));
+    mockGetAllAuctions.mockResolvedValueOnce([makeAuction(1), makeAuction(2)]);
+
+    function Comp() {
+      const { auctions } = useAuctions();
+      return <span data-testid="count">{auctions.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+
+  it('sets error when both indexer and contract fail', async () => {
+    const { fetchAuctions } = jest.requireMock('@/lib/indexer');
+    fetchAuctions.mockRejectedValueOnce(new Error('indexer down'));
+    mockGetAllAuctions.mockRejectedValueOnce(new Error('chain down'));
+
+    function Comp() {
+      const { error } = useAuctions();
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+
+  it('exposes a refresh function that re-fetches', async () => {
+    const { fetchAuctions } = jest.requireMock('@/lib/indexer');
+    fetchAuctions
+      .mockResolvedValueOnce([makeAuction(1)])
+      .mockResolvedValueOnce([makeAuction(1), makeAuction(2)]);
+
+    let refreshFn: () => void;
+    function Comp() {
+      const { auctions, refresh } = useAuctions();
+      refreshFn = refresh;
+      return <span data-testid="count">{auctions.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+
+    await act(async () => { refreshFn(); });
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+});
+
+// ── useArtistAuctions ─────────────────────────────────────────────────────────
+
+describe('useArtistAuctions', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when publicKey is null', () => {
+    function Comp() {
+      const { auctions, isLoading } = useArtistAuctions(null);
+      return (
+        <div>
+          <span data-testid="count">{auctions.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('fetches auctions for a given artist', async () => {
+    mockGetArtistAuctions.mockResolvedValueOnce([10, 11]);
+    mockGetAuction
+      .mockResolvedValueOnce(makeAuction(10))
+      .mockResolvedValueOnce(makeAuction(11));
+
+    function Comp() {
+      const { auctions } = useArtistAuctions('GARTIST');
+      return <span data-testid="count">{auctions.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+
+  it('sets error when fetch fails', async () => {
+    mockGetArtistAuctions.mockRejectedValueOnce(new Error('nope'));
+
+    function Comp() {
+      const { error } = useArtistAuctions('GARTIST');
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+});
+
+// ── useCreateAuction ──────────────────────────────────────────────────────────
+
+describe('useCreateAuction', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns null immediately when publicKey is null', async () => {
+    function Comp() {
+      const { create, isCreating } = useCreateAuction(null);
+      const [result, setResult] = React.useState<number | null | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await create({
+            title: 'T', description: 'D', artistName: 'A', year: '2024',
+            category: 'C', imageFile: new File([], 'f.png'),
+            reservePriceXlm: 10, durationHours: 24,
+          }))}>create</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="creating">{String(isCreating)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('null'));
+  });
+
+  it('calls create auction contract and returns id on success', async () => {
+    mockCreateAuction.mockResolvedValueOnce(42);
+
+    function Comp() {
+      const { create } = useCreateAuction('GCREATOR');
+      const [result, setResult] = React.useState<number | null | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await create({
+            title: 'T', description: 'D', artistName: 'A', year: '2024',
+            category: 'C', imageFile: new File([], 'f.png'),
+            reservePriceXlm: 10, durationHours: 24,
+          }))}>create</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('42'));
+  });
+
+  it('returns null and sets error when creation fails', async () => {
+    mockCreateAuction.mockRejectedValueOnce(new Error('contract error'));
+
+    function Comp() {
+      const { create, error } = useCreateAuction('GCREATOR');
+      const [result, setResult] = React.useState<number | null | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await create({
+            title: 'T', description: 'D', artistName: 'A', year: '2024',
+            category: 'C', imageFile: new File([], 'f.png'),
+            reservePriceXlm: 10, durationHours: 24,
+          }))}>create</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('null'));
+    expect(screen.getByTestId('error').textContent).not.toBe('none');
+  });
+});
+
+// ── usePlaceBid ───────────────────────────────────────────────────────────────
+
+describe('usePlaceBid', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false immediately when publicKey is null', async () => {
+    function Comp() {
+      const { bid } = usePlaceBid(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await bid(1, 5))}>bid</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('returns true and calls placeBid on success', async () => {
+    mockPlaceBid.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { bid } = usePlaceBid('GBIDDER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await bid(1, 5))}>bid</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockPlaceBid).toHaveBeenCalledWith('GBIDDER', 1, 5);
+  });
+
+  it('returns false and sets error when bid fails', async () => {
+    mockPlaceBid.mockRejectedValueOnce(new Error('bid error'));
+
+    function Comp() {
+      const { bid, error } = usePlaceBid('GBIDDER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await bid(1, 5))}>bid</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+    expect(screen.getByTestId('error').textContent).not.toBe('none');
+  });
+});
+
+// ── useFinalizeAuction ────────────────────────────────────────────────────────
+
+describe('useFinalizeAuction', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false immediately when publicKey is null', async () => {
+    function Comp() {
+      const { finalize } = useFinalizeAuction(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await finalize(1))}>finalize</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls finalizeAuction and returns true on success', async () => {
+    mockFinalizeAuction.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { finalize } = useFinalizeAuction('GCALLER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await finalize(5))}>finalize</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockFinalizeAuction).toHaveBeenCalledWith('GCALLER', 5);
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useMagicWallet.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useMagicWallet.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Unit tests for useMagicWallet.ts
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockIsMagicLoggedIn = jest.fn();
+const mockLoginWithMagicLink = jest.fn();
+const mockLoginWithPasskey = jest.fn();
+const mockGetMagicUserMetadata = jest.fn();
+const mockLogoutFromMagic = jest.fn();
+
+jest.mock('@/lib/magic', () => ({
+  isMagicLoggedIn: (...args: unknown[]) => mockIsMagicLoggedIn(...args),
+  loginWithMagicLink: (...args: unknown[]) => mockLoginWithMagicLink(...args),
+  loginWithPasskey: (...args: unknown[]) => mockLoginWithPasskey(...args),
+  getMagicUserMetadata: (...args: unknown[]) => mockGetMagicUserMetadata(...args),
+  logoutFromMagic: (...args: unknown[]) => mockLogoutFromMagic(...args),
+}));
+
+jest.mock('@/providers/PostHogProvider', () => ({
+  trackEvent: {
+    walletConnected: jest.fn(),
+    walletConnectionDropOff: jest.fn(),
+  },
+}));
+
+import { useMagicWallet } from '@/hooks/useMagicWallet';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function StatusComp() {
+  const { status, email, publicAddress, isConnecting, isConnected, error,
+          loginWithEmail, loginWithPasskey, logout, refresh } = useMagicWallet();
+  return (
+    <div>
+      <span data-testid="status">{status}</span>
+      <span data-testid="email">{email ?? 'null'}</span>
+      <span data-testid="address">{publicAddress ?? 'null'}</span>
+      <span data-testid="connecting">{String(isConnecting)}</span>
+      <span data-testid="connected">{String(isConnected)}</span>
+      <span data-testid="error">{error ?? 'none'}</span>
+      <button data-testid="login-email" onClick={() => loginWithEmail('test@test.com')}>email</button>
+      <button data-testid="login-passkey" onClick={() => loginWithPasskey()}>passkey</button>
+      <button data-testid="logout" onClick={() => logout()}>logout</button>
+      <button data-testid="refresh" onClick={() => refresh()}>refresh</button>
+    </div>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useMagicWallet', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('starts in NOT_INITIALIZED status and transitions to DISCONNECTED after refresh', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(false);
+    render(<StatusComp />);
+    // Initially NOT_INITIALIZED
+    expect(screen.getByTestId('status').textContent).toBe('NOT_INITIALIZED');
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+  });
+
+  it('shows CONNECTED status when already logged in on mount', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(true);
+    mockGetMagicUserMetadata.mockResolvedValueOnce({
+      email: 'user@test.com',
+      publicAddress: 'GMAGIC',
+    });
+    render(<StatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('CONNECTED')
+    );
+    expect(screen.getByTestId('email').textContent).toBe('user@test.com');
+    expect(screen.getByTestId('address').textContent).toBe('GMAGIC');
+    expect(screen.getByTestId('connected').textContent).toBe('true');
+  });
+
+  it('loginWithEmail sets connected state on success', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(false);
+    mockLoginWithMagicLink.mockResolvedValueOnce({
+      email: 'new@test.com',
+      publicAddress: 'GNEW',
+    });
+
+    const user = userEvent.setup();
+    render(<StatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('login-email'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('CONNECTED')
+    );
+    expect(screen.getByTestId('email').textContent).toBe('new@test.com');
+    expect(screen.getByTestId('address').textContent).toBe('GNEW');
+  });
+
+  it('loginWithEmail sets error state on failure', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(false);
+    mockLoginWithMagicLink.mockRejectedValueOnce(new Error('email login failed'));
+
+    // Render a version of the component that swallows the rethrow from the hook
+    function SafeStatusComp() {
+      const { status, error, loginWithEmail } = useMagicWallet();
+      return (
+        <div>
+          <span data-testid="status">{status}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+          <button
+            data-testid="login-email"
+            onClick={() => loginWithEmail('test@test.com').catch(() => { /* swallow */ })}
+          >email</button>
+        </div>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<SafeStatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('login-email'));
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+    expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED');
+  });
+
+  it('loginWithPasskey sets connected state on success', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(false);
+    mockLoginWithPasskey.mockResolvedValueOnce({
+      email: 'pk@test.com',
+      publicAddress: 'GPK',
+    });
+
+    const user = userEvent.setup();
+    render(<StatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('login-passkey'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('CONNECTED')
+    );
+    expect(screen.getByTestId('address').textContent).toBe('GPK');
+  });
+
+  it('logout clears state', async () => {
+    mockIsMagicLoggedIn.mockResolvedValueOnce(true);
+    mockGetMagicUserMetadata.mockResolvedValueOnce({
+      email: 'user@test.com',
+      publicAddress: 'GMAGIC',
+    });
+    mockLogoutFromMagic.mockResolvedValueOnce(undefined);
+
+    const user = userEvent.setup();
+    render(<StatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('connected').textContent).toBe('true')
+    );
+
+    await user.click(screen.getByTestId('logout'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+    expect(screen.getByTestId('email').textContent).toBe('null');
+    expect(screen.getByTestId('address').textContent).toBe('null');
+  });
+
+  it('refresh re-checks login status', async () => {
+    mockIsMagicLoggedIn
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockGetMagicUserMetadata.mockResolvedValueOnce({
+      email: 'refreshed@test.com',
+      publicAddress: 'GREFRESHED',
+    });
+
+    const user = userEvent.setup();
+    render(<StatusComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('refresh'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('CONNECTED')
+    );
+    expect(screen.getByTestId('address').textContent).toBe('GREFRESHED');
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useMarketplace.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useMarketplace.test.tsx
@@ -1,31 +1,376 @@
+/**
+ * Unit tests for useMarketplace.ts hooks.
+ * All external dependencies are mocked.
+ */
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
-import { useMarketplace } from '@/hooks/useMarketplace';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-// Mock indexer and contract
-jest.mock('@/lib/indexer', () => ({
-  fetchListings: jest.fn().mockResolvedValue({ listings: [
-    { listing_id: 1, created_at: 1, status: 'Active', metadata_cid: 'Qm1', price: 10000000n, artist: 'A' }
-  ], total: 1 }),
-}));
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetAllListings = jest.fn();
+const mockGetListing = jest.fn();
+const mockGetArtistListings = jest.fn();
+const mockCreateListing = jest.fn();
+const mockBuyArtwork = jest.fn();
+const mockCancelListing = jest.fn();
+const mockUpdateListing = jest.fn();
+const mockGetAuction = jest.fn();
+const mockPlaceBid = jest.fn();
 
 jest.mock('@/lib/contract', () => ({
-  getAllListings: jest.fn().mockResolvedValue([]),
+  getAllListings: (...args: unknown[]) => mockGetAllListings(...args),
+  getListing: (...args: unknown[]) => mockGetListing(...args),
+  getArtistListings: (...args: unknown[]) => mockGetArtistListings(...args),
+  createListing: (...args: unknown[]) => mockCreateListing(...args),
+  buyArtwork: (...args: unknown[]) => mockBuyArtwork(...args),
+  cancelListing: (...args: unknown[]) => mockCancelListing(...args),
+  updateListing: (...args: unknown[]) => mockUpdateListing(...args),
+  getAuction: (...args: unknown[]) => mockGetAuction(...args),
+  placeBid: (...args: unknown[]) => mockPlaceBid(...args),
+  stroopsToXlm: (_v: bigint) => '1',
 }));
 
-function TestComponent() {
-  const { listings, isLoading } = useMarketplace();
-  return (
-    <div>
-      <span data-testid="count">{listings.length}</span>
-      <span data-testid="loading">{isLoading ? '1' : '0'}</span>
-    </div>
-  );
+jest.mock('@/lib/indexer', () => ({
+  fetchListings: jest.fn().mockResolvedValue({ listings: [], total: 0 }),
+}));
+
+jest.mock('@/lib/config', () => ({
+  config: { indexerUrl: '' },
+}));
+
+jest.mock('@/lib/ipfs', () => ({
+  uploadImageToIPFS: jest.fn().mockResolvedValue({ cid: 'QmImage' }),
+  uploadMetadataToIPFS: jest.fn().mockResolvedValue({ cid: 'QmMeta' }),
+}));
+
+jest.mock('@/lib/errors', () => ({
+  getReadableErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+jest.mock('@/lib/token-support', () => ({
+  assertSupportedTokenAddress: jest.fn().mockResolvedValue({ address: 'CTOKEN', code: 'XLM' }),
+}));
+
+jest.mock('@/hooks/useTransientErrorToast', () => ({
+  useTransientErrorToast: jest.fn(),
+}));
+
+jest.mock('@/providers/PostHogProvider', () => ({
+  trackEvent: {
+    listingCreated: jest.fn(),
+    artworkPurchased: jest.fn(),
+    purchaseSuccessful: jest.fn(),
+  },
+}));
+
+import {
+  useMarketplace,
+  useArtistListings,
+  useCreateListing,
+  useBuyArtwork,
+  useCancelListing,
+} from '@/hooks/useMarketplace';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+function makeListing(id: number) {
+  return {
+    listing_id: id,
+    artist: 'GARTIST',
+    metadata_cid: 'Qm',
+    price: 10_000_000n,
+    currency: 'XLM',
+    token: 'CTOKEN',
+    recipients: [],
+    status: 'Active',
+    owner: null,
+    created_at: id * 100,
+    original_creator: 'GARTIST',
+    royalty_bps: 500,
+  };
 }
 
-describe('useMarketplace hook', () => {
+// ── useMarketplace ────────────────────────────────────────────────────────────
+
+describe('useMarketplace', () => {
+  beforeEach(() => jest.clearAllMocks());
+
   it('loads listings from the indexer', async () => {
-    render(<TestComponent />);
+    const { fetchListings } = jest.requireMock('@/lib/indexer');
+    fetchListings.mockResolvedValueOnce({
+      listings: [makeListing(1)],
+      total: 1,
+    });
+
+    function Comp() {
+      const { listings, isLoading } = useMarketplace();
+      return (
+        <div>
+          <span data-testid="count">{listings.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
     await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+  });
+
+  it('falls back to on-chain when indexer returns empty', async () => {
+    const { fetchListings } = jest.requireMock('@/lib/indexer');
+    fetchListings.mockResolvedValueOnce({ listings: [], total: 0 });
+    mockGetAllListings.mockResolvedValueOnce([makeListing(1), makeListing(2)]);
+
+    function Comp() {
+      const { listings } = useMarketplace();
+      return <span data-testid="count">{listings.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+
+  it('falls back to on-chain when indexer throws', async () => {
+    const { fetchListings } = jest.requireMock('@/lib/indexer');
+    fetchListings.mockRejectedValueOnce(new Error('indexer down'));
+    mockGetAllListings.mockResolvedValueOnce([makeListing(5)]);
+
+    function Comp() {
+      const { listings } = useMarketplace();
+      return <span data-testid="count">{listings.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+  });
+
+  it('sets error when both indexer and on-chain fail', async () => {
+    const { fetchListings } = jest.requireMock('@/lib/indexer');
+    fetchListings.mockRejectedValueOnce(new Error('indexer down'));
+    mockGetAllListings.mockRejectedValueOnce(new Error('chain down'));
+
+    function Comp() {
+      const { error } = useMarketplace();
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+
+  it('sorts listings by created_at descending', async () => {
+    const { fetchListings } = jest.requireMock('@/lib/indexer');
+    fetchListings.mockResolvedValueOnce({
+      listings: [makeListing(1), makeListing(3), makeListing(2)],
+      total: 3,
+    });
+
+    function Comp() {
+      const { listings } = useMarketplace();
+      return <span data-testid="ids">{listings.map((l) => l.listing_id).join(',')}</span>;
+    }
+    render(<Comp />);
+    // sorted desc by created_at (id * 100): 3 > 2 > 1
+    await waitFor(() =>
+      expect(screen.getByTestId('ids').textContent).toBe('3,2,1')
+    );
+  });
+});
+
+// ── useArtistListings ─────────────────────────────────────────────────────────
+
+describe('useArtistListings', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when publicKey is null', () => {
+    function Comp() {
+      const { listings, isLoading } = useArtistListings(null);
+      return (
+        <div>
+          <span data-testid="count">{listings.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('fetches listings for an artist', async () => {
+    mockGetArtistListings.mockResolvedValueOnce([1, 2]);
+    mockGetListing
+      .mockResolvedValueOnce(makeListing(1))
+      .mockResolvedValueOnce(makeListing(2));
+
+    function Comp() {
+      const { listings } = useArtistListings('GARTIST');
+      return <span data-testid="count">{listings.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+});
+
+// ── useCreateListing ──────────────────────────────────────────────────────────
+
+describe('useCreateListing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns null when publicKey is null', async () => {
+    function Comp() {
+      const { create } = useCreateListing(null);
+      const [result, setResult] = React.useState<number | null | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await create({
+            title: 'T', description: 'D', artistName: 'A',
+            year: '2024', category: 'C',
+            imageFile: new File([], 'f.png'),
+            price: 10, tokenAddress: 'CTOKEN', royaltyBps: 500,
+          }))}>c</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('null'));
+  });
+
+  it('creates a listing and returns id on success', async () => {
+    mockCreateListing.mockResolvedValueOnce(99);
+
+    function Comp() {
+      const { create, error } = useCreateListing('GARTIST');
+      const [result, setResult] = React.useState<number | null | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await create({
+            title: 'T', description: 'D', artistName: 'A',
+            year: '2024', category: 'C',
+            imageFile: new File([], 'f.png'),
+            price: 10, tokenAddress: 'CTOKEN', royaltyBps: 500,
+          }))}>c</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).not.toBe('undefined'));
+    // If the result is still null, output the error for debugging
+    expect(screen.getByTestId('result').textContent).toBe('99');
+  });
+});
+
+// ── useBuyArtwork ─────────────────────────────────────────────────────────────
+
+describe('useBuyArtwork', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false when publicKey is null', async () => {
+    function Comp() {
+      const { buy } = useBuyArtwork(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await buy(1))}>b</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls buyArtwork and returns true on success', async () => {
+    mockGetListing.mockResolvedValueOnce(makeListing(7));
+    mockBuyArtwork.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { buy } = useBuyArtwork('GBUYER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await buy(7))}>b</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockBuyArtwork).toHaveBeenCalledWith('GBUYER', 7);
+  });
+
+  it('returns false and sets error when buy fails', async () => {
+    mockGetListing.mockResolvedValueOnce(makeListing(7));
+    mockBuyArtwork.mockRejectedValueOnce(new Error('insufficient funds'));
+
+    function Comp() {
+      const { buy, error } = useBuyArtwork('GBUYER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await buy(7))}>b</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+    expect(screen.getByTestId('error').textContent).not.toBe('none');
+  });
+});
+
+// ── useCancelListing ──────────────────────────────────────────────────────────
+
+describe('useCancelListing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false when publicKey is null', async () => {
+    function Comp() {
+      const { cancel } = useCancelListing(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await cancel(1))}>c</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls cancelListing and returns true on success', async () => {
+    mockCancelListing.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { cancel } = useCancelListing('GARTIST');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await cancel(3))}>c</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockCancelListing).toHaveBeenCalledWith('GARTIST', 3);
   });
 });

--- a/frontend/afristore-app/src/__tests__/useOffers.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useOffers.test.tsx
@@ -1,0 +1,359 @@
+/**
+ * Unit tests for useOffers.ts hooks.
+ */
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetOffer = jest.fn();
+const mockGetOffererOffers = jest.fn();
+const mockGetListingOffers = jest.fn();
+const mockGetArtistListings = jest.fn();
+const mockGetListing = jest.fn();
+const mockWithdrawOffer = jest.fn();
+const mockAcceptOffer = jest.fn();
+const mockRejectOffer = jest.fn();
+const mockMakeOffer = jest.fn();
+
+jest.mock('@/lib/contract', () => ({
+  getOffer: (...args: unknown[]) => mockGetOffer(...args),
+  getOffererOffers: (...args: unknown[]) => mockGetOffererOffers(...args),
+  getListingOffers: (...args: unknown[]) => mockGetListingOffers(...args),
+  getArtistListings: (...args: unknown[]) => mockGetArtistListings(...args),
+  getListing: (...args: unknown[]) => mockGetListing(...args),
+  withdrawOffer: (...args: unknown[]) => mockWithdrawOffer(...args),
+  acceptOffer: (...args: unknown[]) => mockAcceptOffer(...args),
+  rejectOffer: (...args: unknown[]) => mockRejectOffer(...args),
+  makeOffer: (...args: unknown[]) => mockMakeOffer(...args),
+}));
+
+jest.mock('@/lib/errors', () => ({
+  getReadableErrorMessage: (_e: unknown, fallback: string) => fallback,
+}));
+
+jest.mock('@/hooks/useTransientErrorToast', () => ({
+  useTransientErrorToast: jest.fn(),
+}));
+
+import {
+  useOffererOffers,
+  useListingOffers,
+  useIncomingOffers,
+  useWithdrawOffer,
+  useAcceptOffer,
+  useRejectOffer,
+  useMakeOffer,
+} from '@/hooks/useOffers';
+
+function makeOffer(id: number) {
+  return {
+    offer_id: id,
+    listing_id: 1,
+    offerer: 'GOFFERER',
+    amount: 5_000_000n,
+    token: 'CTOKEN',
+    status: 'Pending',
+    created_at: 1000,
+  };
+}
+
+function makeListing(id: number) {
+  return {
+    listing_id: id,
+    artist: 'GARTIST',
+    status: 'Active',
+    price: 10_000_000n,
+    metadata_cid: 'Qm',
+  };
+}
+
+// ── useOffererOffers ──────────────────────────────────────────────────────────
+
+describe('useOffererOffers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when publicKey is null', () => {
+    function Comp() {
+      const { offers, isLoading } = useOffererOffers(null);
+      return (
+        <div>
+          <span data-testid="count">{offers.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('loads and enriches offers with listing data', async () => {
+    mockGetOffererOffers.mockResolvedValueOnce([10, 11]);
+    mockGetOffer
+      .mockResolvedValueOnce(makeOffer(10))
+      .mockResolvedValueOnce(makeOffer(11));
+    mockGetListing.mockResolvedValue(makeListing(1));
+
+    function Comp() {
+      const { offers } = useOffererOffers('GOFFERER');
+      return <span data-testid="count">{offers.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+
+  it('sets error when fetch fails', async () => {
+    mockGetOffererOffers.mockRejectedValueOnce(new Error('fail'));
+
+    function Comp() {
+      const { error } = useOffererOffers('GOFFERER');
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+});
+
+// ── useListingOffers ──────────────────────────────────────────────────────────
+
+describe('useListingOffers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when listingId is null', () => {
+    function Comp() {
+      const { offers, isLoading } = useListingOffers(null);
+      return (
+        <div>
+          <span data-testid="count">{offers.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('fetches offers for a listing', async () => {
+    mockGetListingOffers.mockResolvedValueOnce([5, 6]);
+    mockGetOffer
+      .mockResolvedValueOnce(makeOffer(5))
+      .mockResolvedValueOnce(makeOffer(6));
+
+    function Comp() {
+      const { offers } = useListingOffers(1);
+      return <span data-testid="count">{offers.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+});
+
+// ── useIncomingOffers ─────────────────────────────────────────────────────────
+
+describe('useIncomingOffers', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when ownerPublicKey is null', () => {
+    function Comp() {
+      const { offersByListing } = useIncomingOffers(null);
+      return <span data-testid="count">{offersByListing.length}</span>;
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+  });
+
+  it('fetches offers for all active listings of the owner', async () => {
+    mockGetArtistListings.mockResolvedValueOnce([1]);
+    mockGetListing.mockResolvedValueOnce(makeListing(1));
+    mockGetListingOffers.mockResolvedValueOnce([7]);
+    mockGetOffer.mockResolvedValueOnce(makeOffer(7));
+
+    function Comp() {
+      const { offersByListing } = useIncomingOffers('GOWNER');
+      return <span data-testid="count">{offersByListing.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+  });
+});
+
+// ── useWithdrawOffer ──────────────────────────────────────────────────────────
+
+describe('useWithdrawOffer', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false when publicKey is null', async () => {
+    function Comp() {
+      const { withdraw } = useWithdrawOffer(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await withdraw(1))}>w</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls withdrawOffer and returns true on success', async () => {
+    mockWithdrawOffer.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { withdraw } = useWithdrawOffer('GPUBLICKEY');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await withdraw(3))}>w</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockWithdrawOffer).toHaveBeenCalledWith('GPUBLICKEY', 3);
+  });
+});
+
+// ── useAcceptOffer ────────────────────────────────────────────────────────────
+
+describe('useAcceptOffer', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false when publicKey is null', async () => {
+    function Comp() {
+      const { accept } = useAcceptOffer(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await accept(1))}>a</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls acceptOffer and returns true on success', async () => {
+    mockAcceptOffer.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { accept } = useAcceptOffer('GARTIST');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await accept(5))}>a</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockAcceptOffer).toHaveBeenCalledWith('GARTIST', 5);
+  });
+});
+
+// ── useRejectOffer ────────────────────────────────────────────────────────────
+
+describe('useRejectOffer', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls rejectOffer and returns true on success', async () => {
+    mockRejectOffer.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { reject } = useRejectOffer('GARTIST');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await reject(8))}>r</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockRejectOffer).toHaveBeenCalledWith('GARTIST', 8);
+  });
+
+  it('sets error and returns false on failure', async () => {
+    mockRejectOffer.mockRejectedValueOnce(new Error('reject failed'));
+
+    function Comp() {
+      const { reject, error } = useRejectOffer('GARTIST');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await reject(8))}>r</button>
+          <span data-testid="result">{String(result)}</span>
+          <span data-testid="error">{error ?? 'none'}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+    expect(screen.getByTestId('error').textContent).not.toBe('none');
+  });
+});
+
+// ── useMakeOffer ──────────────────────────────────────────────────────────────
+
+describe('useMakeOffer', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns false when publicKey is null', async () => {
+    function Comp() {
+      const { make } = useMakeOffer(null);
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await make(1, 5, 'CTOKEN'))}>m</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('false'));
+  });
+
+  it('calls makeOffer and returns true on success', async () => {
+    mockMakeOffer.mockResolvedValueOnce(undefined);
+
+    function Comp() {
+      const { make } = useMakeOffer('GBIDDER');
+      const [result, setResult] = React.useState<boolean | undefined>(undefined);
+      return (
+        <div>
+          <button onClick={async () => setResult(await make(2, 3, 'CTOKEN'))}>m</button>
+          <span data-testid="result">{String(result)}</span>
+        </div>
+      );
+    }
+    const user = userEvent.setup();
+    render(<Comp />);
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => expect(screen.getByTestId('result').textContent).toBe('true'));
+    expect(mockMakeOffer).toHaveBeenCalledWith('GBIDDER', 2, 3, 'CTOKEN');
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useUserActivity.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useUserActivity.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Unit tests for useUserActivity.ts
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetWalletActivity = jest.fn();
+const mockGetRoyaltyStats = jest.fn();
+const mockGetListingActivity = jest.fn();
+
+jest.mock('@/lib/indexer', () => ({
+  getWalletActivity: (...args: unknown[]) => mockGetWalletActivity(...args),
+  getRoyaltyStats: (...args: unknown[]) => mockGetRoyaltyStats(...args),
+  getListingActivity: (...args: unknown[]) => mockGetListingActivity(...args),
+}));
+
+import { useUserActivity, useListingActivity } from '@/hooks/useUserActivity';
+
+function makeActivity(id: string) {
+  return {
+    id,
+    type: 'PURCHASE' as const,
+    listing_id: 1,
+    title: 'Test',
+    price: '10',
+    timestamp: 1000,
+    from: 'GA',
+    to: 'GB',
+    tx_hash: '0xabc',
+  };
+}
+
+// ── useUserActivity ───────────────────────────────────────────────────────────
+
+describe('useUserActivity', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when publicKey is null', () => {
+    function Comp() {
+      const { activities, isLoading } = useUserActivity(null);
+      return (
+        <div>
+          <span data-testid="count">{activities.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('loads activities and royalty stats', async () => {
+    mockGetWalletActivity.mockResolvedValueOnce([
+      makeActivity('1'),
+      makeActivity('2'),
+    ]);
+    mockGetRoyaltyStats.mockResolvedValueOnce({
+      totalEarned: '500',
+      payoutCount: 3,
+      lastPayout: 9999,
+    });
+
+    function Comp() {
+      const { activities, royaltyStats } = useUserActivity('GPUBKEY');
+      return (
+        <div>
+          <span data-testid="count">{activities.length}</span>
+          <span data-testid="earned">{royaltyStats?.totalEarned ?? 'null'}</span>
+          <span data-testid="payouts">{royaltyStats?.payoutCount ?? 0}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+    expect(screen.getByTestId('earned').textContent).toBe('500');
+    expect(screen.getByTestId('payouts').textContent).toBe('3');
+  });
+
+  it('sets error when fetch fails', async () => {
+    mockGetWalletActivity.mockRejectedValueOnce(new Error('network error'));
+    mockGetRoyaltyStats.mockRejectedValueOnce(new Error('network error'));
+
+    function Comp() {
+      const { error } = useUserActivity('GPUBKEY');
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+
+  it('refresh re-fetches data', async () => {
+    mockGetWalletActivity
+      .mockResolvedValueOnce([makeActivity('a')])
+      .mockResolvedValueOnce([makeActivity('a'), makeActivity('b')]);
+    mockGetRoyaltyStats
+      .mockResolvedValue({ totalEarned: '100', payoutCount: 1, lastPayout: 0 });
+
+    let refreshFn: () => void;
+    function Comp() {
+      const { activities, refresh } = useUserActivity('GPUBKEY');
+      refreshFn = refresh;
+      return <span data-testid="count">{activities.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+
+    await act(async () => { refreshFn(); });
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+});
+
+// ── useListingActivity ────────────────────────────────────────────────────────
+
+describe('useListingActivity', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('does nothing when listingId is null', () => {
+    function Comp() {
+      const { activities, isLoading } = useListingActivity(null);
+      return (
+        <div>
+          <span data-testid="count">{activities.length}</span>
+          <span data-testid="loading">{String(isLoading)}</span>
+        </div>
+      );
+    }
+    render(<Comp />);
+    expect(screen.getByTestId('count').textContent).toBe('0');
+    expect(screen.getByTestId('loading').textContent).toBe('false');
+  });
+
+  it('loads activities for a listing', async () => {
+    mockGetListingActivity.mockResolvedValueOnce([
+      makeActivity('ev1'),
+      makeActivity('ev2'),
+      makeActivity('ev3'),
+    ]);
+
+    function Comp() {
+      const { activities } = useListingActivity(5);
+      return <span data-testid="count">{activities.length}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('3'));
+    expect(mockGetListingActivity).toHaveBeenCalledWith(5);
+  });
+
+  it('sets error when fetch fails', async () => {
+    mockGetListingActivity.mockRejectedValueOnce(new Error('fail'));
+
+    function Comp() {
+      const { error } = useListingActivity(7);
+      return <span data-testid="error">{error ?? 'none'}</span>;
+    }
+    render(<Comp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+
+  it('re-fetches when listingId changes', async () => {
+    mockGetListingActivity
+      .mockResolvedValueOnce([makeActivity('a')])
+      .mockResolvedValueOnce([makeActivity('b'), makeActivity('c')]);
+
+    function Comp({ id }: { id: number }) {
+      const { activities } = useListingActivity(id);
+      return <span data-testid="count">{activities.length}</span>;
+    }
+    const { rerender } = render(<Comp id={1} />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('1'));
+
+    rerender(<Comp id={2} />);
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'));
+  });
+});

--- a/frontend/afristore-app/src/__tests__/useWallet.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useWallet.test.tsx
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for useWallet.ts (Freighter adapter).
+ * Tests the hook via useFreighterWallet since that is what useWallet
+ * delegates to in non-e2e mode.
+ */
+import React from 'react';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockIsFreighterInstalled = jest.fn();
+const mockGetConnectedPublicKey = jest.fn();
+const mockConnectFreighter = jest.fn();
+
+jest.mock('@/lib/freighter', () => ({
+  isFreighterInstalled: (...args: unknown[]) => mockIsFreighterInstalled(...args),
+  getConnectedPublicKey: (...args: unknown[]) => mockGetConnectedPublicKey(...args),
+  connectFreighter: (...args: unknown[]) => mockConnectFreighter(...args),
+}));
+
+jest.mock('@/lib/config', () => ({
+  config: {
+    networkPassphrase: 'Test SDF Network ; September 2015',
+    network: 'testnet',
+  },
+}));
+
+jest.mock('@/providers/PostHogProvider', () => ({
+  trackEvent: {
+    walletConnected: jest.fn(),
+    walletConnectionDropOff: jest.fn(),
+  },
+}));
+
+// Force e2e mock chain to be off so useWallet delegates to Freighter
+jest.mock('@/lib/e2e-chain-mock', () => ({
+  isE2eMockChain: () => false,
+}));
+
+jest.mock('@/hooks/useE2eWallet', () => ({
+  useE2eWallet: () => ({
+    publicKey: null,
+    networkPassphrase: null,
+    status: 'DISCONNECTED',
+    isInstalled: false,
+    isConnecting: false,
+    isConnected: false,
+    isWrongNetwork: false,
+    error: null,
+    connect: jest.fn(),
+    disconnect: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
+import { useWallet } from '@/hooks/useWallet';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function WalletComp() {
+  const { status, publicKey, isConnected, isInstalled, error, connect, disconnect, refresh } =
+    useWallet();
+  return (
+    <div>
+      <span data-testid="status">{status}</span>
+      <span data-testid="key">{publicKey ?? 'null'}</span>
+      <span data-testid="connected">{String(isConnected)}</span>
+      <span data-testid="installed">{String(isInstalled)}</span>
+      <span data-testid="error">{error ?? 'none'}</span>
+      <button data-testid="connect" onClick={connect}>connect</button>
+      <button data-testid="disconnect" onClick={disconnect}>disconnect</button>
+      <button data-testid="refresh" onClick={refresh}>refresh</button>
+    </div>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useWallet (Freighter)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('shows NOT_INSTALLED when Freighter is absent', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(false);
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('NOT_INSTALLED')
+    );
+    expect(screen.getByTestId('installed').textContent).toBe('false');
+  });
+
+  it('auto-detects existing connection on mount', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue('GEXISTING');
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('key').textContent).toBe('GEXISTING')
+    );
+  });
+
+  it('shows DISCONNECTED when Freighter installed but not connected', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue(null);
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+    expect(screen.getByTestId('connected').textContent).toBe('false');
+  });
+
+  it('connect sets publicKey and shows CONNECTED on success', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue(null);
+    mockConnectFreighter.mockResolvedValue({
+      publicKey: 'GNEWKEY',
+      networkPassphrase: 'Test SDF Network ; September 2015',
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('connect'));
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('CONNECTED')
+    );
+    expect(screen.getByTestId('key').textContent).toBe('GNEWKEY');
+  });
+
+  it('connect sets error on wrong network', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue(null);
+    mockConnectFreighter.mockResolvedValue({
+      publicKey: 'GWRONGNET',
+      networkPassphrase: 'Public Global Stellar Network ; September 2015',
+    });
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('connect'));
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+    expect(screen.getByTestId('status').textContent).toBe('WRONG_NETWORK');
+  });
+
+  it('connect sets error when user denies', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue(null);
+    mockConnectFreighter.mockRejectedValue(new Error('User denied'));
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('status').textContent).toBe('DISCONNECTED')
+    );
+
+    await user.click(screen.getByTestId('connect'));
+    await waitFor(() =>
+      expect(screen.getByTestId('error').textContent).not.toBe('none')
+    );
+  });
+
+  it('disconnect clears publicKey', async () => {
+    mockIsFreighterInstalled.mockResolvedValue(true);
+    mockGetConnectedPublicKey.mockResolvedValue('GEXISTING');
+
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    render(<WalletComp />);
+    await waitFor(() =>
+      expect(screen.getByTestId('key').textContent).toBe('GEXISTING')
+    );
+
+    await user.click(screen.getByTestId('disconnect'));
+    await waitFor(() =>
+      expect(screen.getByTestId('key').textContent).toBe('null')
+    );
+  });
+});


### PR DESCRIPTION
## Description

**Resolves Issue:** Closes #221 , Closes #222 , Closes #223 , Closes #224 

This PR addresses four open test-coverage issues across the frontend and the `collection_nft_erc721` smart contract.

---

### #221 — Fix pre-existing `ListingCard.test.tsx` failure

`ListingCard` now opens a `CheckoutModal` on "Buy Now" click instead of invoking `buy()` directly. The test at line 192 expected `mockBuy(7)` to be called immediately, which caused it to fail.

**Fix:** A `CheckoutModal` mock was added to the test file that renders a "Confirm Purchase" button when `isOpen=true` and calls `onCryptoPurchase` on click. The buy-click test was updated to: click "Buy Now" → wait for modal → click confirm → assert `mockBuy(7)` was called.

---

### #222 — Unit tests for 7 core hooks

New test files covering all async logic, error states, and edge cases:

| File | Hooks tested |
|------|-------------|
| `useAuctions.test.tsx` | `useAuctions`, `useArtistAuctions`, `useCreateAuction`, `usePlaceBid`, `useFinalizeAuction` |
| `useOffers.test.tsx` | `useOffererOffers`, `useListingOffers`, `useIncomingOffers`, `useWithdrawOffer`, `useAcceptOffer`, `useRejectOffer`, `useMakeOffer` |
| `useAdmin.test.tsx` | `useAdminStats`, `useModeration`, `useTokenManagement`, `useAdminCheck` |
| `useMagicWallet.test.tsx` | `useMagicWallet` (all status transitions, email/passkey login, logout, refresh) |
| `useUserActivity.test.tsx` | `useUserActivity`, `useListingActivity` |
| `useWallet.test.tsx` | `useWallet` / `useFreighterWallet` (install detection, connect, disconnect, wrong network) |
| `useMarketplace.test.tsx` | `useMarketplace`, `useArtistListings`, `useCreateListing`, `useBuyArtwork`, `useCancelListing` (expanded from 1 to 14 tests) |

---

### #223 — Component tests for 8 UI components

New/expanded test files:

| File | Tests |
|------|-------|
| `CheckoutModal.test.tsx` | Visibility, price display, crypto purchase success/failure, fiat payment flow, card input validation, success/error states (expanded from 1 to 15 tests) |
| `MagicWalletModal.test.tsx` | Open/close, email form, passkey login, error display |
| `SearchFilter.test.tsx` | Search input, status filters, sort toggle, result count, clear filters |
| `WalletGuard.test.tsx` | Connected/disconnected rendering, custom fallback, modal trigger |
| `BiddingPanel.test.tsx` | Reserve price, bid input, place bid, finalize, status badges |
| `CollectionForm.test.tsx` | Form fields, deploy call, success state with address |
| `ConnectWalletModal.test.tsx` | Freighter button, error display, coming-soon Magic badge |

---

### #224 — Expanded `collection_nft_erc721` contract tests

The suite grew from 3 tests (TTL-only) to **31 tests**. New coverage:

- **Query functions:** `name`, `symbol`, `total_supply`, `max_supply`, `balance_of`, `royalty_info`, `next_token_id`
- **Minting:** supply/balance increments, `owner_of` / `token_uri` correctness, multi-recipient balance tracking
- **Max supply enforcement:** mint fails with `MaxSupplyReached` error; cannot re-initialize
- **Transfers:** ownership + balance updates, non-owner rejection, approval clearing on transfer, `transfer_from` by approved spender and operator, `transfer_from` failure without approval
- **Approvals:** `approve` sets/returns single-token approval, non-owner approve rejected, `set_approval_for_all` toggle, operator can approve on behalf of owner
- **Burns:** supply/balance decrement, token deletion, non-owner rejection, approved spender burn, operator burn, nonexistent token burn

---

## Soroban Safety Checklist
- [x] **TTL Extensions:** No persistent storage changes — existing TTL behaviour is unchanged.
- [x] **Instance TTL:** Not modified — tests only.
- [x] **Authorization:** Not modified — tests only.
- [x] **Gas Efficiency:** Not modified — tests only.
- [x] **State Bloat:** Not modified — tests only.
- [x] **Signature Security:** N/A — tests only.
- [x] **Front-Running Protection:** N/A — tests only.
- [x] **Error Handling:** N/A — tests only.

## Testing
- [x] I have added unit tests to cover my changes and tested edge cases.
- [x] All tests pass locally (`cargo test` for contracts; `npm run test` for frontend — pre-existing failures in `listings.test.tsx`, `ListingForm.test.tsx`, and `dummy.spec.ts` were already failing on `master` before this branch).

## Additional Context

- All external dependencies (blockchain, IPFS, Magic SDK, PostHog) are fully mocked; no network calls in any test.
- The pre-existing failures (`listings.test.tsx` renders with missing context, `ListingForm.test.tsx` file-input assertion, `dummy.spec.ts` Playwright import) are unrelated to these issues and were present on `master`.
