### PR TITLE
feat: Protection against duplicate events

### DIFF
--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -75,6 +75,7 @@ model MarketplaceEvent {
   ledgerTimestamp DateTime @default(now())
   @@index([actor])
   @@index([eventType])
+  @@unique([listingId, eventType, ledgerSequence])
 }
 
 model Collection {

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -150,6 +150,7 @@ export async function startPolling() {
         console.log(`Found ${response.events.length} new events since ledger ${syncState.lastLedger}`);
 
         let maxLedger = syncState.lastLedger;
+        const decodedEvents: any[] = [];
 
         for (const event of response.events) {
           // Topics in v14 are ScVal, need to convert to strings (symbol or other)
@@ -163,9 +164,7 @@ export async function startPolling() {
             typeof event.value === 'string' ? event.value : event.value.toXDR('base64'),
             event.ledger
           );
-          if (decoded) {
-            await processEvent(decoded);
-          }
+          if (decoded) decodedEvents.push(decoded);
           if (event.ledger > maxLedger) maxLedger = event.ledger;
         }
 
@@ -183,18 +182,58 @@ export async function startPolling() {
           console.error(`Failed to fetch hash for ledger ${maxLedger}:`, err);
         }
 
-        // Persist the new cursor with the ledger hash for continuity validation
-        const updatedState = await prisma.syncState.update({
-          where: { id: 1 },
-          data: {
-            lastLedger: maxLedger,
-            lastLedgerHash: latestHash,
-          },
+        // Write events + state updates atomically. We first detect which events are new,
+        // insert them with createMany(skipDuplicates), then apply state updates only for new events.
+        const { updatedState, newEvents } = await prisma.$transaction(async (tx) => {
+          const conditions = decodedEvents.map((e) => ({
+            listingId: e.listingId ?? null,
+            eventType: e.eventType,
+            ledgerSequence: e.ledgerSequence,
+          }));
+
+          const existing = conditions.length
+            ? await tx.marketplaceEvent.findMany({ where: { OR: conditions }, select: { listingId: true, eventType: true, ledgerSequence: true } })
+            : [];
+
+          const existingSet = new Set(existing.map((e) => `${e.listingId ?? 'null'}|${e.eventType}|${e.ledgerSequence}`));
+
+          const toInsert = decodedEvents.filter((e) => !existingSet.has(`${e.listingId ?? 'null'}|${e.eventType}|${e.ledgerSequence}`));
+
+          if (toInsert.length > 0) {
+            await tx.marketplaceEvent.createMany({
+              data: toInsert.map((ev) => ({
+                listingId: ev.listingId,
+                eventType: ev.eventType,
+                actor: ev.actor,
+                data: ev.data,
+                ledgerSequence: ev.ledgerSequence,
+              })),
+              skipDuplicates: true,
+            });
+
+            // Apply state updates for newly-inserted events inside the same transaction
+            for (const ev of toInsert) {
+              await processEvent(ev, tx, true);
+            }
+          }
+
+          const updated = await tx.syncState.update({
+            where: { id: 1 },
+            data: {
+              lastLedger: maxLedger,
+              lastLedgerHash: latestHash,
+            },
+          });
+
+          return { updatedState: updated, newEvents: toInsert };
         });
 
         latestLedgerProcessedGauge.set(updatedState.lastLedger);
         networkLatestLedgerGauge.set(networkLatestLedger);
         syncLatencyGauge.set(Math.max(0, networkLatestLedger - updatedState.lastLedger));
+
+        // Emit SSEs for events that were actually newly applied
+        for (const ev of newEvents) emitSSEEvent(ev);
       } else if (response.latestLedger && response.latestLedger > syncState.lastLedger) {
         // If there are no events but the network has advanced, we can catch up the syncState
         // so we don't scan empty ranges repeatedly. Fetch the hash for the latest ledger.
@@ -255,19 +294,22 @@ async function fetchAuctionFromChain(_auctionId: bigint): Promise<any | null> {
   return null;
 }
 
-export async function processEvent(event: any) {
+export async function processEvent(event: any, tx?: any, skipInsert = false) {
   const { eventType, listingId, actor, ledgerSequence, data } = event;
 
-  // 1. Log to MarketplaceEvent history
-  await prisma.marketplaceEvent.create({
-    data: {
-      listingId,
-      eventType,
-      actor,
-      ledgerSequence,
-      data,
-    },
-  });
+  const db = tx ?? prisma;
+
+  if (!skipInsert) {
+    await db.marketplaceEvent.create({
+      data: {
+        listingId,
+        eventType,
+        actor,
+        ledgerSequence,
+        data,
+      },
+    });
+  }
 
   // 2. Handle deploy events (no listingId — collection deployments)
   if (eventType === 'DEPLOY_NORMAL_721' || eventType === 'DEPLOY_NORMAL_1155' ||
@@ -282,7 +324,7 @@ export async function processEvent(event: any) {
     const creatorAddr  = rawData[0]?.toString() || actor;
     const contractAddr = rawData[1]?.toString() || '';
     if (contractAddr) {
-      await prisma.collection.upsert({
+      await db.collection.upsert({
         where: { contractAddress: contractAddr },
         create: {
           contractAddress: contractAddr,
@@ -328,7 +370,7 @@ export async function processEvent(event: any) {
           }))
         : [];
 
-      await prisma.listing.upsert({
+      await db.listing.upsert({
         where: { listingId },
         create: {
           listingId,
@@ -359,7 +401,7 @@ export async function processEvent(event: any) {
     }
 
     case 'LISTING_UPDATED':
-      await prisma.listing.update({
+      await db.listing.update({
         where: { listingId },
         data: {
           price: data.new_price,
@@ -370,7 +412,7 @@ export async function processEvent(event: any) {
       break;
 
     case 'ARTWORK_SOLD':
-      await prisma.listing.update({
+      await db.listing.update({
         where: { listingId },
         data: {
           status: 'Sold',
@@ -381,7 +423,7 @@ export async function processEvent(event: any) {
       break;
 
     case 'LISTING_CANCELLED':
-      await prisma.listing.update({
+      await db.listing.update({
         where: { listingId },
         data: {
           status: 'Cancelled',
@@ -414,7 +456,7 @@ export async function processEvent(event: any) {
           }))
         : [];
 
-      await prisma.auction.upsert({
+      await db.auction.upsert({
         where: { auctionId: listingId },
         create: {
           auctionId: listingId,
@@ -449,7 +491,7 @@ export async function processEvent(event: any) {
     }
 
     case 'BID_PLACED': {
-      await prisma.auction.update({
+      await db.auction.update({
         where: { auctionId: listingId },
         data: {
           highestBid: data.bid_amount,
@@ -461,7 +503,7 @@ export async function processEvent(event: any) {
     }
 
     case 'AUCTION_RESOLVED': {
-      await prisma.auction.update({
+      await db.auction.update({
         where: { auctionId: listingId },
         data: {
           status: 'Finalized',
@@ -474,7 +516,7 @@ export async function processEvent(event: any) {
     }
 
     case 'OFFER_MADE': {
-      await prisma.offer.upsert({
+      await db.offer.upsert({
         where: { offerId: BigInt(data.offer_id) },
         create: {
           offerId: BigInt(data.offer_id),
@@ -499,14 +541,14 @@ export async function processEvent(event: any) {
     }
 
     case 'OFFER_ACCEPTED': {
-      await prisma.offer.update({
+      await db.offer.update({
         where: { offerId: BigInt(data.offer_id) },
         data: {
           status: 'Accepted',
           updatedAtLedger: ledgerSequence,
         }
       });
-      await prisma.listing.update({
+      await db.listing.update({
         where: { listingId: BigInt(data.listing_id) },
         data: {
           status: 'Sold',
@@ -518,7 +560,7 @@ export async function processEvent(event: any) {
     }
 
     case 'OFFER_REJECTED': {
-      await prisma.offer.update({
+      await db.offer.update({
         where: { offerId: BigInt(data.offer_id) },
         data: {
           status: 'Rejected',
@@ -529,7 +571,7 @@ export async function processEvent(event: any) {
     }
 
     case 'OFFER_WITHDRAWN': {
-      await prisma.offer.update({
+      await db.offer.update({
         where: { offerId: BigInt(data.offer_id) },
         data: {
           status: 'Withdrawn',
@@ -542,5 +584,5 @@ export async function processEvent(event: any) {
   }
 
   // Broadcast to any connected SSE clients after the DB write is complete.
-  emitSSEEvent(event);
+  if (!tx) emitSSEEvent(event);
 }

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -182,8 +182,7 @@ export async function startPolling() {
           console.error(`Failed to fetch hash for ledger ${maxLedger}:`, err);
         }
 
-        // Write events + state updates atomically. We first detect which events are new,
-        // insert them with createMany(skipDuplicates), then apply state updates only for new events.
+    
         const { updatedState, newEvents } = await prisma.$transaction(async (tx) => {
           const conditions = decodedEvents.map((e) => ({
             listingId: e.listingId ?? null,


### PR DESCRIPTION
# Description

closes #238 
No protection against duplicate events.

### The Problem
Previously, events were inserted using a standard `create` call without any uniqueness constraints. If the indexer process crashed *after* inserting events but *before* updating the synchronization state (the `SyncState` ledger pointer), the process would restart, fetch the same ledger range, and re-insert the exact same events, resulting in duplicate database rows.

### The Solution
This PR hardens the ingestion pipeline against crash-loops and duplicate processing by making the event insertion idempotent and coupling it atomically with the `SyncState` update. 

### Changes Proposed
- **Schema Update:** Added a composite unique constraint `@@unique([listingId, eventType, ledgerSequence])` to the `MarketplaceEvent` model in `schema.prisma`.
- **Atomic Processing:** Wrapped the entire batch event insertion and the `SyncState` update inside a single interactive Prisma `$transaction`. If any part of the batch fails, the entire block rolls back.
- **Idempotent Inserts:** Replaced individual `create` calls with a bulk `createMany` utilizing the `skipDuplicates: true` flag. 
- **Optimized Deduplication:** Added an in-memory `existingSet` check to filter out known duplicate events *before* attempting the database write, reducing unnecessary DB load.
- **State Updates:** Refactored `processEvent` to optionally accept a database transaction (`tx`) and a `skipInsert` flag so it can participate in the batch transaction without trying to re-insert the event.

### Checklist
- [x] Add `@@unique([listingId, eventType, ledgerSequence])` to `MarketplaceEvent` model
- [x] Use `createMany` with `skipDuplicates` or upsert pattern
- [x] Wrap event batch in Prisma transaction
- [x] Tested locally to verify crash recovery ignores duplicate events