### PR TITLE
Remove redundant Marketplace button from Navbar

### DIFF
--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -8,22 +8,22 @@ import { useState, useEffect } from "react";
 import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
 import {
-  Wallet,
-  LayoutDashboard,
-  Menu,
-  X,
   AlertTriangle,
-  LogOut,
-  ShieldCheck,
-  Tag,
-  Inbox,
   Compass,
-  User,
   Gavel,
-  Settings,
   HelpCircle,
+  Inbox,
+  LayoutDashboard,
+  LogOut,
+  Menu,
   Rocket,
+  Settings,
+  ShieldCheck,
   Split,
+  Tag,
+  User,
+  Wallet,
+  X,
 } from "lucide-react";
 import { ConnectWalletModal } from "./ConnectWalletModal";
 

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -9,7 +9,6 @@ import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
 import {
   Wallet,
-  Store,
   LayoutDashboard,
   Menu,
   X,
@@ -74,13 +73,6 @@ export function Navbar() {
 
           {/* Desktop nav links */}
           <div className="hidden md:flex items-center gap-8 text-sm font-medium">
-            <Link
-              href="/"
-              className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
-            >
-              <Store size={16} />
-              Marketplace
-            </Link>
             <Link
               href="/explore"
               className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
@@ -224,14 +216,6 @@ export function Navbar() {
         >
           <div className="bg-midnight-950/98 backdrop-blur-xl border-t border-white/5 px-4 py-8 space-y-6">
             <div className="grid grid-cols-1 gap-4">
-              <Link
-                href="/"
-                onClick={() => setMobileOpen(false)}
-                className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
-              >
-                <Store size={20} className="text-brand-500" />
-                Marketplace
-              </Link>
               <Link
                 href="/explore"
                 onClick={() => setMobileOpen(false)}


### PR DESCRIPTION
Closes #322

## What changed
- Removed the `Marketplace` text link from the desktop nav (it pointed to `/`, same as the logo)
- Removed the `Marketplace` text link from the mobile drawer (same reason)
- Removed the now-unused `Store` icon import from lucide-react

## Why
- Both the logo and the Marketplace button routed to `/`, creating unnecessary duplication and wasting nav space
- The logo already serves as the primary route back to the homepage

## How to test
- Open the app and confirm the Afristore logo still navigates to `/`
- Confirm "Marketplace" no longer appears as a separate nav item in desktop or mobile views
- Confirm remaining nav links (Explore, Auctions, Launchpad, etc.) are unaffected