### PR TITLE
fix: hash fix

### DIFF
--- a/indexer/package-lock.json
+++ b/indexer/package-lock.json
@@ -596,7 +596,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
       "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1185,7 +1184,6 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -2008,7 +2006,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2731,7 +2728,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -3327,7 +3323,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3380,7 +3375,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -84,7 +84,13 @@ vi.mock('@stellar/stellar-sdk', () => ({
   },
 }));
 
-import { processEvent, revertLedgers, validateHashContinuity, startPolling } from '../poller';
+import {
+  processEvent,
+  revertLedgers,
+  validateHashContinuity,
+  buildSyncStateLedgerData,
+  startPolling,
+} from '../poller';
 
 // ── helpers ───────────────────────────────────────────────────────────────────
 
@@ -414,10 +420,38 @@ describe('revertLedgers', () => {
   });
 });
 
+// ── buildSyncStateLedgerData (#244) ───────────────────────────────────────────
+
+describe('buildSyncStateLedgerData', () => {
+  it('includes lastLedgerHash when hash fetch succeeds', () => {
+    expect(buildSyncStateLedgerData(100, 'ledger_hash')).toEqual({
+      lastLedger: 100,
+      lastLedgerHash: 'ledger_hash',
+    });
+  });
+
+  it('omits lastLedgerHash when hash fetch fails so the prior checkpoint is preserved', () => {
+    expect(buildSyncStateLedgerData(100, null)).toEqual({ lastLedger: 100 });
+  });
+});
+
 // ── validateHashContinuity ────────────────────────────────────────────────────
 
 describe('validateHashContinuity', () => {
   beforeEach(() => vi.clearAllMocks());
+
+  it('returns true and skips RPC when lastLedgerHash is null (#244)', async () => {
+    const mockServer = { getLedgers: vi.fn() } as any;
+
+    const result = await validateHashContinuity(
+      { lastLedger: 100, lastLedgerHash: null },
+      mockServer
+    );
+
+    expect(result).toBe(true);
+    expect(mockServer.getLedgers).not.toHaveBeenCalled();
+    expect(mockPrisma.$transaction).not.toHaveBeenCalled();
+  });
 
   it('returns true if network hash matches lastLedgerHash', async () => {
     const mockServer = {
@@ -588,5 +622,68 @@ describe('startPolling — window floor reset', () => {
     expect(mockPrisma.syncState.create).not.toHaveBeenCalled();
     // The poller must have requested events starting at the window floor
     expect(capturedStartLedger).toBe(expectedWindowFloor);
+  }, 8000);
+});
+
+// ── hash fetch failure (#244) ─────────────────────────────────────────────────
+
+describe('startPolling — hash fetch failure', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.MARKETPLACE_CONTRACT_ID = 'CTEST';
+  });
+
+  afterEach(() => {
+    delete process.env.MARKETPLACE_CONTRACT_ID;
+  });
+
+  it('advances lastLedger without clearing lastLedgerHash when hash fetch fails', async () => {
+    const networkLatest = 60;
+    const priorHash = 'prev_hash';
+
+    mockPrisma.syncState.upsert.mockResolvedValueOnce({
+      id: 1,
+      lastLedger: 50,
+      lastLedgerHash: priorHash,
+    });
+    mockPrisma.syncState.update.mockResolvedValue({
+      id: 1,
+      lastLedger: networkLatest,
+      lastLedgerHash: priorHash,
+    });
+
+    vi.resetModules();
+    const { startPolling: freshStart } = await import('../poller');
+    const sdkMod = await import('@stellar/stellar-sdk');
+
+    vi.spyOn(sdkMod.rpc.Server.prototype, 'getLatestLedger')
+      .mockResolvedValue({ sequence: networkLatest } as any);
+    vi.spyOn(sdkMod.rpc.Server.prototype, 'getEvents')
+      .mockResolvedValue({ events: [], latestLedger: networkLatest } as any);
+    vi.spyOn(sdkMod.rpc.Server.prototype, 'getLedgers')
+      .mockImplementation(({ startLedger }: { startLedger: number }) => {
+        if (startLedger === 50) {
+          return Promise.resolve({ ledgers: [{ hash: priorHash, sequence: 50 }] });
+        }
+        if (startLedger === networkLatest) {
+          return Promise.reject(new Error('network error'));
+        }
+        return Promise.resolve({ ledgers: [] });
+      });
+
+    freshStart().catch(() => {});
+
+    await vi.waitFor(() => {
+      expect(mockPrisma.syncState.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: { lastLedger: networkLatest },
+        })
+      );
+    }, { timeout: 3000 });
+
+    const hashAdvanceUpdate = mockPrisma.syncState.update.mock.calls.find(
+      ([arg]) => arg.data?.lastLedger === networkLatest
+    );
+    expect(hashAdvanceUpdate?.[0].data).not.toHaveProperty('lastLedgerHash');
   }, 8000);
 });

