### PR TITLE
Add RoyaltySplitter Soroban contract

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "contracts/collection_nft_erc1155",
     "contracts/lazy_mint_erc721",
     "contracts/lazy_mint_erc1155",
+    "contracts/royalty-splitter",
 ]
 resolver = "2"
 

--- a/contracts/royalty-splitter/Cargo.toml
+++ b/contracts/royalty-splitter/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "royalty-splitter"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "25.3.0" }
+
+[dev-dependencies]
+soroban-sdk = { version = "25.3.0", features = ["testutils"] }

--- a/contracts/royalty-splitter/src/contract.rs
+++ b/contracts/royalty-splitter/src/contract.rs
@@ -1,0 +1,106 @@
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, token::Client as TokenClient, Address, Env, Vec,
+};
+
+use crate::{
+    storage::{
+        is_initialized, load_beneficiaries, load_shares, load_token, save_beneficiaries,
+        save_shares, save_token, set_initialized, MAX_BENEFICIARIES,
+    },
+    types::SplitterError,
+};
+
+#[contract]
+pub struct RoyaltySplitter;
+
+#[contractimpl]
+impl RoyaltySplitter {
+    /// Lock in the token, beneficiaries, and BPS shares forever.
+    /// Shares must sum to exactly 10 000. Can only be called once.
+    pub fn initialize(
+        env: Env,
+        token: Address,
+        beneficiaries: Vec<Address>,
+        shares: Vec<u32>,
+    ) {
+        if is_initialized(&env) {
+            panic_with_error!(&env, SplitterError::AlreadyInitialized);
+        }
+        if beneficiaries.len() == 0 {
+            panic_with_error!(&env, SplitterError::NoBeneficiaries);
+        }
+        if beneficiaries.len() > MAX_BENEFICIARIES {
+            panic_with_error!(&env, SplitterError::TooManyBeneficiaries);
+        }
+        if beneficiaries.len() != shares.len() {
+            panic_with_error!(&env, SplitterError::LengthMismatch);
+        }
+
+        let mut total: u32 = 0;
+        for i in 0..shares.len() {
+            total += shares.get(i).unwrap();
+        }
+        if total != 10_000 {
+            panic_with_error!(&env, SplitterError::InvalidShares);
+        }
+
+        save_token(&env, &token);
+        save_beneficiaries(&env, &beneficiaries);
+        save_shares(&env, &shares);
+        set_initialized(&env);
+    }
+
+    /// Drain the contract's full token balance to all beneficiaries
+    /// proportionally. Callable by anyone; no auth required.
+    /// The final beneficiary absorbs any rounding remainder so no dust
+    /// is ever trapped.
+    pub fn distribute(env: Env) {
+        if !is_initialized(&env) {
+            panic_with_error!(&env, SplitterError::NotInitialized);
+        }
+
+        let token = load_token(&env);
+        let token_client = TokenClient::new(&env, &token);
+        let contract_addr = env.current_contract_address();
+
+        let balance = token_client.balance(&contract_addr);
+        if balance <= 0 {
+            return;
+        }
+
+        let beneficiaries = load_beneficiaries(&env);
+        let shares = load_shares(&env);
+        let len = beneficiaries.len();
+
+        let mut distributed: i128 = 0;
+        for i in 0..len - 1 {
+            let share = shares.get(i).unwrap() as i128;
+            let amount = balance * share / 10_000;
+            if amount > 0 {
+                token_client.transfer(&contract_addr, &beneficiaries.get(i).unwrap(), &amount);
+                distributed += amount;
+            }
+        }
+
+        let remainder = balance - distributed;
+        if remainder > 0 {
+            token_client.transfer(
+                &contract_addr,
+                &beneficiaries.get(len - 1).unwrap(),
+                &remainder,
+            );
+        }
+    }
+
+    pub fn get_token(env: Env) -> Address {
+        load_token(&env)
+    }
+
+    pub fn get_beneficiaries(env: Env) -> Vec<Address> {
+        load_beneficiaries(&env)
+    }
+
+    pub fn get_shares(env: Env) -> Vec<u32> {
+        load_shares(&env)
+    }
+}

