### PR TITLE
fix(launchpad): update page background to align with global dark them…

### DIFF
--- a/frontend/afristore-app/src/app/launchpad/page.tsx
+++ b/frontend/afristore-app/src/app/launchpad/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from "react";
 import Link from "next/link";
-import { Navbar } from "@/components/Navbar";
 import { useLaunchpadCollections } from "@/hooks/useLaunchpad";
 import { useWalletContext } from "@/context/WalletContext";
 import { useLaunchpadAdminCheck } from "@/hooks/useLaunchpadAdmin";
@@ -18,9 +17,7 @@ export default function LaunchpadPage() {
   const featured = collections.slice(0, 3);
 
   return (
-    <main className="min-h-screen bg-brand-50/20">
-      <Navbar />
-
+    <main className="min-h-screen bg-midnight-950 text-white selection:bg-brand-500 selection:text-white">
       <div className="pt-24 pb-12">
         {/* Hero Section */}
         <section className="relative overflow-hidden bg-gradient-to-br from-brand-500 via-terracotta-500 to-mint-500 text-white">
@@ -64,50 +61,50 @@ export default function LaunchpadPage() {
         <section className="py-20">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="text-center mb-16">
-              <span className="inline-block px-4 py-1.5 rounded-full bg-brand-100 text-brand-600 text-sm font-bold uppercase tracking-widest mb-4">
+              <span className="inline-block px-4 py-1.5 rounded-full bg-brand-500/20 text-brand-400 text-sm font-bold uppercase tracking-widest mb-4">
                 Features
               </span>
-              <h2 className="text-4xl font-display font-black text-gray-900 mb-4">
+              <h2 className="text-4xl font-display font-black text-white mb-4">
                 Everything You Need to Launch
               </h2>
-              <p className="text-gray-500 max-w-2xl mx-auto font-inter text-lg">
+              <p className="text-white/60 max-w-2xl mx-auto font-inter text-lg">
                 Our launchpad provides all the tools and infrastructure for successful NFT collection deployment.
               </p>
             </div>
 
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-              <div className="bg-white rounded-3xl p-8 border border-gray-100 shadow-sm hover:shadow-xl transition-all hover:-translate-y-2">
-                <div className="w-12 h-12 rounded-2xl bg-brand-100 flex items-center justify-center mb-6">
-                  <Palette size={24} className="text-brand-600" />
+              <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-sm hover:shadow-xl hover:shadow-brand-500/10 hover:border-brand-500/30 transition-all hover:-translate-y-2">
+                <div className="w-12 h-12 rounded-2xl bg-brand-500/20 flex items-center justify-center mb-6">
+                  <Palette size={24} className="text-brand-400" />
                 </div>
-                <h3 className="text-xl font-display font-bold text-gray-900 mb-3">
+                <h3 className="text-xl font-display font-bold text-white mb-3">
                   Multiple Standards
                 </h3>
-                <p className="text-gray-500 font-inter">
+                <p className="text-white/60 font-inter">
                   Deploy ERC-721 and ERC-1155 collections with normal or lazy minting capabilities.
                 </p>
               </div>
 
-              <div className="bg-white rounded-3xl p-8 border border-gray-100 shadow-sm hover:shadow-xl transition-all hover:-translate-y-2">
-                <div className="w-12 h-12 rounded-2xl bg-mint-100 flex items-center justify-center mb-6">
-                  <Zap size={24} className="text-mint-600" />
+              <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-sm hover:shadow-xl hover:shadow-mint-500/10 hover:border-mint-500/30 transition-all hover:-translate-y-2">
+                <div className="w-12 h-12 rounded-2xl bg-mint-500/20 flex items-center justify-center mb-6">
+                  <Zap size={24} className="text-mint-400" />
                 </div>
-                <h3 className="text-xl font-display font-bold text-gray-900 mb-3">
+                <h3 className="text-xl font-display font-bold text-white mb-3">
                   Gas Efficient
                 </h3>
-                <p className="text-gray-500 font-inter">
+                <p className="text-white/60 font-inter">
                   Shared WASM bytecode reduces deployment costs and network storage requirements.
                 </p>
               </div>
 
-              <div className="bg-white rounded-3xl p-8 border border-gray-100 shadow-sm hover:shadow-xl transition-all hover:-translate-y-2">
-                <div className="w-12 h-12 rounded-2xl bg-terracotta-100 flex items-center justify-center mb-6">
-                  <TrendingUp size={24} className="text-terracotta-600" />
+              <div className="bg-white/5 backdrop-blur-md rounded-3xl p-8 border border-white/10 shadow-sm hover:shadow-xl hover:shadow-terracotta-500/10 hover:border-terracotta-500/30 transition-all hover:-translate-y-2">
+                <div className="w-12 h-12 rounded-2xl bg-terracotta-500/20 flex items-center justify-center mb-6">
+                  <TrendingUp size={24} className="text-terracotta-400" />
                 </div>
-                <h3 className="text-xl font-display font-bold text-gray-900 mb-3">
+                <h3 className="text-xl font-display font-bold text-white mb-3">
                   Royalty Support
                 </h3>
-                <p className="text-gray-500 font-inter">
+                <p className="text-white/60 font-inter">
                   Built-in royalty enforcement ensures creators earn from secondary sales.
                 </p>
               </div>
@@ -116,30 +113,30 @@ export default function LaunchpadPage() {
         </section>
 
         {/* Stats Section */}
-        <section className="py-20 bg-white">
+        <section className="py-20 bg-midnight-900 border-y border-white/5">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
               <div className="text-center">
-                <div className="text-4xl font-display font-black text-brand-600 mb-2">
+                <div className="text-4xl font-display font-black text-brand-400 mb-2">
                   {collections.length}
                 </div>
-                <div className="text-gray-500 font-inter font-medium">
+                <div className="text-white/50 font-inter font-medium">
                   Collections Deployed
                 </div>
               </div>
               <div className="text-center">
-                <div className="text-4xl font-display font-black text-mint-600 mb-2">
+                <div className="text-4xl font-display font-black text-mint-400 mb-2">
                   {new Set(collections.map(c => c.creator)).size}
                 </div>
-                <div className="text-gray-500 font-inter font-medium">
+                <div className="text-white/50 font-inter font-medium">
                   Active Creators
                 </div>
               </div>
               <div className="text-center">
-                <div className="text-4xl font-display font-black text-terracotta-600 mb-2">
+                <div className="text-4xl font-display font-black text-terracotta-400 mb-2">
                   4
                 </div>
-                <div className="text-gray-500 font-inter font-medium">
+                <div className="text-white/50 font-inter font-medium">
                   Collection Types
                 </div>
               </div>
@@ -153,19 +150,19 @@ export default function LaunchpadPage() {
             <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
               <div className="flex flex-col md:flex-row md:items-end justify-between gap-6 mb-12">
                 <div>
-                  <span className="inline-block px-4 py-1.5 rounded-full bg-brand-100 text-brand-600 text-sm font-bold uppercase tracking-widest mb-4">
+                  <span className="inline-block px-4 py-1.5 rounded-full bg-brand-500/20 text-brand-400 text-sm font-bold uppercase tracking-widest mb-4">
                     Featured
                   </span>
-                  <h2 className="text-4xl font-display font-black text-gray-900 mb-4">
+                  <h2 className="text-4xl font-display font-black text-white mb-4">
                     Latest Collections
                   </h2>
-                  <p className="text-gray-500 max-w-xl font-inter text-lg">
+                  <p className="text-white/60 max-w-xl font-inter text-lg">
                     Discover the newest collections launched on our platform.
                   </p>
                 </div>
                 <Link
                   href="/launchpad/collections"
-                  className="flex items-center gap-2 rounded-2xl bg-gray-100 px-6 py-3 text-sm font-bold text-gray-900 hover:bg-brand-500 hover:text-white transition-all"
+                  className="flex items-center gap-2 rounded-2xl bg-white/10 px-6 py-3 text-sm font-bold text-white hover:bg-brand-500 transition-all"
                 >
                   View All
                   <ExternalLink size={16} />
@@ -175,40 +172,40 @@ export default function LaunchpadPage() {
               {isLoading ? (
                 <div className="flex flex-col items-center justify-center py-20 gap-4">
                   <Loader2 size={48} className="animate-spin text-brand-500" />
-                  <p className="text-gray-500 font-medium font-inter">Loading collections...</p>
+                  <p className="text-white/60 font-medium font-inter">Loading collections...</p>
                 </div>
               ) : error ? (
-                <div className="rounded-3xl bg-red-50 p-12 text-center border border-red-100">
-                  <p className="text-red-600 font-bold mb-4">{error}</p>
+                <div className="rounded-3xl bg-red-500/10 p-12 text-center border border-red-500/20">
+                  <p className="text-red-400 font-bold mb-4">{error}</p>
                 </div>
               ) : (
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
                   {featured.map((c) => (
                     <div
                       key={c.address}
-                      className="group bg-white rounded-3xl border border-gray-100 p-6 shadow-sm hover:shadow-xl hover:shadow-brand-900/5 transition-all hover:-translate-y-1"
+                      className="group bg-white/5 backdrop-blur-md rounded-3xl border border-white/10 p-6 shadow-sm hover:shadow-xl hover:shadow-brand-500/10 hover:border-brand-500/30 transition-all hover:-translate-y-1"
                     >
                       <div className="flex justify-between items-start mb-4">
                         <span className={`px-3 py-1 rounded-full text-xs font-bold tracking-wider uppercase ${
-                          c.kind.startsWith('Lazy') ? 'bg-amber-100 text-amber-700' : 'bg-brand-100 text-brand-700'
+                          c.kind.startsWith('Lazy') ? 'bg-amber-500/20 text-amber-400' : 'bg-brand-500/20 text-brand-400'
                         }`}>
                           {c.kind}
                         </span>
                       </div>
-                      <h3 className="text-xl font-display font-bold text-gray-900 mb-2 truncate" title={c.address}>
+                      <h3 className="text-xl font-display font-bold text-white mb-2 truncate" title={c.address}>
                         {c.address.slice(0, 8)}...{c.address.slice(-8)}
                       </h3>
                       <div className="space-y-2 mb-4">
                         <div className="flex justify-between text-sm">
-                          <span className="text-gray-400 font-inter">Creator</span>
-                          <span className="text-gray-700 font-mono font-medium truncate ml-4 w-32 text-right">
+                          <span className="text-white/40 font-inter">Creator</span>
+                          <span className="text-white/70 font-mono font-medium truncate ml-4 w-32 text-right">
                             {c.creator.slice(0, 4)}...{c.creator.slice(-4)}
                           </span>
                         </div>
                       </div>
                       <Link
                         href={`/launchpad/collections/${c.address}`}
-                        className="mt-4 block w-full text-center py-3 rounded-2xl bg-gray-50 text-gray-900 font-bold hover:bg-brand-500 hover:text-white transition-all"
+                        className="mt-4 block w-full text-center py-3 rounded-2xl bg-white/10 text-white font-bold hover:bg-brand-500 transition-all"
                       >
                         View Details
                       </Link>


### PR DESCRIPTION
Closes #323.

### Context
The Launchpad page previously used a light background, causing the Navbar elements (which are white) to be practically invisible when navigating the page. Furthermore, it did not follow the global dark aesthetic utilized in the rest of the application.

### Changes Made
- Updated the Launchpad page wrapper to use the global dark theme (`bg-midnight-950 text-white`).
- Removed the redundant `<Navbar />` tag since the navigation is already rendered globally in `layout.tsx`.
- Updated section backgrounds, border colors, and text classes on the Launchpad page (Features, Stats, Collections) to properly align with the dark aesthetic of the application and to ensure all elements are clearly visible.

### Acceptance Criteria Met
- [x] The background color of the Launchpad page now aligns with the global dark theme.
- [x] The Navbar elements are now clearly visible and accessible.