--- a/indexer/src/backfill.ts
+++ b/indexer/src/backfill.ts
@@ -2,7 +2,7 @@ import { rpc } from '@stellar/stellar-sdk';
 import dotenv from 'dotenv';
 import { pathToFileURL } from 'node:url';
 import prisma from './db.js';
-import { applyDecodedEvents } from './poller.js';
+import { applyDecodedEvents, buildSyncStateLedgerData } from './poller.js';
 import { collectMarketplaceEvents } from './event-sync.js';
 
 dotenv.config();
@@ -92,17 +92,11 @@ export async function runBackfill() {
 
   const { insertedCount } = await prisma.$transaction(async (tx) => {
     const inserted = await applyDecodedEvents(decodedEvents, tx);
+    const ledgerData = buildSyncStateLedgerData(processedLedger, latestHash);
     await tx.syncState.upsert({
       where: { id: 1 },
-      create: {
-        id: 1,
-        lastLedger: processedLedger,
-        lastLedgerHash: latestHash,
-      },
-      update: {
-        lastLedger: processedLedger,
-        lastLedgerHash: latestHash,
-      },
+      create: { id: 1, ...ledgerData },
+      update: ledgerData,
     });
 
     return { insertedCount: inserted.length };

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -116,10 +116,22 @@ export async function revertLedgers(safeAtLedger: number): Promise<void> {
   console.log(`[Reorg] Rollback complete. Resuming from ledger ${safeAtLedger + 1}`);
 }
 
+/** SyncState fields for a ledger advance; omits hash when fetch failed so we keep the prior checkpoint. */
+export function buildSyncStateLedgerData(
+  lastLedger: number,
+  ledgerHash: string | null
+): { lastLedger: number; lastLedgerHash?: string } {
+  if (ledgerHash !== null) {
+    return { lastLedger, lastLedgerHash: ledgerHash };
+  }
+  return { lastLedger };
+}
+
 export async function validateHashContinuity(
   syncState: { lastLedger: number; lastLedgerHash: string | null },
   rpcServer: rpc.Server
 ): Promise<boolean> {
+  // No stored hash (initial sync or prior hash fetch failure) — cannot detect re-org.
   if (syncState.lastLedger > 0 && syncState.lastLedgerHash) {
     try {
       const ledgersRes = await rpcServer.getLedgers({
@@ -229,10 +241,7 @@ export async function startPolling() {
           const toInsert = await applyDecodedEvents(decodedEvents, tx);
           const updated = await tx.syncState.update({
             where: { id: 1 },
-            data: {
-              lastLedger: maxLedger,
-              lastLedgerHash: latestHash,
-            },
+            data: buildSyncStateLedgerData(maxLedger, latestHash),
           });
 
           return { updatedState: updated, newEvents: toInsert };
@@ -256,10 +265,7 @@ export async function startPolling() {
 
         const updatedState = await prisma.syncState.update({
           where: { id: 1 },
-          data: {
-            lastLedger: networkLatestLedger,
-            lastLedgerHash: latestHash,
-          },
+          data: buildSyncStateLedgerData(networkLatestLedger, latestHash),
         });
 
         updateSyncMetrics(updatedState.lastLedger, networkLatestLedger);


### PR DESCRIPTION
## Summary

On RPC failure, `latestHash` remained `null` but was still persisted to `SyncState`. This overwrote the existing checkpoint hash.

As a result, a subsequent continuity check could:

- Incorrectly treat `null !== networkHash` as a reorg, or
- Leave the indexer without a valid checkpoint hash.

## Changes

### `buildSyncStateLedgerData`

- Only includes `lastLedgerHash` when a non-null hash is successfully fetched.
- If hash retrieval fails, only `lastLedger` is updated.
- This allows Prisma to retain the previously stored checkpoint hash.

### Poller

- Updated both sync-state update paths:
  - After event processing
  - During idle catch-up
- Both now use `buildSyncStateLedgerData`.

### Backfill

- Updated to use the shared helper, ensuring consistent behavior with the poller.

### `validateHashContinuity`

- Already skipped continuity validation when `lastLedgerHash` is `null`.
- Added a clarifying code comment.
- Added a dedicated unit test.

## Tests Added

- ✅ `buildSyncStateLedgerData` omits `lastLedgerHash` when hash retrieval fails.
- ✅ `validateHashContinuity` skips RPC continuity checks when the stored hash is `null`.
- ✅ `startPolling` advances `lastLedger` without persisting `lastLedgerHash: null` when `getLedgers` rejects for the latest ledger.

Closes: #244 