### PR TITLE
fix: treat empty indexer response as valid state in listings

### DIFF
--- a/frontend/afristore-app/src/__tests__/contract.test.ts
+++ b/frontend/afristore-app/src/__tests__/contract.test.ts
@@ -1,4 +1,17 @@
-import { stroopsToXlm, xlmToStroops } from "../lib/contract";
+import { stroopsToXlm, xlmToStroops, getAllListings } from "../lib/contract";
+
+jest.mock("@/lib/e2e-chain-mock", () => ({
+  isE2eMockChain: () => false,
+  e2eMockCreateListing: jest.fn(),
+  e2eMockBuyArtwork: jest.fn(),
+  getE2eMockListings: jest.fn(),
+  registerE2eMockListingsOnWindow: jest.fn(),
+}));
+
+jest.mock("@/lib/indexer", () => ({
+  fetchListings: jest.fn(),
+  fetchAuctions: jest.fn(),
+}));
 
 describe("xlmToStroops", () => {
   it("converts 0.0000001 XLM to 1 stroop (FP bug regression)", () => {
@@ -51,5 +64,41 @@ describe("stroopsToXlm", () => {
     // Whole: 12345678901234567890123n
     // Frac: 4567890n -> "456789"
     expect(stroopsToXlm(largeStroops)).toBe("12345678901234567890123.456789");
+  });
+});
+
+describe("getAllListings — indexer path", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns empty array when indexer responds with { listings: [] }", async () => {
+    const { fetchListings } = jest.requireMock("@/lib/indexer");
+    fetchListings.mockResolvedValueOnce({ listings: [] });
+
+    const result = await getAllListings();
+
+    expect(result).toEqual([]);
+    expect(fetchListings).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns listings from indexer without on-chain fallback", async () => {
+    const { fetchListings } = jest.requireMock("@/lib/indexer");
+    const mockListing = { listing_id: 1, artist: "GARTIST", status: "Active" };
+    fetchListings.mockResolvedValueOnce({ listings: [mockListing] });
+
+    const result = await getAllListings();
+
+    expect(result).toEqual([mockListing]);
+    expect(fetchListings).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not return empty array when indexer response has no listings field", async () => {
+    const { fetchListings } = jest.requireMock("@/lib/indexer");
+    // Returns a non-array for listings — should fall through to on-chain path,
+    // but since we cannot reach Soroban in unit tests, we only assert indexer was called.
+    fetchListings.mockResolvedValueOnce({ listings: null });
+
+    // On-chain path will throw (no real RPC) — catch and assert indexer was attempted.
+    await expect(getAllListings()).rejects.toThrow();
+    expect(fetchListings).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/afristore-app/src/__tests__/useMarketplace.test.tsx
+++ b/frontend/afristore-app/src/__tests__/useMarketplace.test.tsx
@@ -120,10 +120,9 @@ describe("useMarketplace", () => {
     );
   });
 
-  it("falls back to on-chain when indexer returns empty", async () => {
+  it("treats empty indexer response as valid — no on-chain fallback", async () => {
     const { fetchListings } = jest.requireMock("@/lib/indexer");
     fetchListings.mockResolvedValueOnce({ listings: [], total: 0 });
-    mockGetAllListings.mockResolvedValueOnce([makeListing(1), makeListing(2)]);
 
     function Comp() {
       const { listings } = useMarketplace();
@@ -131,8 +130,9 @@ describe("useMarketplace", () => {
     }
     render(<Comp />);
     await waitFor(() =>
-      expect(screen.getByTestId("count").textContent).toBe("2"),
+      expect(screen.getByTestId("count").textContent).toBe("0"),
     );
+    expect(mockGetAllListings).not.toHaveBeenCalled();
   });
 
   it("falls back to on-chain when indexer throws", async () => {

--- a/frontend/afristore-app/src/app/explore/page.tsx
+++ b/frontend/afristore-app/src/app/explore/page.tsx
@@ -96,11 +96,11 @@ export default function ExplorePage() {
       const res = await fetchListings(opts);
       const rows = Array.isArray(res.listings)
         ? (res.listings as Listing[])
-        : [];
-      if (rows.length > 0) {
+        : null;
+      if (rows !== null) {
         setAllListings(rows);
       } else {
-        // Fallback to on-chain scan when indexer returns nothing
+        // Fallback to on-chain scan only when indexer response is malformed
         const all = await getAllListings();
         setAllListings(all);
       }

--- a/frontend/afristore-app/src/hooks/useMarketplace.ts
+++ b/frontend/afristore-app/src/hooks/useMarketplace.ts
@@ -59,13 +59,13 @@ export function useMarketplace(opts?: { page?: number; limit?: number }) {
           setListings(sorted as Listing[]);
         } else {
           const res = await fetchListings({ status: "Active", limit: 1000 });
-          if (Array.isArray(res.listings) && res.listings.length > 0) {
+          if (Array.isArray(res.listings)) {
             const sorted = [...res.listings].sort(
               (a: any, b: any) => b.created_at - a.created_at,
             );
             setListings(sorted as Listing[]);
           } else {
-            // Fallback to on-chain scan
+            // Fallback to on-chain scan only when indexer response is malformed
             const all = await getAllListings();
             const sorted = [...all].sort((a, b) => b.created_at - a.created_at);
             setListings(sorted);

--- a/frontend/afristore-app/src/lib/contract.ts
+++ b/frontend/afristore-app/src/lib/contract.ts
@@ -423,7 +423,7 @@ export async function getAllListings(): Promise<Listing[]> {
   // Optimized path: Use the indexer (1 RPC/HTTP call)
   try {
     const res = await fetchListings({ status: "Active" });
-    if (res.listings && res.listings.length > 0) {
+    if (Array.isArray(res.listings)) {
       return res.listings as Listing[];
     }
   } catch (e) {
@@ -432,31 +432,12 @@ export async function getAllListings(): Promise<Listing[]> {
 
   // Backup path: On-chain scan (N RPC calls)
   const total = await getTotalListings();
+  if (total <= 0) return [];
   const ids = Array.from({ length: total }, (_, i) => i + 1);
   const results = await Promise.all(
     ids.map((id) => getListing(id).catch(() => null)),
   );
   return results.filter((l): l is Listing => l !== null);
-  const totalRaw = await getTotalListings();
-  if (total <= 0) return [];
-
-  const listings: Listing[] = [];
-  const BATCH_SIZE = 10;
-
-  for (let offset = 1; offset <= total; offset += BATCH_SIZE) {
-    const batchIds = Array.from(
-      { length: Math.min(BATCH_SIZE, total - offset + 1) },
-      (_, i) => offset + i,
-    );
-
-    const results = await Promise.all(
-      batchIds.map((id) => getListing(id).catch(() => null)),
-    );
-
-    listings.push(...results.filter((l): l is Listing => l !== null));
-  }
-
-  return listings;
 }
 
 // ── Offer types mirrored from the Rust contract ──────────────


### PR DESCRIPTION
**Resolves Issue:** Empty indexer response (`{ listings: [] }`) was treated as a failure, triggering on-chain fallback to a broken Soroban testnet contract, crashing the
  Explore page with `Bad union switch: 1` instead of rendering "No artworks found".

  **Fix:** Three frontend files now accept an empty array from the indexer as a valid successful response. On-chain fallback only triggers on indexer throw/unreachable, not on
  empty results.

  Files changed: `contract.ts` (`getAllListings`), `useMarketplace.ts`, `explore/page.tsx`, plus tests in `contract.test.ts` and `useMarketplace.test.tsx`.

  ### Soroban Safety Checklist
  > **N/A — frontend-only change. No Soroban contracts were modified.**

  - [ ] **TTL Extensions:** N/A
  - [ ] **Instance TTL:** N/A
  - [ ] **Authorization:** N/A
  - [ ] **Gas Efficiency:** N/A
  - [ ] **State Bloat:** N/A
  - [ ] **Signature Security:** N/A
  - [ ] **Front-Running Protection:** N/A
  - [ ] **Error Handling:** N/A

  ## Testing
  - [x] I have added unit tests to cover my changes and tested edge cases.
  - [x] All tests pass locally (`npx jest` → 26/26 pass across `contract.test.ts` and `useMarketplace.test.tsx`).

  ## Additional Context

  - Empty DB + indexer running → Explore page renders "No artworks found" (verified locally)
  - Indexer down → on-chain fallback still triggers as before
  - Indexer returning listings → grid renders normally, no regression
  - `getAllAuctions` in `contract.ts` still has the same pattern bug (`raw.length > 0`) — tracked separately, out of scope for this fix
  
  Closes #326 