--- a/contracts/royalty-splitter/src/contract.rs
+++ b/contracts/royalty-splitter/src/contract.rs
@@ -17,12 +17,7 @@ pub struct RoyaltySplitter;
 impl RoyaltySplitter {
     /// Lock in the token, beneficiaries, and BPS shares forever.
     /// Shares must sum to exactly 10 000. Can only be called once.
-    pub fn initialize(
-        env: Env,
-        token: Address,
-        beneficiaries: Vec<Address>,
-        shares: Vec<u32>,
-    ) {
+    pub fn initialize(env: Env, token: Address, beneficiaries: Vec<Address>, shares: Vec<u32>) {
         if is_initialized(&env) {
             panic_with_error!(&env, SplitterError::AlreadyInitialized);
         }

--- a/contracts/royalty-splitter/src/lib.rs
+++ b/contracts/royalty-splitter/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+mod contract;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+pub use contract::RoyaltySplitter;
+pub use types::SplitterError;
+
+#[cfg(any(test, feature = "testutils"))]
+pub use contract::RoyaltySplitterClient;

--- a/contracts/royalty-splitter/src/storage.rs
+++ b/contracts/royalty-splitter/src/storage.rs
@@ -20,9 +20,7 @@ pub fn is_initialized(env: &Env) -> bool {
 }
 
 pub fn set_initialized(env: &Env) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::Initialized, &true);
+    env.storage().persistent().set(&DataKey::Initialized, &true);
     env.storage().persistent().extend_ttl(
         &DataKey::Initialized,
         LEDGER_TTL_THRESHOLD,
@@ -32,11 +30,9 @@ pub fn set_initialized(env: &Env) {
 
 pub fn save_token(env: &Env, token: &Address) {
     env.storage().persistent().set(&DataKey::Token, token);
-    env.storage().persistent().extend_ttl(
-        &DataKey::Token,
-        LEDGER_TTL_THRESHOLD,
-        LEDGER_TTL_BUMP,
-    );
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Token, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
 }
 
 pub fn load_token(env: &Env) -> Address {
@@ -66,11 +62,9 @@ pub fn load_beneficiaries(env: &Env) -> Vec<Address> {
 
 pub fn save_shares(env: &Env, shares: &Vec<u32>) {
     env.storage().persistent().set(&DataKey::Shares, shares);
-    env.storage().persistent().extend_ttl(
-        &DataKey::Shares,
-        LEDGER_TTL_THRESHOLD,
-        LEDGER_TTL_BUMP,
-    );
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::Shares, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
 }
 
 pub fn load_shares(env: &Env) -> Vec<u32> {

--- a/contracts/royalty-splitter/src/storage.rs
+++ b/contracts/royalty-splitter/src/storage.rs
@@ -1,0 +1,81 @@
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+pub const MAX_BENEFICIARIES: u32 = 20;
+pub const LEDGER_TTL_BUMP: u32 = 432_000;
+pub const LEDGER_TTL_THRESHOLD: u32 = 144_000;
+
+#[contracttype]
+pub enum DataKey {
+    Initialized,
+    Token,
+    Beneficiaries,
+    Shares,
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage()
+        .persistent()
+        .get::<DataKey, bool>(&DataKey::Initialized)
+        .unwrap_or(false)
+}
+
+pub fn set_initialized(env: &Env) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Initialized, &true);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Initialized,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn save_token(env: &Env, token: &Address) {
+    env.storage().persistent().set(&DataKey::Token, token);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Token,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn load_token(env: &Env) -> Address {
+    env.storage()
+        .persistent()
+        .get::<DataKey, Address>(&DataKey::Token)
+        .expect("token not set")
+}
+
+pub fn save_beneficiaries(env: &Env, beneficiaries: &Vec<Address>) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::Beneficiaries, beneficiaries);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Beneficiaries,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn load_beneficiaries(env: &Env) -> Vec<Address> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, Vec<Address>>(&DataKey::Beneficiaries)
+        .expect("beneficiaries not set")
+}
+
+pub fn save_shares(env: &Env, shares: &Vec<u32>) {
+    env.storage().persistent().set(&DataKey::Shares, shares);
+    env.storage().persistent().extend_ttl(
+        &DataKey::Shares,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn load_shares(env: &Env) -> Vec<u32> {
+    env.storage()
+        .persistent()
+        .get::<DataKey, Vec<u32>>(&DataKey::Shares)
+        .expect("shares not set")
+}

--- a/contracts/royalty-splitter/src/test.rs
+++ b/contracts/royalty-splitter/src/test.rs
@@ -253,11 +253,7 @@ fn test_distribute_single_beneficiary_gets_all() {
     let (env, client, token, contract_id) = setup();
     let alice = Address::generate(&env);
 
-    client.initialize(
-        &token,
-        &vec![&env, alice.clone()],
-        &vec![&env, 10_000_u32],
-    );
+    client.initialize(&token, &vec![&env, alice.clone()], &vec![&env, 10_000_u32]);
 
     let sac = StellarAssetClient::new(&env, &token);
     sac.mint(&contract_id, &5_000);

--- a/contracts/royalty-splitter/src/test.rs
+++ b/contracts/royalty-splitter/src/test.rs
@@ -1,0 +1,296 @@
+use super::*;
+
+use soroban_sdk::{
+    testutils::Address as _,
+    token::{StellarAssetClient, TokenClient},
+    vec, Address, Env,
+};
+
+fn setup() -> (
+    Env,
+    RoyaltySplitterClient<'static>,
+    Address, // token
+    Address, // contract_id
+) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(RoyaltySplitter, ());
+    let client = RoyaltySplitterClient::new(&env, &contract_id);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    (env, client, token, contract_id)
+}
+
+// ── initialize ────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_stores_config() {
+    let (env, client, token, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 6_000_u32, 4_000_u32],
+    );
+
+    assert_eq!(client.get_token(), token);
+    let beneficiaries = client.get_beneficiaries();
+    assert_eq!(beneficiaries.get(0).unwrap(), alice);
+    assert_eq!(beneficiaries.get(1).unwrap(), bob);
+    let shares = client.get_shares();
+    assert_eq!(shares.get(0).unwrap(), 6_000_u32);
+    assert_eq!(shares.get(1).unwrap(), 4_000_u32);
+}
+
+#[test]
+fn test_double_initialize_is_rejected() {
+    let (env, client, token, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 5_000_u32, 5_000_u32],
+    );
+
+    let err = client
+        .try_initialize(
+            &token,
+            &vec![&env, alice, bob],
+            &vec![&env, 5_000_u32, 5_000_u32],
+        )
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(err, SplitterError::AlreadyInitialized.into());
+}
+
+#[test]
+fn test_shares_not_summing_to_10000_is_rejected() {
+    let (env, client, token, _) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let err = client
+        .try_initialize(
+            &token,
+            &vec![&env, alice, bob],
+            &vec![&env, 5_000_u32, 4_000_u32], // sums to 9000
+        )
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(err, SplitterError::InvalidShares.into());
+}
+
+#[test]
+fn test_length_mismatch_is_rejected() {
+    let (env, client, token, _) = setup();
+    let alice = Address::generate(&env);
+
+    let err = client
+        .try_initialize(
+            &token,
+            &vec![&env, alice],
+            &vec![&env, 5_000_u32, 5_000_u32],
+        )
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(err, SplitterError::LengthMismatch.into());
+}
+
+#[test]
+fn test_empty_beneficiaries_is_rejected() {
+    let (env, client, token, _) = setup();
+
+    let err = client
+        .try_initialize(&token, &vec![&env], &vec![&env])
+        .unwrap_err()
+        .unwrap();
+
+    assert_eq!(err, SplitterError::NoBeneficiaries.into());
+}
+
+// ── distribute ────────────────────────────────────────────────
+
+#[test]
+fn test_distribute_two_parties() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 6_000_u32, 4_000_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+    sac.mint(&contract_id, &10_000);
+
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice), 6_000);
+    assert_eq!(tc.balance(&bob), 4_000);
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_distribute_three_parties() {
+    let (env, client, token, contract_id) = setup();
+    let a = Address::generate(&env);
+    let b = Address::generate(&env);
+    let c = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, a.clone(), b.clone(), c.clone()],
+        &vec![&env, 3_334_u32, 3_333_u32, 3_333_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+    sac.mint(&contract_id, &9_000);
+
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(
+        tc.balance(&a) + tc.balance(&b) + tc.balance(&c),
+        9_000,
+        "all funds must be distributed"
+    );
+    assert_eq!(tc.balance(&contract_id), 0, "contract must drain to zero");
+}
+
+#[test]
+fn test_distribute_rounding_no_dust_trapped() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    // 3333 + 6667 = 10000; with balance=10 alice gets floor(3.333)=3, bob gets 7
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 3_333_u32, 6_667_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+    sac.mint(&contract_id, &10);
+
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice) + tc.balance(&bob), 10);
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_distribute_empty_balance_is_noop() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 5_000_u32, 5_000_u32],
+    );
+
+    // No tokens minted — should not panic
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice), 0);
+    assert_eq!(tc.balance(&bob), 0);
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_distribute_callable_by_anyone() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 7_000_u32, 3_000_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+    sac.mint(&contract_id, &1_000);
+
+    // Any address can trigger distribute — no special auth
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice), 700);
+    assert_eq!(tc.balance(&bob), 300);
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_distribute_before_initialize_is_rejected() {
+    let (_env, client, _, _) = setup();
+
+    let err = client.try_distribute().unwrap_err().unwrap();
+    assert_eq!(err, SplitterError::NotInitialized.into());
+}
+
+#[test]
+fn test_distribute_single_beneficiary_gets_all() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone()],
+        &vec![&env, 10_000_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+    sac.mint(&contract_id, &5_000);
+
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice), 5_000);
+    assert_eq!(tc.balance(&contract_id), 0);
+}
+
+#[test]
+fn test_distribute_can_be_called_multiple_times() {
+    let (env, client, token, contract_id) = setup();
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    client.initialize(
+        &token,
+        &vec![&env, alice.clone(), bob.clone()],
+        &vec![&env, 5_000_u32, 5_000_u32],
+    );
+
+    let sac = StellarAssetClient::new(&env, &token);
+
+    sac.mint(&contract_id, &2_000);
+    client.distribute();
+
+    sac.mint(&contract_id, &4_000);
+    client.distribute();
+
+    let tc = TokenClient::new(&env, &token);
+    assert_eq!(tc.balance(&alice), 3_000);
+    assert_eq!(tc.balance(&bob), 3_000);
+    assert_eq!(tc.balance(&contract_id), 0);
+}

