### PR TITLE
feat: added AUCTION_CANCELLED feature

### DIFF
--- a/indexer/src/__tests__/parser.test.ts
+++ b/indexer/src/__tests__/parser.test.ts
@@ -48,6 +48,7 @@ describe('parseMarketplaceEvent — topic mapping', () => {
     ['lst_updt', 'LISTING_UPDATED'],
     ['bid_plcd', 'BID_PLACED'],
     ['auc_rslv', 'AUCTION_RESOLVED'],
+    ['auc_cncl', 'AUCTION_CANCELLED'],
     ['ofr_made', 'OFFER_MADE'],
     ['ofr_accp', 'OFFER_ACCEPTED'],
     ['ofr_rjct', 'OFFER_REJECTED'],

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -264,6 +264,21 @@ describe('processEvent — BID_PLACED', () => {
   });
 });
 
+// ── AUCTION_CANCELLED ─────────────────────────────────────────────────────────
+
+describe('processEvent — AUCTION_CANCELLED', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sets auction status to Cancelled', async () => {
+    await processEvent(makeEvent('AUCTION_CANCELLED', 11n, 'GA_CREATOR', {}, 615));
+
+    expect(mockPrisma.auction.updateMany).toHaveBeenCalledWith({
+      where: { auctionId: 11n },
+      data: expect.objectContaining({ status: 'Cancelled' }),
+    });
+  });
+});
+
 // ── AUCTION_RESOLVED ───────────────────────────────────────────────────────────
 
 describe('processEvent — AUCTION_RESOLVED', () => {
@@ -501,6 +516,13 @@ describe('processEvent — out-of-order events do not throw', () => {
     const data = { winner: 'GB', amount: '100' };
     await expect(
       processEvent(makeEvent('AUCTION_RESOLVED', 99n, 'GA', data, 500))
+    ).resolves.not.toThrow();
+  });
+
+  it('AUCTION_CANCELLED with no prior auction resolves without throwing', async () => {
+    mockPrisma.auction.updateMany.mockResolvedValueOnce({ count: 0 });
+    await expect(
+      processEvent(makeEvent('AUCTION_CANCELLED', 99n, 'GA', {}, 500))
     ).resolves.not.toThrow();
   });
 });

--- a/indexer/src/parser.ts
+++ b/indexer/src/parser.ts
@@ -16,6 +16,7 @@ const TOPIC_MAP: Record<string, string> = {
   'lst_updt': 'LISTING_UPDATED',
   'bid_plcd': 'BID_PLACED',
   'auc_rslv': 'AUCTION_RESOLVED',
+  'auc_cncl': 'AUCTION_CANCELLED',
   'ofr_made': 'OFFER_MADE',
   'ofr_accp': 'OFFER_ACCEPTED',
   'ofr_rjct': 'OFFER_REJECTED',

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -574,6 +574,18 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
       break;
     }
 
+    case 'AUCTION_CANCELLED': {
+      const { count } = await db.auction.updateMany({
+        where: { auctionId: listingId },
+        data: {
+          status: 'Cancelled',
+          updatedAtLedger: ledgerSequence,
+        },
+      });
+      if (count === 0) console.warn(`AUCTION_CANCELLED: auction ${listingId} not found at ledger ${ledgerSequence}`);
+      break;
+    }
+
     case 'OFFER_MADE': {
       await db.offer.upsert({
         where: { offerId: BigInt(data.offer_id) },


### PR DESCRIPTION
## Summary

Fixes #253 by adding end-to-end support for auction cancellation events in the indexer.

Previously, auction cancellation events emitted by the contract were not recognized by the parser or processed by the poller, preventing cancelled auctions from being reflected in the indexer database and downstream consumers.

This PR adds support for `AUCTION_CANCELLED` events throughout the indexing pipeline.

## Changes

### Event Processing

#### `processEvent`

- Added handling for `AUCTION_CANCELLED` events.
- Updates the auction status to `Cancelled`.
- Updates `updatedAtLedger` using the same pattern as `LISTING_CANCELLED`.

### Event Parsing

#### Parser Mapping

- Added mapping from the on-chain topic:
  ```text
  auc_cncl
  ```
  to:
  ```text
  AUCTION_CANCELLED
  ```

- Ensures auction cancellation events are correctly decoded and forwarded to the poller.


Closes #253 