### PR TITLE
fix: extend TTL on treasury and protocol fee storage reads (#281)

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -918,14 +918,6 @@ impl MarketplaceContract {
         load_offerer_offers(&env, &offerer)
     }
 
-    pub fn get_total_auctions(env: Env) -> u64 {
-        crate::storage::get_auction_count(&env)
-    }
-
-    pub fn get_artist_auctions(env: Env, artist: Address) -> Vec<u64> {
-        crate::storage::get_artist_auction_ids(&env, &artist)
-    }
-
     fn require_admin(env: &Env) {
         let key = crate::storage::DataKey::Admin;
         let admin = env

--- a/contracts/soroban-marketplace/src/storage.rs
+++ b/contracts/soroban-marketplace/src/storage.rs
@@ -259,7 +259,13 @@ pub fn set_treasury_storage(env: &Env, addr: &Address) {
 }
 
 pub fn get_treasury_storage(env: &Env) -> Option<Address> {
-    env.storage().persistent().get(&DataKey::Treasury)
+    let value = env.storage().persistent().get(&DataKey::Treasury);
+    if value.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(&DataKey::Treasury, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    }
+    value
 }
 
 pub fn set_protocol_fee_bps_storage(env: &Env, bps: u32) {
@@ -269,7 +275,15 @@ pub fn set_protocol_fee_bps_storage(env: &Env, bps: u32) {
 }
 
 pub fn get_protocol_fee_bps_storage(env: &Env) -> Option<u32> {
-    env.storage().persistent().get(&DataKey::ProtocolFeeBps)
+    let value = env.storage().persistent().get(&DataKey::ProtocolFeeBps);
+    if value.is_some() {
+        env.storage().persistent().extend_ttl(
+            &DataKey::ProtocolFeeBps,
+            LEDGER_TTL_THRESHOLD,
+            LEDGER_TTL_BUMP,
+        );
+    }
+    value
 }
 
 // ── Reentrancy Guards ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Resolves #281. `get_treasury_storage` and `get_protocol_fee_bps_storage` read their persistent keys without extending TTL, risking expiry of these long-lived keys under read-heavy access patterns.

Both functions now call `extend_ttl` on a successful read, only bumping when the key actually exists. This mirrors the existing pattern in `is_artist_revoked_storage` and reuses the `LEDGER_TTL_THRESHOLD` / `LEDGER_TTL_BUMP` constants.

## Incidental fix

`master` currently fails to compile due to a duplicate `get_total_auctions` / `get_artist_auctions` definition (a bad-merge artifact). The redundant copies were removed so the crate builds; the kept definitions are functionally identical.

## Testing

- `cargo build` succeeds
- `cargo test` — all 114 tests pass, including `test_set_treasury_and_protocol_fee`