### PR TITLE
fix: add pause check to finalize_auction and fix pre-existing test bugs

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -595,6 +595,9 @@ impl MarketplaceContract {
     }
 
     pub fn finalize_auction(env: Env, caller: Address, auction_id: u64) {
+        if crate::storage::is_paused(&env) {
+            panic_with_error!(&env, MarketplaceError::ContractPaused);
+        }
         caller.require_auth();
 
         // Reentrancy guard

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -1563,7 +1563,7 @@ fn test_update_listing_too_many_recipients_fails() {
 }
 
 #[test]
-#[should_panic(expected = "Error(Contract, #8)")]
+#[should_panic(expected = "Error(Contract, #7)")]
 fn test_update_listing_empty_recipients_fails() {
     let (env, client, artist, _, token_id, _contract_id) = setup();
     client.set_admin(&artist);
@@ -2348,6 +2348,11 @@ fn test_buy_artwork_fails_if_token_delisted() {
     let (env, client, artist, buyer, token_id, _contract_id) = setup();
     client.set_admin(&artist);
     client.add_token_to_whitelist(&token_id);
+    // Add a second token so the whitelist is non-empty after removing token_id.
+    // An empty whitelist means "allow all" by design, so we need at least one
+    // other entry to make token_id genuinely non-whitelisted.
+    let other_token = Address::generate(&env);
+    client.add_token_to_whitelist(&other_token);
     let cid = bytes!(&env, 0x516d74657374);
     let id = client.create_listing(
         &artist,


### PR DESCRIPTION
Closes #268 

### What changed

finalize_auction missing pause check (contract.rs)

Every state-changing function in the marketplace checks is_paused at the top and panics with 
ContractPaused (#23) if the contract is paused — except finalize_auction. This meant auctions 
could be finalized (triggering token transfers and state mutations) while the contract was 
paused, which defeats the purpose of the pause mechanism entirely.

Added the guard as the very first check in finalize_auction, before require_auth and before the
reentrancy lock, consistent with all other state-changing functions.

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Pre-existing test bugs fixed

Two tests were failing on main before this PR.

test_update_listing_empty_recipients_fails

The test called update_listing with an empty recipients vector and expected 
TooManyRecipients (#8) to be thrown. The contract correctly throws InvalidSplit (#7) — zero 
recipients is a split validation failure, not a "too many" error. The #[should_panic] 
annotation had the wrong error code.

test_buy_artwork_fails_if_token_delisted

The test intended to verify that a buyer cannot purchase a listing whose token has since been 
removed from the whitelist. However, it added only one token to the whitelist and then removed 
it, leaving the whitelist empty. The is_token_whitelisted helper intentionally returns true 
when the whitelist is empty (open/permissionless mode — this is documented in 
test_add_and_remove_token_whitelist). So the purchase was never blocked, and the test never 
reached the expected panic.

Fixed by adding a second token to the whitelist before removal, so after 
remove_token_from_whitelist(&token_id) the whitelist is non-empty and token_id is genuinely not
whitelisted — correctly triggering TokenNotWhitelisted (#25).

━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### Test results

114 tests pass, 0 failures.