### PR TITLE
Prevent auction finalization while paused

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -592,6 +592,9 @@ impl MarketplaceContract {
     }
 
     pub fn finalize_auction(env: Env, caller: Address, auction_id: u64) {
+        if crate::storage::is_paused(&env) {
+            panic_with_error!(&env, MarketplaceError::ContractPaused);
+        }
         caller.require_auth();
 
         // Reentrancy guard

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -1983,6 +1983,28 @@ fn test_create_auction_while_paused_fails() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #23)")]
+fn test_finalize_auction_while_paused_fails() {
+    let (env, client, artist, _, token_id, _) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&token_id);
+    let auction_id = client.create_auction(
+        &artist,
+        &bytes!(&env, 0x516d74657374),
+        &token_id,
+        &1_000_000_i128,
+        &3600_u64,
+        &0u32,
+        &valid_recipients(&env, &artist),
+    );
+    env.ledger().with_mut(|l| {
+        l.timestamp += 7200;
+    });
+    client.admin_pause(&artist);
+    client.finalize_auction(&artist, &auction_id);
+}
+
+#[test]
 fn test_actions_succeed_after_unpause() {
     let (env, client, artist, buyer, token_id, _) = setup();
     client.set_admin(&artist);


### PR DESCRIPTION
## Description
**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [ ] I have added unit tests to cover my changes and tested edge cases.
- [ ] All tests pass locally (`cargo test`).

Closes #268 