### PR TITLE
fix(#233): refresh syncState after window floor DB persist

### DIFF
--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // ── Mock Prisma ───────────────────────────────────────────────────────────────
 
@@ -73,8 +73,7 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
 }));
 
-import { processEvent, revertLedgers, validateHashContinuity } from '../poller';
-import { processEvent, revertLedgers, startPolling } from '../poller';
+import { processEvent, revertLedgers, validateHashContinuity, startPolling } from '../poller';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -440,10 +439,71 @@ describe('validateHashContinuity', () => {
     expect(result).toBe(false);
     // revertLedgers wraps everything in a prisma transaction
     expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+  });
+});
+
 // ── startPolling validation ───────────────────────────────────────────────────
 
 describe('startPolling', () => {
   it('throws an error if both CONTRACT_ID and LAUNCHPAD_CONTRACT_ID are empty', async () => {
     await expect(startPolling()).rejects.toThrow('At least one of MARKETPLACE_CONTRACT_ID or LAUNCHPAD_CONTRACT_ID must be set');
+  });
+});
+
+// ── window floor reset (issue #233) ──────────────────────────────────────────
+
+describe('startPolling — window floor reset', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Ensure CONTRACT_ID is set so startPolling doesn't throw immediately
+    process.env.MARKETPLACE_CONTRACT_ID = 'CTEST';
+  });
+
+  afterEach(() => {
+    delete process.env.MARKETPLACE_CONTRACT_ID;
+  });
+
+  it('fetches events from windowFloor when syncState.lastLedger is too old', async () => {
+    // Network is at ledger 20000; MAX_LEDGER_WINDOW is 17000 → windowFloor = 3000
+    // syncState.lastLedger = 100 → startLedger would be 101, which is < 3000
+    const staleLastLedger = 100;
+    const networkLatest = 20_000;
+    const expectedWindowFloor = networkLatest - 17_000; // 3000
+
+    mockPrisma.syncState.findUnique.mockResolvedValue({
+      id: 1,
+      lastLedger: staleLastLedger,
+      lastLedgerHash: null,
+    });
+    // After the window-floor persist, update returns the new state
+    mockPrisma.syncState.update.mockResolvedValue({
+      id: 1,
+      lastLedger: expectedWindowFloor - 1,
+      lastLedgerHash: null,
+    });
+
+    // Override the SDK Server mock to return a stale-range scenario and then
+    // stop the loop by throwing after the first getEvents call.
+    const { rpc } = await import('@stellar/stellar-sdk');
+    const serverInstance = new rpc.Server('');
+    vi.spyOn(serverInstance, 'getLatestLedger').mockResolvedValue({ sequence: networkLatest } as any);
+    vi.spyOn(serverInstance, 'getEvents').mockImplementationOnce(({ startLedger }: any) => {
+      // Verify the poller used windowFloor, not the stale lastLedger + 1
+      expect(startLedger).toBe(expectedWindowFloor);
+      // Throw to break out of the infinite while loop after one iteration
+      throw new Error('stop-loop');
+    });
+
+    // Run one iteration; it will throw 'stop-loop' which we catch
+    await startPolling().catch((err) => {
+      if (err.message !== 'stop-loop') throw err;
+    });
+
+    // The DB persist for the window-floor reset must have been called
+    expect(mockPrisma.syncState.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ lastLedger: expectedWindowFloor - 1, lastLedgerHash: null }),
+      })
+    );
   });
 });

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -135,10 +135,12 @@ export async function startPolling() {
         });
         startLedger = windowFloor;
         // Persist the reset so future polls don't re-request the stale range.
-        await prisma.syncState.update({
+        const resetState = await prisma.syncState.update({
           where: { id: 1 },
           data: { lastLedger: windowFloor - 1, lastLedgerHash: null },
         });
+
+        syncState = resetState;
       }
 
       const response = await server.getEvents({


### PR DESCRIPTION
- Capture the return value of prisma.syncState.update when resetting to windowFloor and assign it back to syncState so the rest of the current iteration uses the persisted value, not the stale in-memory one.
- Fix duplicate import and unclosed it-block in poller.test.ts.
- Add test: simulate stale ledger range and verify events are fetched from window floor.

Closes #233 