### PR TITLE
removing Dead imports and unused variables

### DIFF
--- a/frontend/afristore-app/src/app/launchpad/page.tsx
+++ b/frontend/afristore-app/src/app/launchpad/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import Link from "next/link";
 import { useLaunchpadCollections } from "@/hooks/useLaunchpad";
 import { useWalletContext } from "@/context/WalletContext";
@@ -12,8 +11,6 @@ import {
   Zap,
   ExternalLink,
   TrendingUp,
-  Users,
-  Star,
   Shield,
 } from "lucide-react";
 
@@ -21,7 +18,6 @@ export default function LaunchpadPage() {
   const { collections, isLoading, error } = useLaunchpadCollections();
   const { publicKey, isConnected } = useWalletContext();
   const { isAdmin } = useLaunchpadAdminCheck(publicKey);
-  const [featuredCollections, setFeaturedCollections] = useState<any[]>([]);
 
   // Get some featured collections (first 3 for now)
   const featured = collections.slice(0, 3);

--- a/frontend/afristore-app/src/app/page.tsx
+++ b/frontend/afristore-app/src/app/page.tsx
@@ -615,24 +615,4 @@ function FinalCTASection({
   );
 }
 
-// Re-export useInView for sub-components
-function useInView2(threshold = 0.2) {
-  const ref = useRef<HTMLDivElement>(null);
-  const [inView, setInView] = useState(false);
-  useEffect(() => {
-    const el = ref.current;
-    if (!el) return;
-    const obs = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setInView(true);
-          obs.unobserve(el);
-        }
-      },
-      { threshold },
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, [threshold]);
-  return { ref, inView };
-}
+


### PR DESCRIPTION
## Description  
closes #314                                                                      
    Resolves Issue: Fixes unused variables, imports, hooks, and states across several frontend files:                                                                        
                                                                                         
     `app/page.tsx`: Removed the unused `useInView2` hook.   
    ---                           
   `app/listings/[id]/page.tsx`: Removed the unused imports for `ListingStatus` and `AuctionStatus`. 
    ---
     `app/launchpad/page.tsx`: Removed unused `Users` and `Star` icon imports from `lucide-react` as well 
     as the unused `featuredCollections` state and unused `useState` import.