### PR TITLE
feat: NFT staking contract, indexer tracking, and dashboard UI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "contracts/lazy_mint_erc721",
     "contracts/lazy_mint_erc1155",
     "contracts/royalty-splitter",
+    "contracts/nft-staking",
 ]
 resolver = "2"
 

--- a/contracts/nft-staking/Cargo.toml
+++ b/contracts/nft-staking/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "nft-staking"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+doctest = false
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "25.3.0" }
+
+[dev-dependencies]
+soroban-sdk = { version = "25.3.0", features = ["testutils"] }

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -1,6 +1,4 @@
-use soroban_sdk::{
-    contract, contractimpl, panic_with_error, Address, Env, IntoVal,
-};
+use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, IntoVal};
 
 use crate::events::*;
 use crate::storage::*;
@@ -23,7 +21,9 @@ impl NftStaking {
     }
 
     pub fn get_admin(env: Env) -> Option<Address> {
-        env.storage().persistent().get::<_, Address>(&DataKey::Admin)
+        env.storage()
+            .persistent()
+            .get::<_, Address>(&DataKey::Admin)
     }
 
     fn require_admin(env: &Env) {
@@ -77,7 +77,11 @@ impl NftStaking {
         };
 
         save_staked_position(&env, &position_key, &position);
-        add_user_stake(&env, &user, DataKey::StakedPosition(user.clone(), token_address.clone(), token_id));
+        add_user_stake(
+            &env,
+            &user,
+            DataKey::StakedPosition(user.clone(), token_address.clone(), token_id),
+        );
         set_total_staked(&env, get_total_staked(&env) + 1);
 
         StakedEvent {

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -1,0 +1,206 @@
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, Address, Env, IntoVal,
+};
+
+use crate::events::*;
+use crate::storage::*;
+use crate::types::*;
+
+const REWARDS_PER_SECOND: i128 = 1_000_000;
+
+#[contract]
+pub struct NftStaking;
+
+#[contractimpl]
+impl NftStaking {
+    pub fn set_admin(env: Env, admin: Address) {
+        let key = DataKey::Admin;
+        if env.storage().persistent().get::<_, Address>(&key).is_some() {
+            panic_with_error!(&env, StakingError::Unauthorized);
+        }
+        admin.require_auth();
+        env.storage().persistent().set(&key, &admin);
+    }
+
+    pub fn get_admin(env: Env) -> Option<Address> {
+        env.storage().persistent().get::<_, Address>(&DataKey::Admin)
+    }
+
+    fn require_admin(env: &Env) {
+        let admin = Self::get_admin(env.clone())
+            .unwrap_or_else(|| panic_with_error!(env, StakingError::Unauthorized));
+        admin.require_auth();
+    }
+
+    pub fn set_paused(env: Env, paused: bool) {
+        Self::require_admin(&env);
+        env.storage().persistent().set(&DataKey::IsPaused, &paused);
+    }
+
+    pub fn is_paused(env: Env) -> bool {
+        env.storage()
+            .persistent()
+            .get::<DataKey, bool>(&DataKey::IsPaused)
+            .unwrap_or(false)
+    }
+
+    pub fn stake(env: Env, user: Address, token_address: Address, token_id: u64) {
+        if Self::is_paused(env.clone()) {
+            panic_with_error!(&env, StakingError::ContractPaused);
+        }
+        user.require_auth();
+
+        let position_key = DataKey::StakedPosition(user.clone(), token_address.clone(), token_id);
+
+        if load_staked_position(&env, &position_key).is_some() {
+            panic_with_error!(&env, StakingError::AlreadyStaked);
+        }
+
+        env.invoke_contract::<()>(
+            &token_address,
+            &soroban_sdk::Symbol::new(&env, "transfer_from"),
+            soroban_sdk::vec![
+                &env,
+                env.current_contract_address().into_val(&env),
+                user.clone().into_val(&env),
+                env.current_contract_address().into_val(&env),
+                (token_id as u64).into_val(&env),
+            ],
+        );
+
+        let position = StakedPosition {
+            owner: user.clone(),
+            token_address: token_address.clone(),
+            token_id,
+            staked_at: env.ledger().timestamp(),
+            rewards_earned: 0,
+        };
+
+        save_staked_position(&env, &position_key, &position);
+        add_user_stake(&env, &user, DataKey::StakedPosition(user.clone(), token_address.clone(), token_id));
+        set_total_staked(&env, get_total_staked(&env) + 1);
+
+        StakedEvent {
+            user,
+            token_address,
+            token_id,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+    }
+
+    pub fn unstake(env: Env, user: Address, token_address: Address, token_id: u64) {
+        if Self::is_paused(env.clone()) {
+            panic_with_error!(&env, StakingError::ContractPaused);
+        }
+        user.require_auth();
+
+        let position_key = DataKey::StakedPosition(user.clone(), token_address.clone(), token_id);
+        let mut position = load_staked_position(&env, &position_key)
+            .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotStaked));
+
+        if position.owner != user {
+            panic_with_error!(&env, StakingError::Unauthorized);
+        }
+
+        let elapsed = env.ledger().timestamp() - position.staked_at;
+        let rewards = (elapsed as i128) * REWARDS_PER_SECOND;
+        position.rewards_earned += rewards;
+
+        env.invoke_contract::<()>(
+            &token_address,
+            &soroban_sdk::Symbol::new(&env, "transfer_from"),
+            soroban_sdk::vec![
+                &env,
+                env.current_contract_address().into_val(&env),
+                env.current_contract_address().into_val(&env),
+                user.clone().into_val(&env),
+                (token_id as u64).into_val(&env),
+            ],
+        );
+
+        remove_staked_position(&env, &position_key);
+        remove_user_stake(&env, &user, &position_key);
+        set_total_staked(&env, get_total_staked(&env).saturating_sub(1));
+
+        UnstakedEvent {
+            user,
+            token_address,
+            token_id,
+            rewards_paid: position.rewards_earned,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+    }
+
+    pub fn claim_rewards(env: Env, user: Address) -> i128 {
+        if Self::is_paused(env.clone()) {
+            panic_with_error!(&env, StakingError::ContractPaused);
+        }
+        user.require_auth();
+
+        let stake_keys = get_user_stakes(&env, &user);
+        let mut total_rewards: i128 = 0;
+
+        for key in stake_keys.iter() {
+            if let Some(mut position) = load_staked_position(&env, &key) {
+                let elapsed = env.ledger().timestamp() - position.staked_at;
+                let rewards = (elapsed as i128) * REWARDS_PER_SECOND;
+                position.rewards_earned += rewards;
+                position.staked_at = env.ledger().timestamp();
+                total_rewards += rewards;
+                save_staked_position(&env, &key, &position);
+            }
+        }
+
+        if total_rewards <= 0 {
+            panic_with_error!(&env, StakingError::NoRewardsToClaim);
+        }
+
+        RewardsClaimedEvent {
+            user,
+            amount: total_rewards,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+
+        total_rewards
+    }
+
+    pub fn get_staked_position(
+        env: Env,
+        user: Address,
+        token_address: Address,
+        token_id: u64,
+    ) -> Option<StakedPosition> {
+        let key = DataKey::StakedPosition(user, token_address, token_id);
+        load_staked_position(&env, &key)
+    }
+
+    pub fn get_user_stakes(env: Env, user: Address) -> soroban_sdk::Vec<StakedPosition> {
+        let keys = get_user_stakes(&env, &user);
+        let mut positions = soroban_sdk::Vec::new(&env);
+        for key in keys.iter() {
+            if let Some(pos) = load_staked_position(&env, &key) {
+                positions.push_back(pos);
+            }
+        }
+        positions
+    }
+
+    pub fn total_staked(env: Env) -> u64 {
+        get_total_staked(&env)
+    }
+
+    pub fn calculate_rewards(env: Env, user: Address) -> i128 {
+        let stake_keys = get_user_stakes(&env, &user);
+        let mut total: i128 = 0;
+        for key in stake_keys.iter() {
+            if let Some(position) = load_staked_position(&env, &key) {
+                let elapsed = env.ledger().timestamp() - position.staked_at;
+                total += (elapsed as i128) * REWARDS_PER_SECOND + position.rewards_earned;
+            }
+        }
+        total
+    }
+}

--- a/contracts/nft-staking/src/events.rs
+++ b/contracts/nft-staking/src/events.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{contracttype, Address, Env};
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StakedEvent {
+    pub user: Address,
+    pub token_address: Address,
+    pub token_id: u64,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnstakedEvent {
+    pub user: Address,
+    pub token_address: Address,
+    pub token_id: u64,
+    pub rewards_paid: i128,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RewardsClaimedEvent {
+    pub user: Address,
+    pub amount: i128,
+    pub timestamp: u64,
+}
+
+impl StakedEvent {
+    #[allow(deprecated)]
+    pub fn publish(self, env: &Env) {
+        env.events().publish((soroban_sdk::symbol_short!("staked"),), self);
+    }
+}
+
+impl UnstakedEvent {
+    #[allow(deprecated)]
+    pub fn publish(self, env: &Env) {
+        env.events().publish((soroban_sdk::symbol_short!("unstkd"),), self);
+    }
+}
+
+impl RewardsClaimedEvent {
+    #[allow(deprecated)]
+    pub fn publish(self, env: &Env) {
+        env.events().publish((soroban_sdk::symbol_short!("reward"),), self);
+    }
+}

--- a/contracts/nft-staking/src/events.rs
+++ b/contracts/nft-staking/src/events.rs
@@ -30,20 +30,23 @@ pub struct RewardsClaimedEvent {
 impl StakedEvent {
     #[allow(deprecated)]
     pub fn publish(self, env: &Env) {
-        env.events().publish((soroban_sdk::symbol_short!("staked"),), self);
+        env.events()
+            .publish((soroban_sdk::symbol_short!("staked"),), self);
     }
 }
 
 impl UnstakedEvent {
     #[allow(deprecated)]
     pub fn publish(self, env: &Env) {
-        env.events().publish((soroban_sdk::symbol_short!("unstkd"),), self);
+        env.events()
+            .publish((soroban_sdk::symbol_short!("unstkd"),), self);
     }
 }
 
 impl RewardsClaimedEvent {
     #[allow(deprecated)]
     pub fn publish(self, env: &Env) {
-        env.events().publish((soroban_sdk::symbol_short!("reward"),), self);
+        env.events()
+            .publish((soroban_sdk::symbol_short!("reward"),), self);
     }
 }

--- a/contracts/nft-staking/src/lib.rs
+++ b/contracts/nft-staking/src/lib.rs
@@ -1,0 +1,15 @@
+#![no_std]
+
+mod contract;
+mod events;
+mod storage;
+mod types;
+
+#[cfg(test)]
+mod test;
+
+pub use contract::NftStaking;
+pub use types::StakingError;
+
+#[cfg(any(test, feature = "testutils"))]
+pub use contract::NftStakingClient;

--- a/contracts/nft-staking/src/storage.rs
+++ b/contracts/nft-staking/src/storage.rs
@@ -24,7 +24,10 @@ pub fn save_staked_position(env: &Env, key: &DataKey, position: &StakedPosition)
 }
 
 pub fn load_staked_position(env: &Env, key: &DataKey) -> Option<StakedPosition> {
-    let res = env.storage().persistent().get::<DataKey, StakedPosition>(key);
+    let res = env
+        .storage()
+        .persistent()
+        .get::<DataKey, StakedPosition>(key);
     if res.is_some() {
         env.storage()
             .persistent()
@@ -88,9 +91,11 @@ pub fn set_total_staked(env: &Env, count: u64) {
     env.storage()
         .persistent()
         .set(&DataKey::TotalStaked, &count);
-    env.storage()
-        .persistent()
-        .extend_ttl(&DataKey::TotalStaked, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    env.storage().persistent().extend_ttl(
+        &DataKey::TotalStaked,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
 }
 
 pub fn get_total_staked(env: &Env) -> u64 {

--- a/contracts/nft-staking/src/storage.rs
+++ b/contracts/nft-staking/src/storage.rs
@@ -1,0 +1,101 @@
+use crate::types::StakedPosition;
+use soroban_sdk::{contracttype, Address, Env, Vec};
+
+#[contracttype]
+#[derive(Clone)]
+pub enum DataKey {
+    StakedPosition(Address, Address, u64),
+    UserStakes(Address),
+    RewardConfig,
+    TotalStaked,
+    Admin,
+    IsPaused,
+    TokenWhitelist,
+}
+
+pub const LEDGER_TTL_BUMP: u32 = 432_000;
+pub const LEDGER_TTL_THRESHOLD: u32 = 144_000;
+
+pub fn save_staked_position(env: &Env, key: &DataKey, position: &StakedPosition) {
+    env.storage().persistent().set(key, position);
+    env.storage()
+        .persistent()
+        .extend_ttl(key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+pub fn load_staked_position(env: &Env, key: &DataKey) -> Option<StakedPosition> {
+    let res = env.storage().persistent().get::<DataKey, StakedPosition>(key);
+    if res.is_some() {
+        env.storage()
+            .persistent()
+            .extend_ttl(key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    }
+    res
+}
+
+pub fn remove_staked_position(env: &Env, key: &DataKey) {
+    env.storage().persistent().remove(key);
+}
+
+pub fn add_user_stake(env: &Env, user: &Address, position_key: DataKey) {
+    let key = DataKey::UserStakes(user.clone());
+    let mut stakes = env
+        .storage()
+        .persistent()
+        .get::<_, Vec<DataKey>>(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    stakes.push_back(position_key);
+    env.storage().persistent().set(&key, &stakes);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+pub fn get_user_stakes(env: &Env, user: &Address) -> Vec<DataKey> {
+    let key = DataKey::UserStakes(user.clone());
+    env.storage()
+        .persistent()
+        .get::<_, Vec<DataKey>>(&key)
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn remove_user_stake(env: &Env, user: &Address, position_key: &DataKey) {
+    let key = DataKey::UserStakes(user.clone());
+    let stakes = env
+        .storage()
+        .persistent()
+        .get::<_, Vec<DataKey>>(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    let mut updated = Vec::new(env);
+    for s in stakes.iter() {
+        let same = match (s.clone(), position_key) {
+            (DataKey::StakedPosition(a1, b1, c1), DataKey::StakedPosition(a2, b2, c2)) => {
+                a1 == *a2 && b1 == *b2 && c1 == *c2
+            }
+            _ => false,
+        };
+        if !same {
+            updated.push_back(s);
+        }
+    }
+    env.storage().persistent().set(&key, &updated);
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+pub fn set_total_staked(env: &Env, count: u64) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::TotalStaked, &count);
+    env.storage()
+        .persistent()
+        .extend_ttl(&DataKey::TotalStaked, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+}
+
+pub fn get_total_staked(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get::<DataKey, u64>(&DataKey::TotalStaked)
+        .unwrap_or(0)
+}

--- a/contracts/nft-staking/src/test.rs
+++ b/contracts/nft-staking/src/test.rs
@@ -1,0 +1,158 @@
+#![cfg(test)]
+
+mod mock_nft {
+    use soroban_sdk::{contract, contractimpl, Address, Env};
+    #[contract]
+    pub struct MockNft;
+    #[contractimpl]
+    impl MockNft {
+        pub fn transfer_from(
+            _env: Env,
+            _spender: Address,
+            _from: Address,
+            _to: Address,
+            _token_id: u64,
+        ) {
+        }
+        pub fn owner_of(_env: Env, _token_id: u64) -> Address {
+            use soroban_sdk::testutils::Address as _;
+            Address::generate(&_env)
+        }
+    }
+}
+
+use soroban_sdk::{
+    testutils::{Address as _, Ledger, LedgerInfo},
+    Address, Env,
+};
+
+use crate::contract::NftStakingClient;
+
+fn setup() -> (Env, NftStakingClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user1 = Address::generate(&env);
+    let user2 = Address::generate(&env);
+
+    let staking_id = env.register_contract(None, crate::NftStaking);
+    let staking = NftStakingClient::new(&env, &staking_id);
+
+    staking.set_admin(&admin);
+
+    (env, staking, admin, user1, user2)
+}
+
+fn setup_with_mock() -> (Env, NftStakingClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let user = Address::generate(&env);
+    let collection = env.register_contract(None, mock_nft::MockNft);
+
+    let staking_id = env.register_contract(None, crate::NftStaking);
+    let staking = NftStakingClient::new(&env, &staking_id);
+
+    staking.set_admin(&admin);
+
+    (env, staking, user, collection, admin)
+}
+
+#[test]
+fn test_stake_and_get_position() {
+    let (_env, staking, user, collection, _admin) = setup_with_mock();
+
+    staking.stake(&user, &collection, &0);
+    let pos = staking.get_staked_position(&user, &collection, &0);
+    assert!(pos.is_some());
+    let p = pos.unwrap();
+    assert_eq!(p.owner, user);
+    assert_eq!(p.token_id, 0);
+}
+
+#[test]
+fn test_pause_unpause() {
+    let (_env, staking, _user, _collection, admin) = setup_with_mock();
+
+    assert!(!staking.is_paused());
+    staking.set_paused(&true);
+    assert!(staking.is_paused());
+    staking.set_paused(&false);
+    assert!(!staking.is_paused());
+}
+
+#[test]
+fn test_total_staked() {
+    let (_env, staking, user, collection, _admin) = setup_with_mock();
+
+    assert_eq!(staking.total_staked(), 0);
+    staking.stake(&user, &collection, &0);
+    assert_eq!(staking.total_staked(), 1);
+    staking.stake(&user, &collection, &1);
+    assert_eq!(staking.total_staked(), 2);
+}
+
+#[test]
+fn test_multiple_stakes_per_user() {
+    let (env, staking, user, collection1, _admin) = setup_with_mock();
+    let collection2 = env.register_contract(None, mock_nft::MockNft);
+
+    staking.stake(&user, &collection1, &0);
+    staking.stake(&user, &collection2, &1);
+
+    let stakes = staking.get_user_stakes(&user);
+    assert_eq!(stakes.len(), 2);
+}
+
+#[test]
+fn test_calculate_rewards() {
+    let (env, staking, user, collection, _admin) = setup_with_mock();
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 1000,
+        protocol_version: 25,
+        sequence_number: 1,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_persistent_entry_ttl: 200_000,
+        min_temp_entry_ttl: 200_000,
+        max_entry_ttl: 500_000,
+    });
+
+    staking.stake(&user, &collection, &0);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 3000,
+        protocol_version: 25,
+        sequence_number: 2,
+        network_id: Default::default(),
+        base_reserve: 10,
+        min_persistent_entry_ttl: 200_000,
+        min_temp_entry_ttl: 200_000,
+        max_entry_ttl: 500_000,
+    });
+
+    let rewards = staking.calculate_rewards(&user);
+    assert!(rewards > 0);
+}
+
+#[test]
+fn test_get_user_stakes_empty() {
+    let (_env, staking, user, _collection, _admin) = setup_with_mock();
+
+    let positions = staking.get_user_stakes(&user);
+    assert_eq!(positions.len(), 0);
+}
+
+#[test]
+fn test_unstake_returns_nft() {
+    let (_env, staking, user, collection, _admin) = setup_with_mock();
+
+    staking.stake(&user, &collection, &0);
+    staking.unstake(&user, &collection, &0);
+
+    let pos = staking.get_staked_position(&user, &collection, &0);
+    assert!(pos.is_none());
+}

--- a/contracts/nft-staking/src/types.rs
+++ b/contracts/nft-staking/src/types.rs
@@ -1,0 +1,30 @@
+use soroban_sdk::{contracterror, contracttype, Address};
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum StakingError {
+    AlreadyStaked = 1,
+    NotStaked = 2,
+    Unauthorized = 3,
+    NoRewardsToClaim = 4,
+    TransferFailed = 5,
+    InvalidDuration = 6,
+    ContractPaused = 7,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct StakedPosition {
+    pub owner: Address,
+    pub token_address: Address,
+    pub token_id: u64,
+    pub staked_at: u64,
+    pub rewards_earned: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+pub struct RewardConfig {
+    pub rewards_per_second: i128,
+}

--- a/frontend/afristore-app/src/app/explore/page.tsx
+++ b/frontend/afristore-app/src/app/explore/page.tsx
@@ -149,10 +149,10 @@ export default function ExplorePage() {
         result.sort((a, b) => a.created_at - b.created_at);
         break;
       case "price-low":
-        result.sort((a, b) => Number(a.price - b.price));
+        result.sort((a, b) => a.price < b.price ? -1 : a.price > b.price ? 1 : 0);
         break;
       case "price-high":
-        result.sort((a, b) => Number(b.price - a.price));
+        result.sort((a, b) => b.price < a.price ? -1 : b.price > a.price ? 1 : 0);
         break;
     }
 

--- a/frontend/afristore-app/src/app/staking/page.tsx
+++ b/frontend/afristore-app/src/app/staking/page.tsx
@@ -1,0 +1,456 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useWalletContext } from "@/context/WalletContext";
+import { useOwnedNFTs } from "@/hooks/useOwnedNFTs";
+import { OwnedToken } from "@/lib/indexer";
+import {
+  AlertCircle,
+  Lock,
+  Unlock,
+  Coins,
+  RefreshCw,
+  Wallet,
+  Layers,
+} from "lucide-react";
+
+interface StakedItem {
+  id: string;
+  collectionAddress: string;
+  tokenId: number;
+  name?: string;
+  image?: string;
+  stakedAt: string;
+  rewardsEarned: string;
+}
+
+export default function StakingPage() {
+  const { publicKey, isConnected, isConnecting } = useWalletContext();
+  const { tokens: ownedNfts, isLoading: nftsLoading, refresh: refreshNFTs } = useOwnedNFTs(publicKey);
+
+  const [stakedNfts, setStakedNfts] = useState<StakedItem[]>([]);
+  const [isLoadingStaked, setIsLoadingStaked] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [isStaking, setIsStaking] = useState(false);
+  const [isUnstaking, setIsUnstaking] = useState(false);
+  const [isClaiming, setIsClaiming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingRewards, setPendingRewards] = useState(0);
+  const [activeTab, setActiveTab] = useState<"unstaked" | "staked">("unstaked");
+  const [totalStakedCount, setTotalStakedCount] = useState(0);
+
+  const fetchStakedNfts = useCallback(async () => {
+    if (!publicKey) return;
+    setIsLoadingStaked(true);
+    try {
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_INDEXER_URL || "http://localhost:4000"}/wallets/${encodeURIComponent(publicKey)}/staked`,
+      );
+      if (res.ok) {
+        const data = await res.json();
+        const mapped = (data || []).map((item: any) => ({
+          id: `${item.tokenAddress}-${item.tokenId}`,
+          collectionAddress: item.tokenAddress,
+          tokenId: Number(item.tokenId),
+          name: `NFT #${item.tokenId}`,
+          stakedAt: item.stakedAt,
+          rewardsEarned: item.rewardsEarned || "0",
+        }));
+        setStakedNfts(mapped);
+        setTotalStakedCount(mapped.length);
+      }
+    } catch {
+      // Indexer might not have staking support yet
+    } finally {
+      setIsLoadingStaked(false);
+    }
+  }, [publicKey]);
+
+  useEffect(() => {
+    if (publicKey) {
+      fetchStakedNfts();
+    }
+  }, [publicKey, fetchStakedNfts]);
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const handleStakeSelected = async () => {
+    if (!publicKey || selectedIds.size === 0) return;
+    setIsStaking(true);
+    setError(null);
+    try {
+      const { stake } = await import("@/lib/staking");
+      const selected = ownedNfts.filter((nft) =>
+        selectedIds.has(`${nft.collectionAddress}-${nft.tokenId}`),
+      );
+      for (const nft of selected) {
+        await stake(publicKey, nft.collectionAddress, nft.tokenId);
+      }
+      setSelectedIds(new Set());
+      await refreshNFTs();
+      await fetchStakedNfts();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Staking failed");
+    } finally {
+      setIsStaking(false);
+    }
+  };
+
+  const handleUnstake = async (collectionAddress: string, tokenId: number) => {
+    if (!publicKey) return;
+    setIsUnstaking(true);
+    setError(null);
+    try {
+      const { unstake } = await import("@/lib/staking");
+      await unstake(publicKey, collectionAddress, tokenId);
+      await fetchStakedNfts();
+      await refreshNFTs();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Unstaking failed");
+    } finally {
+      setIsUnstaking(false);
+    }
+  };
+
+  const handleClaimRewards = async () => {
+    if (!publicKey) return;
+    setIsClaiming(true);
+    setError(null);
+    try {
+      const { claimRewards } = await import("@/lib/staking");
+      await claimRewards(publicKey);
+      await fetchStakedNfts();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Claim failed");
+    } finally {
+      setIsClaiming(false);
+    }
+  };
+
+  if (!isConnected) {
+    return (
+      <div className="min-h-screen bg-gray-50">
+        <div className="bg-midnight-900 pt-32 pb-16">
+          <div className="mx-auto max-w-7xl px-4 sm:px-6">
+            <h1 className="text-5xl font-display font-bold text-white tracking-tight">
+              NFT Staking
+            </h1>
+            <p className="mt-4 max-w-xl text-xl text-white/60 font-inter leading-relaxed">
+              Stake your NFTs to earn platform rewards
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col items-center justify-center py-20">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-brand-50 text-brand-500 mb-4">
+            <Wallet size={32} />
+          </div>
+          <h3 className="font-display font-bold text-gray-900 text-lg">
+            Connect your wallet
+          </h3>
+          <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
+            Connect your Freighter or Magic wallet to stake NFTs and earn rewards.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const unstakedNfts = ownedNfts.filter(
+    (nft) => !stakedNfts.some((s) => s.collectionAddress === nft.collectionAddress && s.tokenId === nft.tokenId),
+  );
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-midnight-900 pt-32 pb-16">
+        <div className="mx-auto max-w-7xl px-4 sm:px-6">
+          <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-8">
+            <div className="space-y-4">
+              <h1 className="text-5xl font-display font-bold text-white tracking-tight">
+                NFT Staking
+              </h1>
+              <p className="max-w-xl text-xl text-white/60 font-inter leading-relaxed">
+                Stake your NFTs to earn platform rewards
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-8 md:gap-12">
+              <div className="relative">
+                <span className="text-3xl font-display font-bold text-white block">
+                  {totalStakedCount}
+                </span>
+                <span className="text-sm font-bold uppercase tracking-widest text-brand-500">
+                  Staked
+                </span>
+              </div>
+              <div className="relative">
+                <span className="text-3xl font-display font-bold text-white block">
+                  {ownedNfts.length}
+                </span>
+                <span className="text-sm font-bold uppercase tracking-widest text-brand-500">
+                  Owned
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-8">
+        <div className="flex gap-4 border-b border-gray-200">
+          <button
+            onClick={() => setActiveTab("unstaked")}
+            className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
+              activeTab === "unstaked"
+                ? "text-brand-600 border-b-2 border-brand-500"
+                : "text-gray-400 hover:text-gray-600"
+            }`}
+          >
+            Your Unstaked NFTs
+          </button>
+          <button
+            onClick={() => setActiveTab("staked")}
+            className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
+              activeTab === "staked"
+                ? "text-brand-600 border-b-2 border-brand-500"
+                : "text-gray-400 hover:text-gray-600"
+            }`}
+          >
+            Your Staked Vault
+          </button>
+        </div>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
+          <div className="flex items-center gap-3 rounded-xl bg-red-50 border border-red-100 p-4">
+            <AlertCircle size={20} className="text-red-500 shrink-0" />
+            <p className="text-sm text-red-700">{error}</p>
+            <button
+              onClick={() => setError(null)}
+              className="ml-auto text-red-400 hover:text-red-600 text-sm font-medium"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Actions bar */}
+      {activeTab === "unstaked" && selectedIds.size > 0 && (
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
+          <div className="flex items-center justify-between rounded-xl bg-brand-50 border border-brand-100 p-4">
+            <span className="text-sm font-medium text-brand-900">
+              {selectedIds.size} NFT{selectedIds.size > 1 ? "s" : ""} selected
+            </span>
+            <button
+              onClick={handleStakeSelected}
+              disabled={isStaking}
+              className="flex items-center gap-2 rounded-xl bg-brand-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-brand-600 disabled:opacity-50 transition-all"
+            >
+              <Lock size={14} />
+              {isStaking ? "Staking..." : "Stake Selected"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {activeTab === "staked" && stakedNfts.length > 0 && (
+        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
+          <div className="flex items-center justify-between rounded-xl bg-mint-50 border border-mint-100 p-4">
+            <div className="flex items-center gap-2">
+              <Coins size={20} className="text-mint-600" />
+              <span className="text-sm font-medium text-mint-900">
+                Pending Rewards
+              </span>
+            </div>
+            <button
+              onClick={handleClaimRewards}
+              disabled={isClaiming}
+              className="flex items-center gap-2 rounded-xl bg-mint-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-mint-600 disabled:opacity-50 transition-all"
+            >
+              <Coins size={14} />
+              {isClaiming ? "Claiming..." : "Claim All Rewards"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
+        {activeTab === "unstaked" && (
+          <>
+            {/* Loading */}
+            {nftsLoading && (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="animate-pulse rounded-2xl border border-gray-100 bg-white overflow-hidden"
+                  >
+                    <div className="aspect-square bg-gray-100" />
+                    <div className="p-4 space-y-3">
+                      <div className="h-4 w-3/4 rounded bg-gray-100" />
+                      <div className="h-3 w-1/2 rounded bg-gray-100" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Empty */}
+            {!nftsLoading && unstakedNfts.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-20">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-brand-50 text-brand-500 mb-4">
+                  <Layers size={32} />
+                </div>
+                <h3 className="font-display font-bold text-gray-900 text-lg">
+                  No unstaked NFTs
+                </h3>
+                <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
+                  {stakedNfts.length > 0
+                    ? "All your NFTs are staked. Come back after unstaking to re-stake."
+                    : "You don't own any NFTs yet. Explore the marketplace to find artworks to collect."}
+                </p>
+              </div>
+            )}
+
+            {/* Grid */}
+            {!nftsLoading && unstakedNfts.length > 0 && (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {unstakedNfts.map((nft) => {
+                  const nftId = `${nft.collectionAddress}-${nft.tokenId}`;
+                  const isSelected = selectedIds.has(nftId);
+                  return (
+                    <button
+                      key={nftId}
+                      onClick={() => toggleSelect(nftId)}
+                      className={`relative rounded-2xl border-2 overflow-hidden bg-white text-left transition-all ${
+                        isSelected
+                          ? "border-brand-500 shadow-lg shadow-brand-500/20"
+                          : "border-gray-100 hover:border-brand-200 hover:shadow-md"
+                      }`}
+                    >
+                      {isSelected && (
+                        <div className="absolute top-3 right-3 z-10 flex h-7 w-7 items-center justify-center rounded-full bg-brand-500 text-white text-xs font-bold">
+                          ✓
+                        </div>
+                      )}
+                      <div className="aspect-square bg-gray-50 flex items-center justify-center">
+                        {nft.image ? (
+                          <img
+                            src={nft.image}
+                            alt={nft.name || `NFT #${nft.tokenId}`}
+                            className="w-full h-full object-cover"
+                          />
+                        ) : (
+                          <Layers size={48} className="text-gray-300" />
+                        )}
+                      </div>
+                      <div className="p-4">
+                        <p className="font-display font-bold text-gray-900 truncate">
+                          {nft.name || `NFT #${nft.tokenId}`}
+                        </p>
+                        <p className="text-xs font-mono text-gray-400 truncate mt-1">
+                          {nft.collectionAddress.slice(0, 8)}...
+                        </p>
+                      </div>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </>
+        )}
+
+        {activeTab === "staked" && (
+          <>
+            {/* Loading */}
+            {isLoadingStaked && (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {Array.from({ length: 4 }).map((_, i) => (
+                  <div
+                    key={i}
+                    className="animate-pulse rounded-2xl border border-gray-100 bg-white overflow-hidden"
+                  >
+                    <div className="aspect-square bg-gray-100" />
+                    <div className="p-4 space-y-3">
+                      <div className="h-4 w-3/4 rounded bg-gray-100" />
+                      <div className="h-3 w-1/2 rounded bg-gray-100" />
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {/* Empty */}
+            {!isLoadingStaked && stakedNfts.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-20">
+                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-mint-50 text-mint-500 mb-4">
+                  <Lock size={32} />
+                </div>
+                <h3 className="font-display font-bold text-gray-900 text-lg">
+                  No staked NFTs
+                </h3>
+                <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
+                  You haven't staked any NFTs yet. Browse your unstaked NFTs and
+                  start staking to earn rewards.
+                </p>
+              </div>
+            )}
+
+            {/* Grid */}
+            {!isLoadingStaked && stakedNfts.length > 0 && (
+              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {stakedNfts.map((nft) => (
+                  <div
+                    key={nft.id}
+                    className="relative rounded-2xl border border-gray-100 bg-white overflow-hidden"
+                  >
+                    <div className="absolute top-3 left-3 z-10 flex items-center gap-1.5 rounded-full bg-mint-500/90 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white">
+                      <Lock size={10} />
+                      Staked
+                    </div>
+                    <div className="aspect-square bg-gray-50 flex items-center justify-center">
+                      <Layers size={48} className="text-gray-300" />
+                    </div>
+                    <div className="p-4 space-y-3">
+                      <p className="font-display font-bold text-gray-900 truncate">
+                        {nft.name || `NFT #${nft.tokenId}`}
+                      </p>
+                      <p className="text-xs font-mono text-gray-400 truncate">
+                        {nft.collectionAddress.slice(0, 8)}...
+                      </p>
+                      <div className="flex items-center gap-1.5 text-sm text-mint-600">
+                        <Coins size={14} />
+                        <span className="font-medium">{nft.rewardsEarned}</span>
+                      </div>
+                      <button
+                        onClick={() =>
+                          handleUnstake(nft.collectionAddress, nft.tokenId)
+                        }
+                        disabled={isUnstaking}
+                        className="w-full flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300 disabled:opacity-50 transition-all"
+                      >
+                        <Unlock size={14} />
+                        {isUnstaking ? "Unstaking..." : "Unstake"}
+                      </button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/app/staking/page.tsx
+++ b/frontend/afristore-app/src/app/staking/page.tsx
@@ -401,7 +401,7 @@ export default function StakingPage() {
                   No staked NFTs
                 </h3>
                 <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
-                  You haven't staked any NFTs yet. Browse your unstaked NFTs and
+                  You haven&apos;t staked any NFTs yet. Browse your unstaked NFTs and
                   start staking to earn rewards.
                 </p>
               </div>

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -14,6 +14,7 @@ import {
   HelpCircle,
   Inbox,
   LayoutDashboard,
+  Lock,
   LogOut,
   Menu,
   Rocket,
@@ -86,6 +87,13 @@ export function Navbar() {
             >
               <Gavel size={16} />
               Auctions
+            </Link>
+            <Link
+              href="/staking"
+              className="flex items-center gap-1.5 text-white/70 hover:text-brand-400 transition-colors duration-300"
+            >
+              <Lock size={16} />
+              Staking
             </Link>
             <Link
               href="/launchpad"
@@ -231,6 +239,14 @@ export function Navbar() {
               >
                 <Gavel size={20} className="text-brand-500" />
                 Auctions
+              </Link>
+              <Link
+                href="/staking"
+                onClick={() => setMobileOpen(false)}
+                className="flex items-center gap-3 text-white/80 hover:text-brand-400 transition-colors text-lg font-display"
+              >
+                <Lock size={20} className="text-brand-500" />
+                Staking
               </Link>
               <Link
                 href="/launchpad"

--- a/frontend/afristore-app/src/lib/config.ts
+++ b/frontend/afristore-app/src/lib/config.ts
@@ -5,6 +5,7 @@
 export const config = {
   contractId: process.env.NEXT_PUBLIC_CONTRACT_ID ?? "",
   launchpadContractId: process.env.NEXT_PUBLIC_LAUNCHPAD_CONTRACT_ID ?? "",
+  stakingContractId: process.env.NEXT_PUBLIC_STAKING_CONTRACT_ID ?? "",
   splitterWasmHash:
     process.env.NEXT_PUBLIC_SPLITTER_WASM_HASH ?? "",
   /** Base URL for the Afristore indexer HTTP API (no trailing slash). */

--- a/frontend/afristore-app/src/lib/staking.ts
+++ b/frontend/afristore-app/src/lib/staking.ts
@@ -1,0 +1,239 @@
+"use client";
+
+import {
+  Contract,
+  SorobanRpc,
+  TransactionBuilder,
+  xdr,
+  nativeToScVal,
+  scValToNative,
+  Address,
+  BASE_FEE,
+} from "@stellar/stellar-sdk";
+import { config } from "./config";
+import { getConnectedPublicKey, signWithFreighter } from "./freighter";
+import { mapSorobanErrorMessage } from "./errors";
+
+export interface StakedPosition {
+  owner: string;
+  token_address: string;
+  token_id: number;
+  staked_at: number;
+  rewards_earned: string;
+}
+
+export interface StakedNFTIndexerRow {
+  id: number;
+  owner: string;
+  tokenAddress: string;
+  tokenId: string;
+  collection: string;
+  stakedAt: string;
+  status: string;
+  rewardsEarned: string;
+  createdAtLedger: number;
+  updatedAtLedger: number;
+}
+
+export const STAKING_CONTRACT_ID =
+  process.env.NEXT_PUBLIC_STAKING_CONTRACT_ID || "";
+
+function getRpc(): SorobanRpc.Server {
+  return new SorobanRpc.Server(config.rpcUrl, { allowHttp: false });
+}
+
+export function getStakingContract(): Contract {
+  return new Contract(STAKING_CONTRACT_ID);
+}
+
+function getNetworkPassphrase(): string {
+  return config.networkPassphrase;
+}
+
+async function invokeStakingContract(
+  callerPublicKey: string,
+  method: string,
+  args: xdr.ScVal[],
+  readonly = false,
+): Promise<xdr.ScVal> {
+  if (!STAKING_CONTRACT_ID) {
+    throw new Error("STAKING_CONTRACT_ID not configured");
+  }
+
+  const readableError = (raw: string, fallback: string): Error => {
+    const mapped = mapSorobanErrorMessage(raw);
+    return new Error(mapped ?? fallback);
+  };
+
+  const rpc = getRpc();
+  const contract = getStakingContract();
+
+  const account = await rpc.getAccount(callerPublicKey);
+  const tx = new TransactionBuilder(account, {
+    fee: BASE_FEE,
+    networkPassphrase: getNetworkPassphrase(),
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simResult = await rpc.simulateTransaction(tx);
+
+  if (SorobanRpc.Api.isSimulationError(simResult)) {
+    const raw = String(simResult.error ?? "");
+    throw readableError(raw, "Unable to simulate this transaction.");
+  }
+
+  if (readonly) {
+    const retVal = (
+      simResult as SorobanRpc.Api.SimulateTransactionSuccessResponse
+    ).result?.retval;
+    if (!retVal) throw new Error("No return value from simulation.");
+    return retVal;
+  }
+
+  const preparedTx = SorobanRpc.assembleTransaction(tx, simResult).build();
+  const txXdr = preparedTx.toXDR();
+  const signedXdr = await signWithFreighter(txXdr, getNetworkPassphrase());
+
+  const submitted = await rpc.sendTransaction(
+    TransactionBuilder.fromXDR(signedXdr, getNetworkPassphrase()),
+  );
+
+  if (submitted.status === "ERROR") {
+    const raw = String(submitted.errorResult ?? "");
+    throw readableError(raw, "Transaction submission failed.");
+  }
+
+  let getResult = await rpc.getTransaction(submitted.hash);
+  while (getResult.status === SorobanRpc.Api.GetTransactionStatus.NOT_FOUND) {
+    await new Promise((r) => setTimeout(r, 1000));
+    getResult = await rpc.getTransaction(submitted.hash);
+  }
+
+  if (getResult.status === SorobanRpc.Api.GetTransactionStatus.FAILED) {
+    const raw = JSON.stringify(getResult);
+    throw readableError(raw, "Transaction failed on-chain.");
+  }
+
+  const successResult =
+    getResult as SorobanRpc.Api.GetSuccessfulTransactionResponse;
+  return successResult.returnValue ?? xdr.ScVal.scvVoid();
+}
+
+export async function stake(
+  userPublicKey: string,
+  tokenAddress: string,
+  tokenId: number,
+): Promise<void> {
+  const args: xdr.ScVal[] = [
+    new Address(userPublicKey).toScVal(),
+    new Address(tokenAddress).toScVal(),
+    nativeToScVal(BigInt(tokenId), { type: "u64" }),
+  ];
+  await invokeStakingContract(userPublicKey, "stake", args);
+}
+
+export async function unstake(
+  userPublicKey: string,
+  tokenAddress: string,
+  tokenId: number,
+): Promise<void> {
+  const args: xdr.ScVal[] = [
+    new Address(userPublicKey).toScVal(),
+    new Address(tokenAddress).toScVal(),
+    nativeToScVal(BigInt(tokenId), { type: "u64" }),
+  ];
+  await invokeStakingContract(userPublicKey, "unstake", args);
+}
+
+export async function claimRewards(
+  userPublicKey: string,
+): Promise<number> {
+  const args: xdr.ScVal[] = [new Address(userPublicKey).toScVal()];
+  const retVal = await invokeStakingContract(userPublicKey, "claim_rewards", args);
+  return Number(scValToNative(retVal));
+}
+
+export async function getStakedPosition(
+  userPublicKey: string,
+  tokenAddress: string,
+  tokenId: number,
+): Promise<StakedPosition | null> {
+  const caller = await getConnectedPublicKey();
+  const pk = caller ?? userPublicKey;
+  const retVal = await invokeStakingContract(
+    pk,
+    "get_staked_position",
+    [
+      new Address(userPublicKey).toScVal(),
+      new Address(tokenAddress).toScVal(),
+      nativeToScVal(BigInt(tokenId), { type: "u64" }),
+    ],
+    true,
+  );
+  const raw = scValToNative(retVal);
+  if (!raw) return null;
+  const obj = raw as Record<string, unknown>;
+  return {
+    owner: (obj["owner"] as any).toString(),
+    token_address: (obj["token_address"] as any).toString(),
+    token_id: Number(obj["token_id"]),
+    staked_at: Number(obj["staked_at"]),
+    rewards_earned: String(obj["rewards_earned"] ?? "0"),
+  };
+}
+
+export async function getUserStakes(
+  userPublicKey: string,
+): Promise<StakedPosition[]> {
+  const caller = await getConnectedPublicKey();
+  const pk = caller ?? userPublicKey;
+  const retVal = await invokeStakingContract(
+    pk,
+    "get_user_stakes",
+    [new Address(userPublicKey).toScVal()],
+    true,
+  );
+  const raw = scValToNative(retVal) as any[];
+  return raw.map((obj: Record<string, unknown>) => ({
+    owner: (obj["owner"] as any).toString(),
+    token_address: (obj["token_address"] as any).toString(),
+    token_id: Number(obj["token_id"]),
+    staked_at: Number(obj["staked_at"]),
+    rewards_earned: String(obj["rewards_earned"] ?? "0"),
+  }));
+}
+
+export async function calculateRewards(
+  userPublicKey: string,
+): Promise<number> {
+  const caller = await getConnectedPublicKey();
+  const pk = caller ?? userPublicKey;
+  const retVal = await invokeStakingContract(
+    pk,
+    "calculate_rewards",
+    [new Address(userPublicKey).toScVal()],
+    true,
+  );
+  return Number(scValToNative(retVal));
+}
+
+export async function isStakingPaused(): Promise<boolean> {
+  const caller = await getConnectedPublicKey();
+  if (!caller) return false;
+  const retVal = await invokeStakingContract(
+    caller,
+    "is_paused",
+    [],
+    true,
+  );
+  return Boolean(scValToNative(retVal));
+}
+
+export async function totalStaked(): Promise<number> {
+  const caller = await getConnectedPublicKey();
+  if (!caller) return 0;
+  const retVal = await invokeStakingContract(caller, "total_staked", [], true);
+  return Number(scValToNative(retVal));
+}

--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -95,3 +95,19 @@ model Collection {
   createdAt       DateTime @default(now())
   @@index([creator])
 }
+
+model StakedNFT {
+  id              Int      @id @default(autoincrement())
+  owner           String
+  tokenAddress    String
+  tokenId         BigInt
+  collection      String
+  stakedAt        DateTime
+  status          String   // "Active", "Unstaked"
+  rewardsEarned   Decimal  @default(0) @db.Decimal(32, 7)
+  createdAtLedger Int
+  updatedAtLedger Int
+  @@unique([owner, tokenAddress, tokenId])
+  @@index([owner])
+  @@index([status])
+}

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -272,6 +272,21 @@ router.get('/creators/:address/collections', async (req: Request, res: Response)
     }
 });
 
+// GET /wallets/:address/staked — active staked NFTs for a wallet
+router.get('/wallets/:address/staked', async (req: Request, res: Response) => {
+  const { address } = req.params;
+  try {
+    const staked = await prisma.stakedNFT.findMany({
+      where: { owner: address as string, status: 'Active' },
+      orderBy: { stakedAt: 'desc' },
+    });
+    res.json(serialize(staked));
+  } catch (err) {
+    console.error('Error details:', err);
+    res.status(500).json({ error: 'Failed to fetch staked NFTs' });
+  }
+});
+
 // GET /wallets/:address/activity — events relevant to a Stellar account
 router.get('/wallets/:address/activity', strictRateLimiter, async (req: Request, res: Response) => {
     const address = req.params.address as string;

--- a/indexer/src/parser.ts
+++ b/indexer/src/parser.ts
@@ -26,6 +26,9 @@ const TOPIC_MAP: Record<string, string> = {
   'dep_n1155': 'DEPLOY_NORMAL_1155',
   'dep_l721': 'DEPLOY_LAZY_721',
   'dep_l1155': 'DEPLOY_LAZY_1155',
+  'staked': 'NFT_STAKED',
+  'unstkd': 'NFT_UNSTAKED',
+  'reward': 'REWARDS_CLAIMED',
 };
 
 export function parseMarketplaceEvent(
@@ -65,6 +68,7 @@ export function parseMarketplaceEvent(
   else if (nativeData.offerer) actor = nativeData.offerer.toString();
   else if (nativeData.bidder) actor = nativeData.bidder.toString();
   else if (nativeData.buyer) actor = nativeData.buyer.toString();
+  else if (nativeData.user) actor = nativeData.user.toString();
 
   // For deploy events the value is a tuple (creator, collection_address)
   // scValToNative returns an array for tuples

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -15,6 +15,7 @@ dotenv.config();
 const RPC_URL = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
 const CONTRACT_ID = process.env.MARKETPLACE_CONTRACT_ID || '';
 const LAUNCHPAD_CONTRACT_ID = process.env.LAUNCHPAD_CONTRACT_ID || '';
+const STAKING_CONTRACT_ID = process.env.STAKING_CONTRACT_ID || '';
 const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '5000');
 
 // Retry back-off base in ms; doubles on each consecutive failure up to MAX_BACKOFF_MS.
@@ -27,7 +28,7 @@ let consecutiveErrors = 0;
 let shuttingDown = false;
 
 function getContractIds(): string[] {
-  return [CONTRACT_ID, LAUNCHPAD_CONTRACT_ID].filter(Boolean);
+  return [CONTRACT_ID, LAUNCHPAD_CONTRACT_ID, STAKING_CONTRACT_ID].filter(Boolean);
 }
 
 function updateSyncMetrics(processedLedger: number, networkLatestLedger: number) {
@@ -676,6 +677,69 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
         where: { offerId: BigInt(data.offer_id) },
         data: {
           status: 'Withdrawn',
+          updatedAtLedger: ledgerSequence,
+        }
+      });
+      break;
+    }
+
+    case 'NFT_STAKED': {
+      const tokenAddress = data.token_address?.toString() || data.token_address || '';
+      const tokenId = BigInt(data.token_id ?? 0);
+      const collection = data.collection?.toString() || '';
+      const stakedAt = data.timestamp ? new Date(Number(data.timestamp) * 1000) : new Date();
+
+      await db.stakedNFT.upsert({
+        where: {
+          owner_tokenAddress_tokenId: {
+            owner: actor,
+            tokenAddress,
+            tokenId,
+          },
+        },
+        create: {
+          owner: actor,
+          tokenAddress,
+          tokenId,
+          collection,
+          stakedAt,
+          status: 'Active',
+          rewardsEarned: '0',
+          createdAtLedger: ledgerSequence,
+          updatedAtLedger: ledgerSequence,
+        },
+        update: {
+          status: 'Active',
+          stakedAt,
+          updatedAtLedger: ledgerSequence,
+        }
+      });
+      break;
+    }
+
+    case 'NFT_UNSTAKED': {
+      const tokenAddr = data.token_address?.toString() || data.token_address || '';
+      const tId = BigInt(data.token_id ?? 0);
+
+      await db.stakedNFT.updateMany({
+        where: {
+          owner: actor,
+          tokenAddress: tokenAddr,
+          tokenId: tId,
+        },
+        data: {
+          status: 'Unstaked',
+          updatedAtLedger: ledgerSequence,
+        }
+      });
+      break;
+    }
+
+    case 'REWARDS_CLAIMED': {
+      await db.stakedNFT.updateMany({
+        where: { owner: actor, status: 'Active' },
+        data: {
+          rewardsEarned: { increment: data.amount?.toString() || '0' },
           updatedAtLedger: ledgerSequence,
         }
       });


### PR DESCRIPTION

## Changes

### Issue #319 — BigInt sort fix
- Replaced `Number(a.price - b.price)` with BigInt-safe comparator in explore page

### Issue #360 — NFT Staking Smart Contract
- New Soroban contract at `contracts/nft-staking/`
- Stake/unstake/claim_rewards with reward calculation
- Admin pause, total staked tracking, 7 passing tests

### Issue #361 — Indexer Staking Event Tracking
- `StakedNFT` model in Prisma schema
- Staking event topics (`staked`, `unstkd`, `reward`) in parser
- `NFT_STAKED`, `NFT_UNSTAKED`, `REWARDS_CLAIMED` event processing
- `GET /wallets/:address/staked` API endpoint
- `STAKING_CONTRACT_ID` env var support

### Issue #362 — Staking Dashboard UI
- New `/staking` page with two tabs: Unstaked NFTs and Staked Vault
- Batch stake selection, individual unstake, claim all rewards
- `Staking` link added to navbar
- `src/lib/staking.ts` for Soroban contract interactions

## Testing
- Contract: `cd contracts/nft-staking && cargo test`
- Indexer: needs `STAKING_CONTRACT_ID` in env
- Frontend: needs `NEXT_PUBLIC_STAKING_CONTRACT_ID` in .env.local

Closes #319 
Closes #360 
Closes #361
Closes #362