--- a/contracts/royalty-splitter/src/types.rs
+++ b/contracts/royalty-splitter/src/types.rs
@@ -1,0 +1,14 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SplitterError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    LengthMismatch = 3,
+    NoBeneficiaries = 4,
+    /// Shares must sum to exactly 10 000 BPS.
+    InvalidShares = 5,
+    TooManyBeneficiaries = 6,
+}


### PR DESCRIPTION
Closes #336

## What changed
- New contract at `contracts/royalty-splitter/` with four source files: `lib.rs`, `contract.rs`, `storage.rs`, `types.rs`
- `initialize(token, beneficiaries, shares)` — locks token address, beneficiary list, and BPS shares forever on first call; reverts on any subsequent call
- `distribute()` — callable by anyone with no auth required; drains the contract's full token balance to all beneficiaries according to their locked shares; the final beneficiary absorbs integer-division remainder so no dust is ever trapped
- Read-only getters: `get_token`, `get_beneficiaries`, `get_shares`
- Added `contracts/royalty-splitter` to the root workspace `Cargo.toml`

## Why
- Core marketplace only supports a single `royalty_recipient`; this standalone contract handles multi-party payouts without adding complexity to the core

## How to test
```bash
cd contracts/royalty-splitter
cargo test
```
All 13 unit tests pass:
- `test_initialize_stores_config`
- `test_double_initialize_is_rejected`
- `test_shares_not_summing_to_10000_is_rejected`
- `test_length_mismatch_is_rejected`
- `test_empty_beneficiaries_is_rejected`
- `test_distribute_two_parties`
- `test_distribute_three_parties`
- `test_distribute_rounding_no_dust_trapped`
- `test_distribute_empty_balance_is_noop`
- `test_distribute_callable_by_anyone`
- `test_distribute_before_initialize_is_rejected`
- `test_distribute_single_beneficiary_gets_all`
- `test_distribute_can_be_called_multiple_times`