### PR TITLE
fix: fix reentrancy

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -774,12 +774,26 @@ impl MarketplaceContract {
         artist.require_auth();
         let mut offer = load_offer(&env, offer_id)
             .unwrap_or_else(|| panic_with_error!(&env, MarketplaceError::OfferNotFound));
-        let mut listing = load_listing(&env, offer.listing_id)
-            .unwrap_or_else(|| panic_with_error!(&env, MarketplaceError::ListingNotFound));
+        let listing_id = offer.listing_id;
+
+        // Reentrancy guard (same listing lock as buy_artwork)
+        if !acquire_listing_lock(&env, listing_id) {
+            panic_with_error!(&env, MarketplaceError::ReentrancyGuard);
+        }
+
+        let mut listing = match load_listing(&env, listing_id) {
+            Some(l) => l,
+            None => {
+                release_listing_lock(&env, listing_id);
+                panic_with_error!(&env, MarketplaceError::ListingNotFound);
+            }
+        };
         if listing.artist != artist {
+            release_listing_lock(&env, listing_id);
             panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
         if offer.status != OfferStatus::Pending || listing.status != ListingStatus::Active {
+            release_listing_lock(&env, listing_id);
             panic_with_error!(&env, MarketplaceError::OfferNotPending);
         }
         Self::distribute_payout(
@@ -826,6 +840,8 @@ impl MarketplaceContract {
                 }
             }
         }
+
+        release_listing_lock(&env, listing_id);
     }
 
     pub fn get_listing(env: Env, listing_id: u64) -> Listing {

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -1232,6 +1232,23 @@ fn test_accept_offer_success() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #22)")]
+fn test_accept_offer_reentrancy_guard() {
+    let (env, client, artist, buyer, token_id, contract_id) = setup();
+    client.set_admin(&artist);
+    client.add_token_to_whitelist(&token_id);
+
+    let listing_id = create_test_listing(&env, &client, &artist, &token_id);
+    let offer_id = client.make_offer(&buyer, &listing_id, &5_000_000_i128, &token_id);
+
+    // Simulate a nested accept_offer while the listing lock is held (e.g. payout token callback).
+    env.as_contract(&contract_id, || {
+        assert!(crate::storage::acquire_listing_lock(&env, listing_id));
+    });
+    client.accept_offer(&artist, &offer_id);
+}
+
+#[test]
 fn test_reject_offer_success() {
     let (env, client, artist, buyer, token_id, _contract_id) = setup();
     client.set_admin(&artist);
@@ -2348,11 +2365,10 @@ fn test_admin_pause_emits_event() {
 
     client.admin_pause(&artist);
 
-    let events = env.events().all();
-    let has_pause_event = events.iter().any(|e| {
-        format!("{:?}", e.1).contains("contract_paused")
-    });
-    assert!(has_pause_event, "admin_pause must emit a CONTRACT_PAUSED event");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ctr_psd"),
+        "admin_pause must emit a CONTRACT_PAUSED event"
+    );
 }
 
 #[test]
@@ -2364,11 +2380,10 @@ fn test_admin_unpause_emits_event() {
     client.admin_pause(&artist);
     client.admin_unpause(&artist);
 
-    let events = env.events().all();
-    let has_unpause_event = events.iter().any(|e| {
-        format!("{:?}", e.1).contains("contract_unpaused")
-    });
-    assert!(has_unpause_event, "admin_unpause must emit a CONTRACT_UNPAUSED event");
+    assert!(
+        has_event_with_topic(&env.events().all(), "ctr_unpsd"),
+        "admin_unpause must emit a CONTRACT_UNPAUSED event"
+    );
 }
 
 #[test]
@@ -2402,17 +2417,8 @@ fn test_create_listing_blocked_when_paused() {
 
     client.admin_pause(&artist);
 
-    let cid = bytes!(&env, 0x516d74657374);
     // Any create_listing call must panic while the contract is paused
-    client.create_listing(
-        &artist,
-        &cid,
-        &10_000_000_i128,
-        &token_id,
-        &valid_recipients(&env, &artist),
-        &500u32,
-        &artist,
-    );
+    create_test_listing(&env, &client, &artist, &token_id);
 }
 
 #[test]
@@ -2424,18 +2430,15 @@ fn test_create_auction_blocked_when_paused() {
 
     client.admin_pause(&artist);
 
-    let cid = bytes!(&env, 0x516d74657374);
-    let end_time = env.ledger().timestamp() + 3600;
     // Any create_auction call must panic while the contract is paused
     client.create_auction(
         &artist,
-        &cid,
-        &5_000_000_i128,
+        &bytes!(&env, 0x516d74657374),
         &token_id,
-        &end_time,
-        &valid_recipients(&env, &artist),
+        &5_000_000_i128,
+        &3600u64,
         &500u32,
-        &artist,
+        &valid_recipients(&env, &artist),
     );
 }
 
@@ -2450,16 +2453,7 @@ fn test_create_listing_succeeds_after_unpause() {
     client.admin_unpause(&artist);
 
     // Now create_listing must work again
-    let cid = bytes!(&env, 0x516d74657374);
-    let listing_id = client.create_listing(
-        &artist,
-        &cid,
-        &10_000_000_i128,
-        &token_id,
-        &valid_recipients(&env, &artist),
-        &500u32,
-        &artist,
-    );
+    let listing_id = create_test_listing(&env, &client, &artist, &token_id);
     assert!(listing_id > 0, "listing must be created after unpause");
 }
 
@@ -2470,19 +2464,10 @@ fn test_buy_artwork_blocked_when_paused() {
     client.set_admin(&artist);
     client.add_token_to_whitelist(&token_id);
 
-    let cid = bytes!(&env, 0x516d74657374);
-    let listing_id = client.create_listing(
-        &artist,
-        &cid,
-        &10_000_000_i128,
-        &token_id,
-        &valid_recipients(&env, &artist),
-        &500u32,
-        &artist,
-    );
+    let listing_id = create_test_listing(&env, &client, &artist, &token_id);
 
     client.admin_pause(&artist);
 
     // buy_artwork must panic while paused
-    client.buy_artwork(&buyer, &listing_id, &token_id);
+    client.buy_artwork(&buyer, &listing_id);
 }


### PR DESCRIPTION
## Summary

Closes #264.

`buy_artwork` and `finalize_auction` already protected payout flows with temporary storage locks to prevent reentrancy. `accept_offer` lacked the same protection, allowing a potential reentrant call during `distribute_payout` (for example, via a token contract with transfer callbacks) to accept the same offer multiple times before contract state was finalized.

This PR adds a listing-scoped reentrancy guard to `accept_offer`, aligning its behavior with the existing marketplace payout flows.

## Changes

### `accept_offer`

- Acquires `acquire_listing_lock` before validation and payout execution.
- Releases the lock on all error paths.
- Releases the lock after successful completion.
- Panics with `MarketplaceError::ReentrancyGuard` when the listing is already locked.

### Tests

- Added `test_accept_offer_reentrancy_guard`.
- Pre-acquires the listing lock and verifies that `accept_offer` fails with `MarketplaceError::ReentrancyGuard`.
- Confirms reentrant execution is blocked before payout processing begins.
