### PR TITLE
Remove hardcoded mock data blocking real listings 1-6

### DIFF
--- a/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
+++ b/frontend/afristore-app/src/app/listings/[id]/ListingClient.tsx
@@ -104,8 +104,13 @@ export default function ListingDetailPage({ id }: ListingClientProps) {
 
                 const cid = l?.metadata_cid || a?.metadata_cid;
                 if (cid) {
-                    const m = await fetchMetadata(cid);
-                    setMetadata(m);
+                    try {
+                        const m = await fetchMetadata(cid);
+                        setMetadata(m);
+                    } catch (e) {
+                        // Metadata is off-chain (IPFS) and may be slow or unavailable.
+                        // The on-chain listing still exists, so render it without metadata.
+                    }
                 }
             } catch (err: any) {
                 setError(err.message || "Failed to load artwork details");

--- a/frontend/afristore-app/src/app/listings/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/listings/[id]/page.tsx
@@ -39,66 +39,6 @@ export async function generateMetadata({
       metadata = await fetchMetadata(cid);
     }
 
-    // Fallback for mock data (IDs 1-6)
-    if (!metadata && Number(id) >= 1 && Number(id) <= 6) {
-      const mockIdx = Number(id) - 1;
-      const mocks = [
-        {
-          title: "Ndebele Geometry",
-          artist: "GB2...Traditional",
-          price: 250,
-          image:
-            "https://images.unsplash.com/photo-1582582621959-48d27397dc69?w=800&q=80",
-        },
-        {
-          title: "Maasai Beadwork Essence",
-          artist: "GB3...Contemporary",
-          price: 180,
-          image:
-            "https://images.unsplash.com/photo-1590845947698-8924d7409b56?w=800&q=80",
-        },
-        {
-          title: "Bronze Kingdom Legacy",
-          artist: "GB4...Classical",
-          price: 420,
-          image:
-            "https://images.unsplash.com/photo-1580136579312-94651dfd596d?w=800&q=80",
-        },
-        {
-          title: "Sahel Sunset Canvas",
-          artist: "GB5...Modern",
-          price: 310,
-          image:
-            "https://images.unsplash.com/photo-1578926375605-eaf7559b1458?w=800&q=80",
-        },
-        {
-          title: "Kente Woven Dreams",
-          artist: "GB6...Textile",
-          price: 195,
-          image:
-            "https://images.unsplash.com/photo-1528699144885-3652875b4783?w=800&q=80",
-        },
-        {
-          title: "Baobab Spirit",
-          artist: "GB7...Sculpture",
-          price: 375,
-          image:
-            "https://images.unsplash.com/photo-1559519529-0935f852b3a6?w=800&q=80",
-        },
-      ];
-      const m = mocks[mockIdx];
-      metadata = {
-        title: m.title,
-        description: `A stunning masterpiece representing the rich ${m.title.split(" ")[0]} culture.`,
-        artist: m.artist,
-        image: m.image,
-      };
-      listing = {
-        price: BigInt(m.price) * BigInt(10_000_000),
-        artist: m.artist,
-      };
-    }
-
     if (!metadata) {
       return {
         title: "Artwork Not Found - Afristore",


### PR DESCRIPTION
closes #286 

## Summary

The listing detail page (`frontend/afristore-app/src/app/listings/[id]/page.tsx`)
contained a hardcoded mock-data fallback that ran for listing IDs 1–6 whenever
IPFS metadata failed to resolve. It injected fake artists, prices, and Unsplash
images — meaning any real on-chain listing with an ID between 1 and 6 could never
be displayed to users.

This PR removes the mock path entirely so listings are always sourced from the
contract, and makes metadata resolution degrade gracefully.

## Changes

- **Remove the IDs 1–6 mock fallback** from `generateMetadata` in `page.tsx`.
  Metadata now comes solely from `getListing` / `getAuction` (the contract),
  falling through to the legitimate "Artwork Not Found" response when nothing exists.
- **Make the client's IPFS `fetchMetadata` call non-fatal** in `ListingClient.tsx`.
  A slow or unavailable metadata CID no longer throws and hides an existing
  on-chain listing — the listing renders with the existing "No media available"
  placeholder instead. The loading spinner already covers the full fetch.

## Checklist (from issue #228)

- [x] Remove mock data paths entirely
- [x] Always fetch from indexer or contract
- [x] Add loading state while metadata resolves

Fixes #228

## Test plan

- [ ] Visit a real on-chain listing with ID 1–6 and confirm its actual
      metadata/image renders (no Unsplash mock).
- [ ] Visit a listing whose IPFS metadata is unavailable and confirm the page
      still renders with the "No media available" placeholder rather than erroring.
- [ ] Visit a non-existent ID and confirm the "Artwork Not Found" state shows.
- [ ] Run `npm run type-check` / `npm run build` once dependencies are installed.