### PR TITLE
fix: add global-error.tsx with Sentry instrumentation

### DIFF
--- a/frontend/afristore-app/src/app/global-error.tsx
+++ b/frontend/afristore-app/src/app/global-error.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as Sentry from "@sentry/nextjs";
+import { useEffect } from "react";
+
+type Props = {
+  error: Error & { digest?: string };
+  reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: Props) {
+  useEffect(() => {
+    Sentry.captureException(error);
+  }, [error]);
+
+  return (
+    <html lang="en">
+      <body>
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            minHeight: "100vh",
+            padding: "2rem",
+            fontFamily: "sans-serif",
+          }}
+        >
+          <h2 style={{ fontSize: "1.5rem", marginBottom: "1rem" }}>
+            Something went wrong
+          </h2>
+          <p style={{ color: "#666", marginBottom: "1.5rem" }}>
+            An unexpected error occurred. Our team has been notified.
+          </p>
+          <button
+            onClick={reset}
+            style={{
+              padding: "0.5rem 1.25rem",
+              background: "#111",
+              color: "#fff",
+              border: "none",
+              borderRadius: "0.375rem",
+              cursor: "pointer",
+              fontSize: "0.875rem",
+            }}
+          >
+            Try again
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}


### PR DESCRIPTION
Fixes #348

## What changed
- Created `frontend/afristore-app/src/app/global-error.tsx` with the `"use client"` directive as required by Next.js App Router.
- Calls `Sentry.captureException(error)` in a `useEffect` so every fatal rendering error is reported to Sentry.
- Renders a minimal fallback UI (heading, description, and a "Try again" button that calls `reset()`) so the app remains usable after a hard crash.

## Why
Without `global-error.tsx`, Sentry logs: _"It seems like you don't have a global error handler set up."_ Fatal App Router render errors at the root layout level were silently dropped and never appeared in the Sentry dashboard.

## How to test
1. Temporarily throw in a root layout or server component (e.g. `throw new Error("test")`).
2. Run `npm run dev`.
3. Confirm the fallback UI is displayed and a new event appears in the Sentry dashboard.
4. Click "Try again" — confirm the app attempts to re-render.