### PR TITLE
fix: listing error fixed

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -326,7 +326,10 @@ impl MarketplaceContract {
             }
         }
 
-        if new_price <= 0 || new_metadata_cid.is_empty() {
+        if new_metadata_cid.is_empty() {
+            panic_with_error!(&env, MarketplaceError::InvalidCid);
+        }
+        if new_price <= 0 {
             panic_with_error!(&env, MarketplaceError::InvalidPrice);
         }
         if !Self::is_token_whitelisted(&env, &new_token) {

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -374,6 +374,34 @@ fn test_update_listing_success() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #1)")]
+fn test_update_listing_empty_cid() {
+    let (env, client, artist, _, token_id, _contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&token_id);
+    let cid = bytes!(&env, 0x516d74657374);
+    let id = client.create_listing(
+        &artist,
+        &cid,
+        &5_000_000_i128,
+        &symbol_short!("XLM"),
+        &token_id,
+        &0u32,
+        &valid_recipients(&env, &artist),
+    );
+
+    let new_rec = valid_recipients(&env, &artist);
+    client.update_listing(
+        &artist,
+        &id,
+        &bytes!(&env,),
+        &10_000_000_i128,
+        &token_id,
+        &new_rec,
+    );
+}
+
+#[test]
 #[should_panic(expected = "Error(Contract, #5)")]
 fn test_update_listing_wrong_artist() {
     let (env, client, artist, buyer, token_id, _contract_id) = setup();


### PR DESCRIPTION
## Summary

Fixes #270 by ensuring `update_listing` returns `MarketplaceError::InvalidCid` when `new_metadata_cid` is empty, instead of incorrectly returning `MarketplaceError::InvalidPrice`.

Validation logic has been split to match `create_listing` behavior:

- Empty metadata CID → `MarketplaceError::InvalidCid`
- Non-positive price → `MarketplaceError::InvalidPrice`

This aligns validation and error reporting across listing creation and updates.

## Changes

### `update_listing`

- Separated CID validation from price validation.
- Added explicit check for empty `new_metadata_cid`.
- Returns `MarketplaceError::InvalidCid` for empty CIDs.
- Preserves existing `MarketplaceError::InvalidPrice` behavior for invalid prices.

### Tests

- Added `test_update_listing_empty_cid`.
- Verifies that updating a listing with an empty CID returns `Error(Contract, #1)`.
- Mirrors the existing `test_create_listing_empty_cid` coverage.

Closes: #270 