### PR TITLE
#[allow(dead_code)] on distribute_payout is stale

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -37,7 +37,6 @@ mod iface {
     use soroban_sdk::{contractclient, Address, BytesN, Env, String};
 
     #[contractclient(name = "Normal721Client")]
-    #[allow(dead_code)]
     pub trait INormal721 {
         fn initialize(
             env: Env,
@@ -51,7 +50,6 @@ mod iface {
     }
 
     #[contractclient(name = "Normal1155Client")]
-    #[allow(dead_code)]
     pub trait INormal1155 {
         fn initialize(
             env: Env,
@@ -63,7 +61,6 @@ mod iface {
     }
 
     #[contractclient(name = "Lazy721Client")]
-    #[allow(dead_code)]
     #[allow(clippy::too_many_arguments)]
     pub trait ILazy721 {
         fn initialize(
@@ -79,7 +76,6 @@ mod iface {
     }
 
     #[contractclient(name = "Lazy1155Client")]
-    #[allow(dead_code)]
     pub trait ILazy1155 {
         fn initialize(
             env: Env,

--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -913,7 +913,6 @@ impl MarketplaceContract {
     }
 
     #[allow(clippy::too_many_arguments)]
-    #[allow(dead_code)]
     fn distribute_payout(
         env: &Env,
         token_addr: &Address,

--- a/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
+++ b/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
@@ -14,8 +14,11 @@ jest.mock('@/context/WalletContext', () => ({
   useWalletContext: () => ({ publicKey: 'GBIDDER123' }),
 }));
 
-jest.mock('@/hooks/useAuctions', () => ({
+jest.mock('@/hooks/usePlaceBid', () => ({
   usePlaceBid: () => ({ bid: mockBid, isBidding: false, error: null }),
+}));
+
+jest.mock('@/hooks/useAuctions', () => ({
   useFinalizeAuction: () => ({ finalize: mockFinalize, isFinalizing: false, error: null }),
 }));
 

--- a/frontend/afristore-app/src/__tests__/listings.test.tsx
+++ b/frontend/afristore-app/src/__tests__/listings.test.tsx
@@ -20,6 +20,9 @@ jest.mock('@/lib/contract', () => ({
 
 jest.mock('@/hooks/useMarketplace', () => ({
   useBuyArtwork: () => ({ buy: jest.fn(), isBuying: false, error: null }),
+}))
+
+jest.mock('@/hooks/usePlaceBid', () => ({
   usePlaceBid: () => ({ bid: jest.fn(), isBidding: false, error: null }),
 }))
 
@@ -34,12 +37,12 @@ jest.mock('@/hooks/useUserActivity', () => ({
 describe('Regression Test: Invalid Listing IDs', () => {
   it('renders Artwork Not Found state for invalid IDs', async () => {
     render(<ListingDetailPage />)
-    
+
     // Wait for the async loading to finish and show error
     await waitFor(() => {
       expect(screen.getByRole('heading', { name: /Artwork Not Found/i })).toBeInTheDocument()
     })
-    
+
     expect(screen.getByRole('heading', { name: /Artwork Not Found/i })).toBeInTheDocument()
     expect(screen.getByText(/Artwork not found/i, { selector: 'p' })).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Return to Marketplace/i })).toBeInTheDocument()

--- a/frontend/afristore-app/src/__tests__/useAuctions.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useAuctions.test.tsx
@@ -45,9 +45,9 @@ import {
   useAuctions,
   useArtistAuctions,
   useCreateAuction,
-  usePlaceBid,
   useFinalizeAuction,
 } from '@/hooks/useAuctions';
+import { usePlaceBid } from '@/hooks/usePlaceBid';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 

--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -267,10 +267,10 @@ export default function AuctionDetailPage() {
             {/* Status badge */}
             <span
               className={`absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${isActive
-                  ? "bg-green-500 text-white"
-                  : isFinalized
-                    ? "bg-blue-500 text-white"
-                    : "bg-gray-400 text-white"
+                ? "bg-green-500 text-white"
+                : isFinalized
+                  ? "bg-blue-500 text-white"
+                  : "bg-gray-400 text-white"
                 }`}
             >
               {auction.status}
@@ -310,7 +310,7 @@ export default function AuctionDetailPage() {
                   Current Bid
                 </span>
                 <span className="text-xl font-bold text-gray-900">
-                  {Number(auction.highest_bid) > 0
+                  {auction.highest_bid > 0n
                     ? `${highestBidXlm} XLM`
                     : "No bids yet"}
                 </span>
@@ -407,8 +407,8 @@ export default function AuctionDetailPage() {
             {(isFinalized || isCancelled) && !finalizeSuccess && (
               <div
                 className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm ${isFinalized
-                    ? "bg-blue-50 text-blue-700"
-                    : "bg-gray-100 text-gray-600"
+                  ? "bg-blue-50 text-blue-700"
+                  : "bg-gray-100 text-gray-600"
                   }`}
               >
                 <CheckCircle2 size={16} />
@@ -482,8 +482,8 @@ export default function AuctionDetailPage() {
                 key={t}
                 onClick={() => setActiveTab(t)}
                 className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${activeTab === t
-                    ? "bg-brand-500 text-white"
-                    : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+                  ? "bg-brand-500 text-white"
+                  : "bg-gray-100 text-gray-600 hover:bg-gray-200"
                   }`}
               >
                 {t === "details" ? "Details" : "Bid History"}

--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -13,7 +13,8 @@ import { fetchMetadata, cidToGatewayUrl, ArtworkMetadata } from "@/lib/ipfs";
 import { getListingActivity, ActivityEvent } from "@/lib/indexer";
 import { getReadableErrorMessage } from "@/lib/errors";
 import { useWalletContext } from "@/context/WalletContext";
-import { usePlaceBid, useFinalizeAuction } from "@/hooks/useAuctions";
+import { usePlaceBid } from "@/hooks/usePlaceBid";
+import { useFinalizeAuction } from "@/hooks/useAuctions";
 import { GuardButton } from "@/components/WalletGuard";
 import {
   ArrowLeft,
@@ -265,13 +266,12 @@ export default function AuctionDetailPage() {
 
             {/* Status badge */}
             <span
-              className={`absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${
-                isActive
+              className={`absolute left-4 top-4 rounded-full px-3 py-1 text-xs font-bold uppercase tracking-wider ${isActive
                   ? "bg-green-500 text-white"
                   : isFinalized
-                  ? "bg-blue-500 text-white"
-                  : "bg-gray-400 text-white"
-              }`}
+                    ? "bg-blue-500 text-white"
+                    : "bg-gray-400 text-white"
+                }`}
             >
               {auction.status}
             </span>
@@ -406,19 +406,17 @@ export default function AuctionDetailPage() {
 
             {(isFinalized || isCancelled) && !finalizeSuccess && (
               <div
-                className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm ${
-                  isFinalized
+                className={`flex items-center gap-2 rounded-xl px-4 py-3 text-sm ${isFinalized
                     ? "bg-blue-50 text-blue-700"
                     : "bg-gray-100 text-gray-600"
-                }`}
+                  }`}
               >
                 <CheckCircle2 size={16} />
                 {isFinalized
-                  ? `Won by ${
-                      auction.highest_bidder
-                        ? `${auction.highest_bidder.slice(0, 8)}…`
-                        : "unknown"
-                    } for ${highestBidXlm} XLM`
+                  ? `Won by ${auction.highest_bidder
+                    ? `${auction.highest_bidder.slice(0, 8)}…`
+                    : "unknown"
+                  } for ${highestBidXlm} XLM`
                   : "Auction ended with no bids"}
               </div>
             )}
@@ -483,11 +481,10 @@ export default function AuctionDetailPage() {
               <button
                 key={t}
                 onClick={() => setActiveTab(t)}
-                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
-                  activeTab === t
+                className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${activeTab === t
                     ? "bg-brand-500 text-white"
                     : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                }`}
+                  }`}
               >
                 {t === "details" ? "Details" : "Bid History"}
                 {t === "bids" && (

--- a/frontend/afristore-app/src/app/auctions/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/page.tsx
@@ -92,7 +92,7 @@ function AuctionCard({ auction }: { auction: Auction }) {
   }, [auction.metadata_cid]);
 
   const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
-  const currentBidXlm = Number(auction.highest_bid) / 10_000_000;
+  const currentBidXlm = parseFloat(stroopsToXlm(auction.highest_bid));
 
   return (
     <Link
@@ -117,9 +117,8 @@ function AuctionCard({ auction }: { auction: Auction }) {
 
         {/* Status badge */}
         <span
-          className={`absolute top-3 right-3 rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${
-            STATUS_COLOR[auction.status] ?? ""
-          }`}
+          className={`absolute top-3 right-3 rounded-full px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider ${STATUS_COLOR[auction.status] ?? ""
+            }`}
         >
           {auction.status}
         </span>
@@ -234,11 +233,10 @@ export default function AuctionsPage() {
                   <button
                     key={key}
                     onClick={() => setTab(key)}
-                    className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${
-                      isActive
+                    className={`rounded-full px-4 py-1.5 text-sm font-medium transition-all ${isActive
                         ? "bg-brand-500 text-white shadow-md shadow-brand-500/20"
                         : "bg-gray-100 text-gray-600 hover:bg-gray-200"
-                    }`}
+                      }`}
                   >
                     {label}
                     {key === "all" && (

--- a/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
+++ b/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
@@ -554,7 +554,7 @@ export default function ListingDetailPage({ id }: ListingClientProps) {
                                     </div>
                                 )}
 
-                                {status === "Sold" || status === "Finalized" && (
+                                {(status === "Sold" || status === "Finalized") && (
                                     <div className="p-6 rounded-2xl bg-white/5 border border-white/10 text-center">
                                         <p className="text-white/40 font-bold italic">
                                             This asset has been privateley collected.

--- a/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
+++ b/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
@@ -18,7 +18,8 @@ import {
 } from "@/lib/contract";
 import { fetchMetadata, cidToGatewayUrl, ArtworkMetadata } from "@/lib/ipfs";
 import { useWalletContext } from "@/context/WalletContext";
-import { useBuyArtwork, usePlaceBid } from "@/hooks/useMarketplace";
+import { useBuyArtwork } from "@/hooks/useMarketplace";
+import { usePlaceBid } from "@/hooks/usePlaceBid";
 import { useListingOffers, useMakeOffer } from "@/hooks/useOffers";
 import { useListingActivity } from "@/hooks/useUserActivity";
 import { GuardButton } from "@/components/WalletGuard";
@@ -42,7 +43,7 @@ import {
 } from "lucide-react";
 
 interface ListingClientProps {
-  id: string;
+    id: string;
 }
 
 export default function ListingDetailPage({ id }: ListingClientProps) {
@@ -62,7 +63,7 @@ export default function ListingDetailPage({ id }: ListingClientProps) {
     const { bid, isBidding, error: bidError } = usePlaceBid(publicKey);
     const { offers, isLoading: isLoadingOffers, refresh: refreshOffers } = useListingOffers(id ? Number(id) : null);
     const { activities, isLoading: isLoadingActivity } = useListingActivity(id ? Number(id) : null);
-    
+
     // Make Offer Hook and States
     const { make: makeOffer, isOffering, error: offerError } = useMakeOffer(publicKey);
     const [offerAmount, setOfferAmount] = useState("");

--- a/frontend/afristore-app/src/components/BiddingPanel.tsx
+++ b/frontend/afristore-app/src/components/BiddingPanel.tsx
@@ -7,7 +7,8 @@
 import { useState, useEffect, useMemo } from "react";
 import { Auction, stroopsToXlm } from "@/lib/contract";
 import { useWalletContext } from "@/context/WalletContext";
-import { usePlaceBid, useFinalizeAuction } from "@/hooks/useAuctions";
+import { usePlaceBid } from "@/hooks/usePlaceBid";
+import { useFinalizeAuction } from "@/hooks/useAuctions";
 import { GuardButton } from "@/components/WalletGuard";
 import {
   Gavel,
@@ -119,9 +120,8 @@ export function BiddingPanel({
       {/* Status badge */}
       <div className="flex items-center justify-between">
         <span
-          className={`rounded-full px-3 py-1 text-xs font-semibold ${
-            STATUS_COLOR[auction.status] ?? ""
-          }`}
+          className={`rounded-full px-3 py-1 text-xs font-semibold ${STATUS_COLOR[auction.status] ?? ""
+            }`}
         >
           {auction.status}
         </span>

--- a/frontend/afristore-app/src/components/BiddingPanel.tsx
+++ b/frontend/afristore-app/src/components/BiddingPanel.tsx
@@ -73,8 +73,8 @@ export function BiddingPanel({
   const [bidAmount, setBidAmount] = useState("");
   const [bidSuccess, setBidSuccess] = useState(false);
 
-  const currentBidXlm = Number(auction.highest_bid) / 10_000_000;
-  const reserveXlm = Number(auction.reserve_price) / 10_000_000;
+  const currentBidXlm = parseFloat(stroopsToXlm(auction.highest_bid));
+  const reserveXlm = parseFloat(stroopsToXlm(auction.reserve_price));
   const minimumBid = Math.max(
     currentBidXlm > 0 ? currentBidXlm + 0.0000001 : reserveXlm,
     reserveXlm

--- a/frontend/afristore-app/src/hooks/useAuctions.ts
+++ b/frontend/afristore-app/src/hooks/useAuctions.ts
@@ -167,37 +167,6 @@ export function useCreateAuction(creatorPublicKey: string | null) {
   return { create, isCreating, progress, error };
 }
 
-// ── usePlaceBid ──────────────────────────────────────────────
-
-export function usePlaceBid(bidderPublicKey: string | null) {
-  const [isBidding, setIsBidding] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  useTransientErrorToast(error);
-
-  const bid = useCallback(
-    async (auctionId: number, amountXlm: number): Promise<boolean> => {
-      if (!bidderPublicKey) {
-        setError("Wallet not connected");
-        return false;
-      }
-      setIsBidding(true);
-      setError(null);
-      try {
-        await placeBid(bidderPublicKey, auctionId, amountXlm);
-        return true;
-      } catch (err: unknown) {
-        setError(getReadableErrorMessage(err, "Failed to place bid"));
-        return false;
-      } finally {
-        setIsBidding(false);
-      }
-    },
-    [bidderPublicKey]
-  );
-
-  return { bid, isBidding, error };
-}
-
 // ── useFinalizeAuction ───────────────────────────────────────
 
 export function useFinalizeAuction(callerPublicKey: string | null) {

--- a/frontend/afristore-app/src/hooks/useMarketplace.ts
+++ b/frontend/afristore-app/src/hooks/useMarketplace.ts
@@ -428,34 +428,3 @@ export function useAuction(auctionId: number | null) {
 
   return { auction, isLoading, error, refresh };
 }
-
-// ── usePlaceBid ───────────────────────────────────────────────
-
-export function usePlaceBid(bidderPublicKey: string | null) {
-  const [isBidding, setIsBidding] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  useTransientErrorToast(error);
-
-  const bid = useCallback(
-    async (auctionId: number, amountXlm: number): Promise<boolean> => {
-      if (!bidderPublicKey) {
-        setError("Wallet not connected");
-        return false;
-      }
-      setIsBidding(true);
-      setError(null);
-      try {
-        await placeBid(bidderPublicKey, auctionId, amountXlm);
-        return true;
-      } catch (err: unknown) {
-        setError(getReadableErrorMessage(err, "Bid failed"));
-        return false;
-      } finally {
-        setIsBidding(false);
-      }
-    },
-    [bidderPublicKey],
-  );
-
-  return { bid, isBidding, error };
-}

--- a/frontend/afristore-app/src/hooks/usePlaceBid.ts
+++ b/frontend/afristore-app/src/hooks/usePlaceBid.ts
@@ -1,0 +1,39 @@
+// ─────────────────────────────────────────────────────────────
+// hooks/usePlaceBid.ts — Place bid hook
+// ─────────────────────────────────────────────────────────────
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { placeBid } from "@/lib/contract";
+import { getReadableErrorMessage } from "@/lib/errors";
+import { useTransientErrorToast } from "./useTransientErrorToast";
+
+export function usePlaceBid(bidderPublicKey: string | null) {
+  const [isBidding, setIsBidding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  useTransientErrorToast(error);
+
+  const bid = useCallback(
+    async (auctionId: number, amountXlm: number): Promise<boolean> => {
+      if (!bidderPublicKey) {
+        setError("Wallet not connected");
+        return false;
+      }
+      setIsBidding(true);
+      setError(null);
+      try {
+        await placeBid(bidderPublicKey, auctionId, amountXlm);
+        return true;
+      } catch (err: unknown) {
+        setError(getReadableErrorMessage(err, "Failed to place bid"));
+        return false;
+      } finally {
+        setIsBidding(false);
+      }
+    },
+    [bidderPublicKey],
+  );
+
+  return { bid, isBidding, error };
+}


### PR DESCRIPTION
## Description


close #283 

**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [x] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [x] I have added unit tests to cover my changes and tested edge cases.
- [x] All tests pass locally (`cargo test`).

## Additional Context