### PR TITLE
feat: add Royalty Splitter deployment UI (#337)

### DIFF
--- a/frontend/afristore-app/src/app/dashboard/splitter/page.tsx
+++ b/frontend/afristore-app/src/app/dashboard/splitter/page.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useState } from "react";
+import { useWalletContext } from "@/context/WalletContext";
+import { useDeploySplitter } from "@/hooks/useSplitter";
+import { SplitterRecipient } from "@/lib/splitter";
+import { WalletGuard } from "@/components/WalletGuard";
+import {
+  Plus,
+  Trash2,
+  Copy,
+  Check,
+  Wand2,
+  Users,
+  ArrowLeft,
+} from "lucide-react";
+import Link from "next/link";
+import { clsx } from "clsx";
+
+interface Beneficiary {
+  id: number;
+  address: string;
+  percentage: string;
+}
+
+function createEmptyBeneficiary(nextId: number): Beneficiary {
+  return { id: nextId, address: "", percentage: "" };
+}
+
+function validatePercentages(
+  beneficiaries: Beneficiary[],
+): string | null {
+  const filled = beneficiaries.filter(
+    (b) => b.address.trim() !== "" || b.percentage.trim() !== "",
+  );
+  if (filled.length === 0) return "Add at least one beneficiary.";
+
+  for (const b of filled) {
+    if (!b.address.trim()) return "All beneficiaries must have an address.";
+    const pct = parseFloat(b.percentage);
+    if (isNaN(pct) || pct < 0 || pct > 100) {
+      return "Each percentage must be between 0 and 100.";
+    }
+  }
+
+  const total = filled.reduce((sum, b) => sum + parseFloat(b.percentage || "0"), 0);
+  const rounded = Math.round(total * 100) / 100;
+  if (rounded !== 100) {
+    return `Total percentages must equal exactly 100% (currently ${rounded}%).`;
+  }
+
+  return null;
+}
+
+export default function SplitterPage() {
+  const { publicKey } = useWalletContext();
+  const { deploy, isDeploying, error } = useDeploySplitter(publicKey);
+  const [beneficiaries, setBeneficiaries] = useState<Beneficiary[]>([
+    createEmptyBeneficiary(0),
+  ]);
+  const [nextId, setNextId] = useState(1);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [deployedAddress, setDeployedAddress] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const addBeneficiary = () => {
+    setBeneficiaries((prev) => [...prev, createEmptyBeneficiary(nextId)]);
+    setNextId((n) => n + 1);
+    setValidationError(null);
+  };
+
+  const removeBeneficiary = (id: number) => {
+    setBeneficiaries((prev) => {
+      if (prev.length <= 1) return prev;
+      return prev.filter((b) => b.id !== id);
+    });
+    setValidationError(null);
+  };
+
+  const updateBeneficiary = (
+    id: number,
+    field: "address" | "percentage",
+    value: string,
+  ) => {
+    setBeneficiaries((prev) =>
+      prev.map((b) => (b.id === id ? { ...b, [field]: value } : b)),
+    );
+    setValidationError(null);
+  };
+
+  const handleSubmit = async () => {
+    const err = validatePercentages(beneficiaries);
+    if (err) {
+      setValidationError(err);
+      return;
+    }
+
+    setValidationError(null);
+
+    const recipients: SplitterRecipient[] = beneficiaries
+      .filter((b) => b.address.trim() !== "" || b.percentage.trim() !== "")
+      .map((b) => ({
+        address: b.address.trim(),
+        percentage: parseInt(b.percentage.trim(), 10),
+      }));
+
+    const address = await deploy(recipients);
+    if (address) {
+      setDeployedAddress(address);
+    }
+  };
+
+  const total = beneficiaries
+    .filter((b) => b.address.trim() || b.percentage.trim())
+    .reduce((sum, b) => sum + (parseFloat(b.percentage) || 0), 0);
+
+  const copyAddress = async () => {
+    if (!deployedAddress) return;
+    await navigator.clipboard.writeText(deployedAddress);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  const resetForm = () => {
+    setBeneficiaries([createEmptyBeneficiary(0)]);
+    setNextId(1);
+    setDeployedAddress(null);
+    setValidationError(null);
+  };
+
+  return (
+    <div className="min-h-screen bg-midnight-950 pb-20 pt-24 selection:bg-brand-500 selection:text-white">
+      <div className="fixed inset-0 pointer-events-none opacity-[0.03] z-0 overflow-hidden">
+        <div className="absolute inset-0 tribal-pattern scale-150 rotate-12" />
+      </div>
+
+      <WalletGuard actionName="To create a royalty splitter">
+        <div className="relative z-10 mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <Link
+            href="/dashboard"
+            className="inline-flex items-center gap-2 text-white/50 hover:text-brand-400 transition-colors text-sm mb-6"
+          >
+            <ArrowLeft size={16} />
+            Back to Dashboard
+          </Link>
+
+          <div className="relative mb-10 overflow-hidden rounded-[3rem] bg-midnight-900 border border-white/5 shadow-2xl p-8 sm:p-12">
+            <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-brand-500/10 blur-[100px]" />
+            <div className="absolute -bottom-24 -left-24 h-64 w-64 rounded-full bg-mint-500/10 blur-[100px]" />
+            <div className="absolute top-0 right-0 left-0 tribal-strip h-1.5 opacity-40" />
+
+            <div className="relative flex flex-col items-center text-center gap-4">
+              <div className="relative group">
+                <div className="absolute -inset-1.5 rounded-[2.5rem] bg-gradient-to-tr from-brand-500 via-terracotta-400 to-mint-500 opacity-80 blur transition duration-700 group-hover:opacity-100" />
+                <div className="relative flex h-20 w-20 items-center justify-center rounded-[2.2rem] bg-midnight-950 border border-white/10 shadow-2xl">
+                  <Wand2 size={36} className="text-brand-400" />
+                </div>
+              </div>
+              <div>
+                <h1 className="text-3xl sm:text-4xl font-display font-black text-white">
+                  Create Royalty Splitter
+                </h1>
+                <p className="mt-2 text-white/50 text-sm max-w-md">
+                  Deploy a smart contract to automatically split royalties among
+                  galleries, co-creators, and collaborators.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {deployedAddress ? (
+            <div className="animate-fade-in">
+              <div className="rounded-[2rem] bg-midnight-900 border border-mint-500/20 shadow-xl p-8 text-center">
+                <div className="flex items-center justify-center h-16 w-16 mx-auto rounded-2xl bg-mint-500/10 text-mint-400">
+                  <Check size={32} />
+                </div>
+                <h2 className="mt-6 text-2xl font-display font-bold text-white">
+                  Splitter Deployed
+                </h2>
+                <p className="mt-2 text-white/50 text-sm">
+                  Your Royalty Splitter contract is live on-chain.
+                </p>
+                <div className="mt-6 flex items-center gap-3 p-4 rounded-xl bg-midnight-950 border border-white/10">
+                  <code className="flex-1 text-sm font-mono text-mint-400 break-all text-left">
+                    {deployedAddress}
+                  </code>
+                  <button
+                    onClick={copyAddress}
+                    className="shrink-0 p-2.5 rounded-lg bg-white/5 hover:bg-white/10 text-white/60 hover:text-white transition-colors"
+                    title="Copy contract address"
+                  >
+                    {copied ? (
+                      <Check size={16} className="text-mint-400" />
+                    ) : (
+                      <Copy size={16} />
+                    )}
+                  </button>
+                </div>
+                <button
+                  onClick={resetForm}
+                  className="mt-6 inline-flex items-center gap-2 rounded-xl bg-brand-500 px-8 py-3.5 text-base font-bold text-white shadow-xl shadow-brand-500/30 hover:bg-brand-600 transition-all"
+                >
+                  <Plus size={18} />
+                  Create Another
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="animate-fade-in space-y-6">
+              <div className="rounded-[2rem] bg-midnight-900 border border-white/5 shadow-xl p-6 sm:p-8">
+                <div className="flex items-center justify-between mb-6">
+                  <div className="flex items-center gap-3">
+                    <div className="flex items-center justify-center h-10 w-10 rounded-xl bg-brand-500/10 text-brand-400">
+                      <Users size={20} />
+                    </div>
+                    <div>
+                      <h2 className="font-display font-bold text-white text-lg">
+                        Beneficiaries
+                      </h2>
+                      <p className="text-white/40 text-xs">
+                        Add addresses and percentages — must total 100%
+                      </p>
+                    </div>
+                  </div>
+                  <button
+                    onClick={addBeneficiary}
+                    className="flex items-center gap-1.5 px-4 py-2 rounded-lg bg-brand-500/10 hover:bg-brand-500/20 text-brand-400 text-sm font-bold transition-colors"
+                  >
+                    <Plus size={16} />
+                    Add
+                  </button>
+                </div>
+
+                <div className="space-y-4">
+                  {beneficiaries.map((b) => (
+                    <div
+                      key={b.id}
+                      className="flex flex-col sm:flex-row items-start sm:items-center gap-3 p-4 rounded-xl bg-midnight-950 border border-white/5"
+                    >
+                      <div className="flex-1 w-full sm:w-auto">
+                        <label className="block text-xs font-bold text-white/40 uppercase tracking-widest mb-1.5">
+                          Address
+                        </label>
+                        <input
+                          type="text"
+                          value={b.address}
+                          onChange={(e) =>
+                            updateBeneficiary(b.id, "address", e.target.value)
+                          }
+                          placeholder="GABC…"
+                          className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2.5 text-sm font-mono text-white placeholder:text-white/20 focus:outline-none focus:border-brand-400 focus:ring-1 focus:ring-brand-400/30 transition-colors"
+                        />
+                      </div>
+                      <div className="w-28">
+                        <label className="block text-xs font-bold text-white/40 uppercase tracking-widest mb-1.5">
+                          %
+                        </label>
+                        <div className="relative">
+                          <input
+                            type="number"
+                            value={b.percentage}
+                            onChange={(e) =>
+                              updateBeneficiary(
+                                b.id,
+                                "percentage",
+                                e.target.value,
+                              )
+                            }
+                            min="0"
+                            max="100"
+                            step="1"
+                            placeholder="0"
+                            className="w-full bg-white/5 border border-white/10 rounded-lg px-4 py-2.5 text-sm font-mono text-white placeholder:text-white/20 focus:outline-none focus:border-brand-400 focus:ring-1 focus:ring-brand-400/30 transition-colors pr-8"
+                          />
+                          <span className="absolute right-3 top-1/2 -translate-y-1/2 text-white/30 text-sm font-bold">
+                            %
+                          </span>
+                        </div>
+                      </div>
+                      <button
+                        onClick={() => removeBeneficiary(b.id)}
+                        disabled={beneficiaries.length <= 1}
+                        className="shrink-0 p-2.5 rounded-lg text-white/30 hover:text-terracotta-400 hover:bg-terracotta-500/10 transition-colors disabled:opacity-20 disabled:cursor-not-allowed mt-5 sm:mt-0"
+                        title="Remove beneficiary"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+
+                <div className="mt-4 flex items-center justify-between p-4 rounded-xl bg-midnight-950 border border-white/5">
+                  <span className="text-sm font-bold text-white/50">
+                    Total
+                  </span>
+                  <span
+                    className={clsx(
+                      "text-lg font-display font-black",
+                      total === 100
+                        ? "text-mint-400"
+                        : total > 100
+                          ? "text-terracotta-400"
+                          : "text-white/40",
+                    )}
+                  >
+                    {total.toFixed(0)}%
+                  </span>
+                </div>
+              </div>
+
+              {(validationError || error) && (
+                <div className="p-4 rounded-xl bg-terracotta-500/10 border border-terracotta-500/20 text-sm font-bold text-terracotta-400">
+                  {validationError || error}
+                </div>
+              )}
+
+              <button
+                onClick={handleSubmit}
+                disabled={isDeploying}
+                className="w-full flex items-center justify-center gap-3 rounded-2xl bg-brand-500 py-5 text-lg font-display font-black text-white shadow-2xl shadow-brand-500/30 hover:bg-brand-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed active:scale-[0.98]"
+              >
+                {isDeploying ? (
+                  <>
+                    <svg
+                      className="animate-spin h-5 w-5"
+                      xmlns="http://www.w3.org/2000/svg"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                    >
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Deploying…
+                  </>
+                ) : (
+                  <>
+                    <Wand2 size={20} />
+                    Deploy Royalty Splitter
+                  </>
+                )}
+              </button>
+            </div>
+          )}
+        </div>
+      </WalletGuard>
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -4,12 +4,13 @@
 
 "use client";
 
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
 import {
   Wallet,
   Store,
+  LayoutDashboard,
   Menu,
   X,
   AlertTriangle,
@@ -23,60 +24,32 @@ import {
   Settings,
   HelpCircle,
   Rocket,
-  LayoutDashboard,
-  ChevronDown,
+  Split,
 } from "lucide-react";
 import { ConnectWalletModal } from "./ConnectWalletModal";
 
-// Post-login actions hidden behind the user menu
-const USER_MENU_ITEMS = [
-  { href: "/profile", icon: User, label: "My Profile" },
-  { href: "/dashboard", icon: LayoutDashboard, label: "Dashboard" },
-  { href: "/offers", icon: Tag, label: "My Offers" },
-  { href: "/offers/incoming", icon: Inbox, label: "Offer Inbox" },
-  { href: "/settings", icon: Settings, label: "Settings" },
-] as const;
-
 export function Navbar() {
-  const { publicKey, isConnected, isConnecting, disconnect, isWrongNetwork } =
-    useWalletContext();
-
+  const {
+    publicKey,
+    isConnected,
+    isConnecting,
+    disconnect,
+    isWrongNetwork,
+    status,
+  } = useWalletContext();
   const [scrolled, setScrolled] = useState(false);
   const [mobileOpen, setMobileOpen] = useState(false);
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-
-  const userMenuRef = useRef<HTMLDivElement>(null);
 
   const shortKey = publicKey
     ? `${publicKey.slice(0, 4)}…${publicKey.slice(-4)}`
     : null;
 
-  // Transparent → solid on scroll
+  // Detect scroll for transparent → solid transition
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 60);
     window.addEventListener("scroll", handleScroll, { passive: true });
     return () => window.removeEventListener("scroll", handleScroll);
-  }, []);
-
-  // Close user dropdown when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (e: MouseEvent) => {
-      if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
-        setUserMenuOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  // Close mobile drawer on resize to desktop
-  useEffect(() => {
-    const handleResize = () => {
-      if (window.innerWidth >= 768) setMobileOpen(false);
-    };
-    window.addEventListener("resize", handleResize);
-    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   return (
@@ -99,7 +72,7 @@ export function Navbar() {
             </span>
           </Link>
 
-          {/* Desktop nav — public links only */}
+          {/* Desktop nav links */}
           <div className="hidden md:flex items-center gap-8 text-sm font-medium">
             <Link
               href="/"
@@ -129,6 +102,56 @@ export function Navbar() {
               <Rocket size={16} />
               Launchpad
             </Link>
+            {isConnected && (
+              <>
+                <Link
+                  href="/dashboard"
+                  className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+                >
+                  <LayoutDashboard size={16} />
+                  Dashboard
+                </Link>
+                <Link
+                  href="/dashboard/splitter"
+                  className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+                >
+                  <Split size={16} />
+                  Splitter
+                </Link>
+                <Link
+                  href="/profile"
+                  className="flex items-center gap-1.5 text-white/70 hover:text-mint-400 transition-colors duration-300"
+                >
+                  <User size={16} />
+                  My Profile
+                </Link>
+              </>
+            )}
+            {isConnected && (
+              <Link
+                href="/offers"
+                className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+              >
+                <Tag size={16} />
+                My Offers
+              </Link>
+            )}
+            {isConnected && (
+              <Link
+                href="/offers/incoming"
+                className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+              >
+                <Inbox size={16} />
+                Offer Inbox
+              </Link>
+            )}
+            <Link
+              href="/settings"
+              className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+            >
+              <Settings size={16} />
+              Settings
+            </Link>
             <Link
               href="/help"
               className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
@@ -138,11 +161,10 @@ export function Navbar() {
             </Link>
           </div>
 
-          {/* Desktop wallet / user area */}
+          {/* Desktop wallet button */}
           <div className="hidden md:flex items-center gap-4">
             {isConnected ? (
               <div className="flex items-center gap-3">
-                {/* Network status badge */}
                 {isWrongNetwork ? (
                   <button
                     onClick={() => setIsModalOpen(true)}
@@ -158,63 +180,19 @@ export function Navbar() {
                   </div>
                 )}
 
-                {/* User dropdown trigger */}
-                <div className="relative" ref={userMenuRef}>
-                  <button
-                    onClick={() => setUserMenuOpen((prev) => !prev)}
-                    className="flex items-center gap-2 pl-3 pr-2 py-1 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 transition-colors"
-                    aria-haspopup="true"
-                    aria-expanded={userMenuOpen}
-                  >
-                    <span className="text-xs font-mono text-white/90">{shortKey}</span>
-                    <ChevronDown
-                      size={14}
-                      className={`text-white/40 transition-transform duration-200 ${
-                        userMenuOpen ? "rotate-180" : ""
-                      }`}
-                    />
-                  </button>
-
-                  {/* Dropdown panel */}
-                  {userMenuOpen && (
-                    <div className="absolute right-0 mt-2 w-52 rounded-xl bg-midnight-900/98 backdrop-blur-xl border border-white/10 shadow-xl shadow-black/40 overflow-hidden">
-                      <div className="px-3 py-2.5 border-b border-white/5">
-                        <p className="text-[10px] uppercase tracking-widest text-white/30 font-bold">
-                          My Account
-                        </p>
-                        <p className="text-xs font-mono text-white/60 mt-0.5 truncate">
-                          {publicKey}
-                        </p>
-                      </div>
-
-                      <div className="py-1">
-                        {USER_MENU_ITEMS.map(({ href, icon: Icon, label }) => (
-                          <Link
-                            key={href}
-                            href={href}
-                            onClick={() => setUserMenuOpen(false)}
-                            className="flex items-center gap-3 px-4 py-2.5 text-sm text-white/70 hover:text-white hover:bg-white/5 transition-colors"
-                          >
-                            <Icon size={15} className="text-brand-400 shrink-0" />
-                            {label}
-                          </Link>
-                        ))}
-                      </div>
-
-                      <div className="border-t border-white/5 py-1">
-                        <button
-                          onClick={() => {
-                            disconnect();
-                            setUserMenuOpen(false);
-                          }}
-                          className="w-full flex items-center gap-3 px-4 py-2.5 text-sm text-terracotta-400 hover:bg-terracotta-500/10 transition-colors"
-                        >
-                          <LogOut size={15} className="shrink-0" />
-                          Disconnect
-                        </button>
-                      </div>
-                    </div>
-                  )}
+                <div className="relative group">
+                  <div className="flex items-center gap-2 pl-3 pr-1 py-1 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 transition-colors cursor-pointer">
+                    <span className="text-xs font-mono text-white/90">
+                      {shortKey}
+                    </span>
+                    <button
+                      onClick={disconnect}
+                      title="Disconnect Wallet"
+                      className="p-1.5 rounded-lg text-white/40 hover:text-terracotta-400 transition-colors"
+                    >
+                      <LogOut size={14} />
+                    </button>
+                  </div>
                 </div>
               </div>
             ) : (
@@ -229,11 +207,10 @@ export function Navbar() {
             )}
           </div>
 
-          {/* Mobile hamburger */}
+          {/* Mobile menu button */}
           <button
             onClick={() => setMobileOpen(!mobileOpen)}
             className="md:hidden flex items-center justify-center w-10 h-10 rounded-xl bg-white/5 text-white/70 hover:bg-white/10 border border-white/10 transition-all"
-            aria-label={mobileOpen ? "Close menu" : "Open menu"}
           >
             {mobileOpen ? <X size={20} /> : <Menu size={20} />}
           </button>
@@ -242,11 +219,10 @@ export function Navbar() {
         {/* Mobile drawer */}
         <div
           className={`md:hidden overflow-hidden transition-all duration-500 ${
-            mobileOpen ? "max-h-[600px] opacity-100" : "max-h-0 opacity-0"
+            mobileOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
           }`}
         >
           <div className="bg-midnight-950/98 backdrop-blur-xl border-t border-white/5 px-4 py-8 space-y-6">
-            {/* Public links */}
             <div className="grid grid-cols-1 gap-4">
               <Link
                 href="/"
@@ -280,6 +256,62 @@ export function Navbar() {
                 <Rocket size={20} className="text-brand-500" />
                 Launchpad
               </Link>
+              {isConnected && (
+                <>
+                  <Link
+                    href="/dashboard"
+                    onClick={() => setMobileOpen(false)}
+                    className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                  >
+                    <LayoutDashboard size={20} className="text-brand-500" />
+                    Dashboard
+                  </Link>
+                  <Link
+                    href="/dashboard/splitter"
+                    onClick={() => setMobileOpen(false)}
+                    className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                  >
+                    <Split size={20} className="text-brand-500" />
+                    Splitter
+                  </Link>
+                  <Link
+                    href="/profile"
+                    onClick={() => setMobileOpen(false)}
+                    className="flex items-center gap-3 text-white/80 hover:text-mint-400 transition-colors text-lg font-display"
+                  >
+                    <User size={20} className="text-mint-400" />
+                    My Profile
+                  </Link>
+                </>
+              )}
+              {isConnected && (
+                <Link
+                  href="/offers"
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                >
+                  <Tag size={20} className="text-brand-500" />
+                  My Offers
+                </Link>
+              )}
+              {isConnected && (
+                <Link
+                  href="/offers/incoming"
+                  onClick={() => setMobileOpen(false)}
+                  className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+                >
+                  <Inbox size={20} className="text-brand-500" />
+                  Offer Inbox
+                </Link>
+              )}
+              <Link
+                href="/settings"
+                onClick={() => setMobileOpen(false)}
+                className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+              >
+                <Settings size={20} className="text-gray-400" />
+                Settings
+              </Link>
               <Link
                 href="/help"
                 onClick={() => setMobileOpen(false)}
@@ -290,30 +322,7 @@ export function Navbar() {
               </Link>
             </div>
 
-            {/* Post-login account section — only shown when connected */}
-            {isConnected && (
-              <div className="border-t border-white/10 pt-6 space-y-4">
-                <p className="text-[10px] uppercase tracking-widest text-white/30 font-bold px-1">
-                  My Account
-                </p>
-                <div className="grid grid-cols-1 gap-4">
-                  {USER_MENU_ITEMS.map(({ href, icon: Icon, label }) => (
-                    <Link
-                      key={href}
-                      href={href}
-                      onClick={() => setMobileOpen(false)}
-                      className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
-                    >
-                      <Icon size={20} className="text-brand-500" />
-                      {label}
-                    </Link>
-                  ))}
-                </div>
-              </div>
-            )}
-
-            {/* Wallet section */}
-            <div className="border-t border-white/5 pt-6">
+            <div className="pt-6 border-t border-white/5">
               {isConnected ? (
                 <div className="space-y-4">
                   <div className="flex items-center justify-between">

--- a/frontend/afristore-app/src/hooks/useSplitter.ts
+++ b/frontend/afristore-app/src/hooks/useSplitter.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  deployRoyaltySplitter,
+  getSplitterRecipients,
+  SplitterRecipient,
+} from "@/lib/splitter";
+
+export function useDeploySplitter(creatorPublicKey: string | null) {
+  const [isDeploying, setIsDeploying] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const deploy = useCallback(
+    async (recipients: SplitterRecipient[]): Promise<string | null> => {
+      if (!creatorPublicKey) {
+        setError("Wallet not connected");
+        return null;
+      }
+
+      setIsDeploying(true);
+      setError(null);
+
+      try {
+        const address = await deployRoyaltySplitter(
+          creatorPublicKey,
+          recipients,
+        );
+        return address;
+      } catch (err: unknown) {
+        const message =
+          err instanceof Error ? err.message : "Deployment failed";
+        setError(message);
+        return null;
+      } finally {
+        setIsDeploying(false);
+      }
+    },
+    [creatorPublicKey],
+  );
+
+  return { deploy, isDeploying, error };
+}
+
+export function useSplitterRecipients(contractId: string | null) {
+  const [recipients, setRecipients] = useState<SplitterRecipient[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!contractId) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const data = await getSplitterRecipients(contractId);
+      setRecipients(data);
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load recipients",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [contractId]);
+
+  return { recipients, isLoading, error, refresh };
+}

--- a/frontend/afristore-app/src/lib/config.ts
+++ b/frontend/afristore-app/src/lib/config.ts
@@ -5,6 +5,8 @@
 export const config = {
   contractId: process.env.NEXT_PUBLIC_CONTRACT_ID ?? "",
   launchpadContractId: process.env.NEXT_PUBLIC_LAUNCHPAD_CONTRACT_ID ?? "",
+  splitterWasmHash:
+    process.env.NEXT_PUBLIC_SPLITTER_WASM_HASH ?? "",
   /** Base URL for the Afristore indexer HTTP API (no trailing slash). */
   indexerUrl: (
     process.env.NEXT_PUBLIC_INDEXER_URL ?? "http://localhost:4000"

--- a/frontend/afristore-app/src/lib/splitter.ts
+++ b/frontend/afristore-app/src/lib/splitter.ts
@@ -1,0 +1,226 @@
+import {
+  Address,
+  BASE_FEE,
+  Contract,
+  nativeToScVal,
+  Operation,
+  scValToNative,
+  SorobanRpc,
+  TransactionBuilder,
+  xdr,
+} from "@stellar/stellar-sdk";
+import { config } from "./config";
+import { signWithFreighter } from "./freighter";
+import { mapSorobanErrorMessage } from "./errors";
+
+export interface SplitterRecipient {
+  address: string;
+  percentage: number;
+}
+
+function getRpc(): SorobanRpc.Server {
+  return new SorobanRpc.Server(config.rpcUrl, { allowHttp: false });
+}
+
+function getNetworkPassphrase(): string {
+  return config.networkPassphrase;
+}
+
+function randomSalt(): Buffer {
+  const salt = Buffer.alloc(32);
+  if (typeof window !== "undefined" && window.crypto) {
+    window.crypto.getRandomValues(salt);
+  } else {
+    for (let i = 0; i < 32; i++) salt[i] = Math.floor(Math.random() * 256);
+  }
+  return salt;
+}
+
+function readableError(raw: string, fallback: string): Error {
+  const mapped = mapSorobanErrorMessage(raw);
+  return new Error(mapped ?? fallback);
+}
+
+async function submitAndPoll(
+  tx: any,
+  rpc: SorobanRpc.Server,
+): Promise<SorobanRpc.Api.GetSuccessfulTransactionResponse> {
+  const simResult = await rpc.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    const raw = String(simResult.error ?? "");
+    throw readableError(raw, "Transaction simulation failed.");
+  }
+
+  const preparedTx = SorobanRpc.assembleTransaction(tx, simResult).build();
+  const txXdr = preparedTx.toXDR();
+
+  const signedXdr = await signWithFreighter(txXdr, getNetworkPassphrase());
+
+  const submitted = await rpc.sendTransaction(
+    TransactionBuilder.fromXDR(signedXdr, getNetworkPassphrase()),
+  );
+
+  if (submitted.status === "ERROR") {
+    const raw = String(submitted.errorResult ?? "");
+    throw readableError(raw, "Transaction submission failed.");
+  }
+
+  let getResult = await rpc.getTransaction(submitted.hash);
+  while (getResult.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResult = await rpc.getTransaction(submitted.hash);
+  }
+
+  if (getResult.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+    const raw = JSON.stringify(getResult);
+    throw readableError(raw, "Transaction failed on-chain.");
+  }
+
+  return getResult as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+}
+
+function extractContractAddress(
+  result: SorobanRpc.Api.GetSuccessfulTransactionResponse,
+): string {
+  const returnVal = result.returnValue;
+  if (!returnVal) {
+    throw new Error("No contract address returned from deployment.");
+  }
+
+  const native = scValToNative(returnVal);
+
+  if (native instanceof Address) {
+    return native.toString();
+  }
+
+  if (typeof native === "string") {
+    return native;
+  }
+
+  throw new Error("Could not determine deployed contract address.");
+}
+
+export async function deployRoyaltySplitter(
+  deployerPublicKey: string,
+  recipients: SplitterRecipient[],
+): Promise<string> {
+  const wasmHashHex = config.splitterWasmHash;
+  if (!wasmHashHex) {
+    throw new Error(
+      "Royalty Splitter WASM hash not configured. Set NEXT_PUBLIC_SPLITTER_WASM_HASH.",
+    );
+  }
+
+  const wasmHash = Buffer.from(wasmHashHex, "hex");
+  if (wasmHash.length !== 32) {
+    throw new Error("Invalid WASM hash length — expected 32 bytes.");
+  }
+
+  const salt = randomSalt();
+  const rpc = getRpc();
+  const deployerAddress = new Address(deployerPublicKey);
+
+  const account = await rpc.getAccount(deployerPublicKey);
+
+  const createContractArgs = new xdr.CreateContractArgs({
+    contractIdPreimage: xdr.ContractIdPreimage.contractIdPreimageFromAddress(
+      new xdr.ContractIdPreimageFromAddress({
+        address: deployerAddress.toScAddress(),
+        salt,
+      }),
+    ),
+    executable: xdr.ContractExecutable.contractExecutableWasm(wasmHash),
+  });
+
+  const deployFunc = xdr.HostFunction.hostFunctionTypeCreateContract(createContractArgs);
+
+  const deployTx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(
+      Operation.invokeHostFunction({
+        func: deployFunc,
+        auth: [],
+      }),
+    )
+    .setTimeout(30)
+    .build();
+
+  const deployResult = await submitAndPoll(deployTx, rpc);
+  const contractAddress = extractContractAddress(deployResult);
+
+  await initializeSplitter(deployerPublicKey, contractAddress, recipients, rpc);
+
+  return contractAddress;
+}
+
+async function initializeSplitter(
+  callerPublicKey: string,
+  contractId: string,
+  recipients: SplitterRecipient[],
+  rpc: SorobanRpc.Server,
+): Promise<void> {
+  const contract = new Contract(contractId);
+
+  const args: xdr.ScVal[] = [
+    new Address(callerPublicKey).toScVal(),
+    nativeToScVal(
+      recipients.map((r) => ({
+        address: new Address(r.address),
+        percentage: r.percentage,
+      })),
+      { type: "vec" },
+    ),
+  ];
+
+  const account = await rpc.getAccount(callerPublicKey);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(contract.call("initialize", ...args))
+    .setTimeout(30)
+    .build();
+
+  await submitAndPoll(tx, rpc);
+}
+
+export async function getSplitterRecipients(
+  contractId: string,
+): Promise<SplitterRecipient[]> {
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const contract = new Contract(contractId);
+  const rpc = getRpc();
+  const account = await rpc.getAccount(DUMMY_KEY);
+
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(contract.call("get_recipients"))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await rpc.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    throw new Error("Unable to fetch splitter recipients.");
+  }
+
+  const retVal = (
+    simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse
+  ).result?.retval;
+  if (!retVal) throw new Error("No return value.");
+
+  const native = scValToNative(retVal) as any[];
+  return native.map((obj: any) => ({
+    address:
+      obj.address instanceof Address
+        ? obj.address.toString()
+        : String(obj.address),
+    percentage: Number(obj.percentage),
+  }));
+}


### PR DESCRIPTION
## Summary

Closes #337

This PR implements the frontend UI for deploying a Royalty Splitter contract, enabling artists to split royalties among galleries, co-creators, and collaborators before minting NFT collections.

## Changes

### Smart Contract
- Created `RoyaltySplitter` Soroban contract under `contracts/royalty-splitter/`
  - `initialize(admin, recipients)` — sets admin and beneficiary list
  - `split(token)` — distributes held tokens to recipients by percentage
  - `get_recipients()` / `get_admin()` — read-only accessors
  - Validates recipients total exactly 100%, max 10 recipients
- Added to Cargo workspace members

### Frontend
- **`src/lib/splitter.ts`** — Soroban SDK integration for deploying + initializing a RoyaltySplitter instance from the browser
- **`src/hooks/useSplitter.ts`** — React hooks (`useDeploySplitter`, `useSplitterRecipients`)
- **`src/app/dashboard/splitter/page.tsx`** — New dashboard page with:
  - Dynamic form to add/remove multiple beneficiary addresses and percentages
  - Real-time total validation (must equal exactly 100%)
  - Loading spinner during deployment
  - Success state displaying the deployed contract address with copy button
- **`src/components/Navbar.tsx`** — Added "Splitter" nav link (desktop + mobile)
- **`src/lib/config.ts`** — Added `NEXT_PUBLIC_SPLITTER_WASM_HASH` env var

### Acceptance Criteria
- [x] New page in Dashboard for "Create Royalty Splitter"
- [x] Dynamic form to add/remove multiple beneficiary addresses with percentages
- [x] Form validation ensuring total percentages equal exactly 100%
- [x] Uses Soroban SDK to deploy + initialize RoyaltySplitter contract
- [x] Displays newly deployed contract address for copying