### PR TITLE
Feat: Validate empty contract_Id

### DIFF
--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -73,7 +73,7 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
 }));
 
-import { processEvent, revertLedgers } from '../poller';
+import { processEvent, revertLedgers, startPolling } from '../poller';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -400,5 +400,13 @@ describe('revertLedgers', () => {
   it('runs all operations inside a single transaction', async () => {
     await revertLedgers(300);
     expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+  });
+});
+
+// ── startPolling validation ───────────────────────────────────────────────────
+
+describe('startPolling', () => {
+  it('throws an error if both CONTRACT_ID and LAUNCHPAD_CONTRACT_ID are empty', async () => {
+    await expect(startPolling()).rejects.toThrow('At least one of MARKETPLACE_CONTRACT_ID or LAUNCHPAD_CONTRACT_ID must be set');
   });
 });

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -66,6 +66,10 @@ export async function revertLedgers(safeAtLedger: number): Promise<void> {
 }
 
 export async function startPolling() {
+  if (!CONTRACT_ID && !LAUNCHPAD_CONTRACT_ID) {
+    throw new Error('At least one of MARKETPLACE_CONTRACT_ID or LAUNCHPAD_CONTRACT_ID must be set');
+  }
+
   console.log(`Starting indexer poller for contract: ${CONTRACT_ID}`);
 
   while (true) {


### PR DESCRIPTION
## Description
closes #245 
**Resolves Issue:** Empty CONTRACT_ID not validated

This PR addresses an issue in the indexer where missing contract IDs caused `.filter(Boolean)` to produce an empty array `[]`. This inadvertently instructed the poller to fetch events for *all* contracts on the Stellar network, leading to performance issues and unnecessary data processing.

**Changes included:**
- Added a validation check at the beginning of `startPolling()` to ensure at least one contract ID is set.
- The poller now immediately halts execution and throws a clear error message (`At least one of MARKETPLACE_CONTRACT_ID or LAUNCHPAD_CONTRACT_ID must be set`) at startup if both variables are missing.
- Added a unit test for `startPolling` to ensure it properly rejects with the expected error when both contract IDs are undefined.


## Testing
- [x] I have added unit tests to cover my changes and tested edge cases.
- [x] All tests pass locally.

## Additional Context
N/A
