### PR TITLE
resolve Soroban compilation constant, indexer crash on out-of-order 

### DIFF
--- a/contracts/soroban-marketplace/src/storage.rs
+++ b/contracts/soroban-marketplace/src/storage.rs
@@ -28,7 +28,7 @@ pub enum DataKey {
 
 pub const LEDGER_TTL_BUMP: u32 = 432_000;
 pub const LEDGER_TTL_THRESHOLD: u32 = 144_000;
-pub const REENTRANCY_LOCK_TTL: u32 = 1;
+pub const REENTRANCY_LOCK_TTL: u32 = 100;
 
 // ── Counter helpers ──────────────────────────────────────────
 

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// Prevent dotenv from loading .env so module-level CONTRACT_ID constants stay empty
+vi.mock('dotenv', () => ({ default: { config: vi.fn() } }));
+
 // ── Mock Prisma ───────────────────────────────────────────────────────────────
 
 const mockTx = vi.hoisted(() => ({
@@ -19,10 +22,12 @@ const mockPrisma = vi.hoisted(() => ({
   listing: {
     upsert: vi.fn().mockResolvedValue({}),
     update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
   auction: {
     upsert: vi.fn().mockResolvedValue({}),
     update: vi.fn().mockResolvedValue({}),
+    updateMany: vi.fn().mockResolvedValue({ count: 1 }),
   },
   offer: {
     upsert: vi.fn().mockResolvedValue({}),
@@ -73,8 +78,7 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
 }));
 
-import { processEvent, revertLedgers, validateHashContinuity } from '../poller';
-import { processEvent, revertLedgers, startPolling } from '../poller';
+import { processEvent, revertLedgers, validateHashContinuity, startPolling } from '../poller';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -146,9 +150,9 @@ describe('processEvent — LISTING_CREATED', () => {
     });
   });
 
-  it('does not call listing.update for LISTING_CREATED', async () => {
+  it('does not call listing.updateMany for LISTING_CREATED', async () => {
     await processEvent(makeEvent('LISTING_CREATED', 1n, 'GA', { artist: 'GA' }, 1));
-    expect(mockPrisma.listing.update).not.toHaveBeenCalled();
+    expect(mockPrisma.listing.updateMany).not.toHaveBeenCalled();
   });
 });
 
@@ -161,8 +165,8 @@ describe('processEvent — LISTING_UPDATED', () => {
     const data = { new_price: '20000000', metadata_cid: 'QmNewCid' };
     await processEvent(makeEvent('LISTING_UPDATED', 5n, '', data, 300));
 
-    expect(mockPrisma.listing.update).toHaveBeenCalledOnce();
-    expect(mockPrisma.listing.update).toHaveBeenCalledWith({
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledOnce();
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledWith({
       where: { listingId: 5n },
       data: expect.objectContaining({
         price: '20000000',
@@ -182,7 +186,7 @@ describe('processEvent — ARTWORK_SOLD', () => {
     const data = { buyer: 'GB_BUYER' };
     await processEvent(makeEvent('ARTWORK_SOLD', 8n, 'GB_BUYER', data, 400));
 
-    expect(mockPrisma.listing.update).toHaveBeenCalledWith({
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledWith({
       where: { listingId: 8n },
       data: expect.objectContaining({ status: 'Sold', owner: 'GB_BUYER' }),
     });
@@ -197,7 +201,7 @@ describe('processEvent — LISTING_CANCELLED', () => {
   it('sets status to Cancelled', async () => {
     await processEvent(makeEvent('LISTING_CANCELLED', 3n, '', {}, 500));
 
-    expect(mockPrisma.listing.update).toHaveBeenCalledWith({
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledWith({
       where: { listingId: 3n },
       data: expect.objectContaining({ status: 'Cancelled' }),
     });
@@ -242,8 +246,8 @@ describe('processEvent — BID_PLACED', () => {
     };
     await processEvent(makeEvent('BID_PLACED', 11n, 'GB_BIDDER', data, 610));
 
-    expect(mockPrisma.auction.update).toHaveBeenCalledOnce();
-    expect(mockPrisma.auction.update).toHaveBeenCalledWith({
+    expect(mockPrisma.auction.updateMany).toHaveBeenCalledOnce();
+    expect(mockPrisma.auction.updateMany).toHaveBeenCalledWith({
       where: { auctionId: 11n },
       data: expect.objectContaining({
         highestBid: '55000000',
@@ -266,8 +270,8 @@ describe('processEvent — AUCTION_RESOLVED', () => {
     };
     await processEvent(makeEvent('AUCTION_RESOLVED', 11n, 'GA_CREATOR', data, 620));
 
-    expect(mockPrisma.auction.update).toHaveBeenCalledOnce();
-    expect(mockPrisma.auction.update).toHaveBeenCalledWith({
+    expect(mockPrisma.auction.updateMany).toHaveBeenCalledOnce();
+    expect(mockPrisma.auction.updateMany).toHaveBeenCalledWith({
       where: { auctionId: 11n },
       data: expect.objectContaining({
         status: 'Finalized',
@@ -332,8 +336,8 @@ describe('processEvent — OFFER_ACCEPTED', () => {
       },
     });
 
-    expect(mockPrisma.listing.update).toHaveBeenCalledOnce();
-    expect(mockPrisma.listing.update).toHaveBeenCalledWith({
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledOnce();
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledWith({
       where: { listingId: 42n },
       data: expect.objectContaining({
         status: 'Sold',
@@ -440,10 +444,57 @@ describe('validateHashContinuity', () => {
     expect(result).toBe(false);
     // revertLedgers wraps everything in a prisma transaction
     expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
+  });
+});
+
 // ── startPolling validation ───────────────────────────────────────────────────
 
 describe('startPolling', () => {
   it('throws an error if both CONTRACT_ID and LAUNCHPAD_CONTRACT_ID are empty', async () => {
     await expect(startPolling()).rejects.toThrow('At least one of MARKETPLACE_CONTRACT_ID or LAUNCHPAD_CONTRACT_ID must be set');
+  });
+});
+
+// ── Out-of-order events — does not throw (#241) ───────────────────────────────
+
+describe('processEvent — out-of-order events do not throw', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('LISTING_UPDATED with no prior listing resolves without throwing', async () => {
+    mockPrisma.listing.updateMany.mockResolvedValueOnce({ count: 0 });
+    const data = { new_price: '999', metadata_cid: 'Qm' };
+    await expect(
+      processEvent(makeEvent('LISTING_UPDATED', 99n, '', data, 500))
+    ).resolves.not.toThrow();
+  });
+
+  it('ARTWORK_SOLD with no prior listing resolves without throwing', async () => {
+    mockPrisma.listing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      processEvent(makeEvent('ARTWORK_SOLD', 99n, 'GB', { buyer: 'GB' }, 500))
+    ).resolves.not.toThrow();
+  });
+
+  it('LISTING_CANCELLED with no prior listing resolves without throwing', async () => {
+    mockPrisma.listing.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      processEvent(makeEvent('LISTING_CANCELLED', 99n, '', {}, 500))
+    ).resolves.not.toThrow();
+  });
+
+  it('BID_PLACED with no prior auction resolves without throwing', async () => {
+    mockPrisma.auction.updateMany.mockResolvedValueOnce({ count: 0 });
+    const data = { bidder: 'GB', bid_amount: '100' };
+    await expect(
+      processEvent(makeEvent('BID_PLACED', 99n, 'GB', data, 500))
+    ).resolves.not.toThrow();
+  });
+
+  it('AUCTION_RESOLVED with no prior auction resolves without throwing', async () => {
+    mockPrisma.auction.updateMany.mockResolvedValueOnce({ count: 0 });
+    const data = { winner: 'GB', amount: '100' };
+    await expect(
+      processEvent(makeEvent('AUCTION_RESOLVED', 99n, 'GA', data, 500))
+    ).resolves.not.toThrow();
   });
 });

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -414,8 +414,8 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
       break;
     }
 
-    case 'LISTING_UPDATED':
-      await db.listing.update({
+    case 'LISTING_UPDATED': {
+      const { count } = await db.listing.updateMany({
         where: { listingId },
         data: {
           price: data.new_price,
@@ -423,10 +423,12 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
           updatedAtLedger: ledgerSequence,
         },
       });
+      if (count === 0) console.warn(`LISTING_UPDATED: listing ${listingId} not found at ledger ${ledgerSequence}`);
       break;
+    }
 
-    case 'ARTWORK_SOLD':
-      await db.listing.update({
+    case 'ARTWORK_SOLD': {
+      const { count } = await db.listing.updateMany({
         where: { listingId },
         data: {
           status: 'Sold',
@@ -434,17 +436,21 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
           updatedAtLedger: ledgerSequence,
         },
       });
+      if (count === 0) console.error(`ARTWORK_SOLD: listing ${listingId} not found — sale not recorded at ledger ${ledgerSequence}`);
       break;
+    }
 
-    case 'LISTING_CANCELLED':
-      await db.listing.update({
+    case 'LISTING_CANCELLED': {
+      const { count } = await db.listing.updateMany({
         where: { listingId },
         data: {
           status: 'Cancelled',
           updatedAtLedger: ledgerSequence,
         },
       });
+      if (count === 0) console.warn(`LISTING_CANCELLED: listing ${listingId} not found at ledger ${ledgerSequence}`);
       break;
+    }
     
     case 'AUCTION_CREATED': {
       let chainAuction = await fetchAuctionFromChain(listingId);
@@ -505,7 +511,7 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
     }
 
     case 'BID_PLACED': {
-      await db.auction.update({
+      const { count } = await db.auction.updateMany({
         where: { auctionId: listingId },
         data: {
           highestBid: data.bid_amount,
@@ -513,11 +519,12 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
           updatedAtLedger: ledgerSequence,
         }
       });
+      if (count === 0) console.warn(`BID_PLACED: auction ${listingId} not found at ledger ${ledgerSequence}`);
       break;
     }
 
     case 'AUCTION_RESOLVED': {
-      await db.auction.update({
+      const { count } = await db.auction.updateMany({
         where: { auctionId: listingId },
         data: {
           status: 'Finalized',
@@ -526,6 +533,7 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
           updatedAtLedger: ledgerSequence,
         }
       });
+      if (count === 0) console.error(`AUCTION_RESOLVED: auction ${listingId} not found — resolution not recorded at ledger ${ledgerSequence}`);
       break;
     }
 
@@ -562,19 +570,15 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
           updatedAtLedger: ledgerSequence,
         }
       });
-      try {
-        await db.listing.update({
-          where: { listingId: BigInt(data.listing_id) },
-          data: {
-            status: 'Sold',
-            owner: data.offerer,
-            updatedAtLedger: ledgerSequence,
-          }
-        });
-      } catch (error) {
-        console.error(`Failed to update listing ${data.listing_id} after offer ${data.offer_id} accepted:`, error);
-        throw error;
-      }
+      const { count: listingCount } = await db.listing.updateMany({
+        where: { listingId: BigInt(data.listing_id) },
+        data: {
+          status: 'Sold',
+          owner: data.offerer,
+          updatedAtLedger: ledgerSequence,
+        }
+      });
+      if (listingCount === 0) console.error(`OFFER_ACCEPTED: listing ${data.listing_id} not found — offer ${data.offer_id} accepted but listing not updated at ledger ${ledgerSequence}`);
       break;
     }
 


### PR DESCRIPTION
 ## What

  Fix four open issues: compilation constant, indexer crash on out-of-order events, and test file
  structural bugs.

  ## Changes

  ### #256 — Define `REENTRANCY_LOCK_TTL`
  - `storage.rs`: define `REENTRANCY_LOCK_TTL: u32 = 100` (was `1`). Used as the dead-man TTL for
  temporary reentrancy lock keys in `acquire_listing_lock` / `acquire_auction_lock`.

  ### #241 — processEvent no longer crashes on missing listing/auction
  - `poller.ts`: replace `db.listing.update()` / `db.auction.update()` with `updateMany()` in all six
  update-only event handlers (`LISTING_UPDATED`, `ARTWORK_SOLD`, `LISTING_CANCELLED`, `BID_PLACED`,
  `AUCTION_RESOLVED`, `OFFER_ACCEPTED` listing side). `updateMany` returns `{ count }` instead of
  throwing `P2025` when the record doesn't exist.
  - Log `console.warn` on count=0 for non-critical cases; `console.error` for `ARTWORK_SOLD`,
  `AUCTION_RESOLVED`, and `OFFER_ACCEPTED` (data-integrity gaps visible to users).
  - Removed the re-throwing try/catch in `OFFER_ACCEPTED` — with `updateMany` it's no longer needed; a
  structured error log captures the split-state signal instead.

  ### #234 — Fix test file structural bugs (variable scoping already correct in poller.ts)
  - `poller.test.ts`: fix duplicate `import` on lines 76–77 (merged into one).
  - `poller.test.ts`: add missing `});` closing the second `it` block and the outer `describe` in
  `validateHashContinuity`.
  - `poller.test.ts`: mock `dotenv` to prevent `.env` from loading during tests, so the `startPolling`
  "throws when no contract IDs" test exits immediately instead of timing out.
  - Update all `listing.update` / `auction.update` mock assertions to `listing.updateMany` /
  `auction.updateMany`.
  - Add `processEvent — out-of-order events do not throw` describe with 5 tests (LISTING_UPDATED,
  ARTWORK_SOLD, LISTING_CANCELLED, BID_PLACED, AUCTION_RESOLVED each with `count: 0` mock).

  ### #252 — N+1 DB round trips (already resolved)
  - `createMany` + `prisma.$transaction` wrapping were already in place in the current codebase. No code
  change needed; confirmed and documented.

  ## Test results

  Tests  27 passed (27)

  ## Closes

  Closes #256
  Closes #241
  Closes #234
  Closes #252