### PR TITLE
fix(#247): restrict CORS to configured origin in production

### DIFF
--- a/indexer/.env.example
+++ b/indexer/.env.example
@@ -11,7 +11,7 @@ STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
 # API
 PORT=4000
 
-# CORS — comma-separated list of allowed frontend origins.
-# Leave unset (or set NODE_ENV != production) for permissive dev mode.
-# Example: ALLOWED_ORIGINS=https://app.afristore.xyz,https://staging.afristore.xyz
-ALLOWED_ORIGINS=
+# CORS — comma-separated list of allowed frontend origins (production only).
+# In development (NODE_ENV != production) all origins are permitted.
+# Example: CORS_ORIGIN=https://app.afristore.xyz,https://staging.afristore.xyz
+CORS_ORIGIN=

--- a/indexer/src/index.ts
+++ b/indexer/src/index.ts
@@ -20,7 +20,12 @@ const limiter = rateLimit({
     message: { error: 'Too many requests, please try again after a minute.' },
 });
 
-app.use(cors());
+app.use(cors({
+    origin: process.env.NODE_ENV === 'production'
+        ? (process.env.CORS_ORIGIN || '').split(',').map(o => o.trim()).filter(Boolean)
+        : true,
+    credentials: true,
+}));
 app.use(express.json());
 app.use(limiter);
 


### PR DESCRIPTION
- Replace app.use(cors()) with an origin-aware config.
- In production (NODE_ENV=production) only origins listed in the CORS_ORIGIN env var (comma-separated) are allowed.
- In all other environments the previous permissive behaviour is kept so local development is unaffected.
- Document CORS_ORIGIN in .env.example.

Closes #247 