### PR TITLE
feat: multi-tenant staking factory, creator setup, and dark dashboard

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -86,9 +86,20 @@ mod iface {
             royalty_receiver: Address,
         );
     }
+
+    #[contractclient(name = "NftStakingClient")]
+    pub trait INftStaking {
+        fn init(
+            env: Env,
+            admin: Address,
+            nft_address: Address,
+            reward_token: Address,
+            reward_rate: i128,
+        );
+    }
 }
 
-use iface::{Lazy1155Client, Lazy721Client, Normal1155Client, Normal721Client};
+use iface::{Lazy1155Client, Lazy721Client, Normal1155Client, Normal721Client, NftStakingClient};
 
 // ─── Salt hardening (fix #53) ─────────────────────────────────────────────────
 /// Bind `raw_salt` to the caller so that two different creators can never
@@ -378,6 +389,54 @@ impl Launchpad {
         Ok(addr)
     }
 
+    /// Register the NftStaking WASM hash (upload off-chain first).
+    pub fn set_staking_wasm_hash(env: Env, wasm_staking: BytesN<32>) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
+        storage::require_admin(&env)?;
+        storage::set_staking_wasm_hash(&env, &wasm_staking);
+        Ok(())
+    }
+
+    // ── Deploy: Staking pool clone ────────────────────────────────────────
+
+    /// Deploy a dedicated NftStaking clone for an NFT collection.
+    ///
+    /// `salt` — unique 32 bytes per pool; combined with creator for front-run protection.
+    pub fn deploy_staking_pool(
+        env: Env,
+        creator: Address,
+        nft_address: Address,
+        reward_token: Address,
+        reward_rate: i128,
+        salt: BytesN<32>,
+    ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
+        creator.require_auth();
+
+        if storage::staking_pool_by_nft(&env, &nft_address).is_some() {
+            return Err(Error::StakingPoolAlreadyExists);
+        }
+
+        let wasm = storage::get_staking_wasm_hash(&env).ok_or(Error::WasmHashNotSet)?;
+
+        let secure_salt = make_secure_salt(&env, &creator, &salt);
+        let addr = env
+            .deployer()
+            .with_current_contract(secure_salt)
+            .deploy_v2(wasm, ());
+
+        NftStakingClient::new(&env, &addr).init(
+            &creator,
+            &nft_address,
+            &reward_token,
+            &reward_rate,
+        );
+
+        storage::record_staking_pool(&env, &nft_address, &addr);
+        events::publish_staking_deploy(&env, &creator, &nft_address, &addr);
+        Ok(addr)
+    }
+
     // ── Admin management ──────────────────────────────────────────────────
 
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
@@ -443,5 +502,10 @@ impl Launchpad {
     /// Callable from frontend and CLI.
     pub fn get_collection_count(env: Env) -> u64 {
         storage::collection_count(&env)
+    }
+
+    /// Look up the staking pool clone deployed for an NFT collection address.
+    pub fn get_staking_pool(env: Env, nft_address: Address) -> Option<Address> {
+        storage::staking_pool_by_nft(&env, &nft_address)
     }
 }

--- a/contracts/launchpad/src/events.rs
+++ b/contracts/launchpad/src/events.rs
@@ -15,3 +15,16 @@ pub fn publish_deploy(
         (creator.clone(), address.clone(), kind.clone()),
     );
 }
+
+#[allow(deprecated)]
+pub fn publish_staking_deploy(
+    env: &Env,
+    creator: &Address,
+    nft_address: &Address,
+    pool_address: &Address,
+) {
+    env.events().publish(
+        (symbol_short!("stake"), symbol_short!("pool")),
+        (creator.clone(), nft_address.clone(), pool_address.clone()),
+    );
+}

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -83,6 +83,32 @@ pub fn get_wasm_lazy_1155(env: &Env) -> Option<BytesN<32>> {
     env.storage().instance().get(&DataKey::WasmLazy1155)
 }
 
+pub fn set_staking_wasm_hash(env: &Env, hash: &BytesN<32>) {
+    env.storage().instance().set(&DataKey::WasmStaking, hash);
+}
+
+pub fn get_staking_wasm_hash(env: &Env) -> Option<BytesN<32>> {
+    env.storage().instance().get(&DataKey::WasmStaking)
+}
+
+pub fn staking_pool_by_nft(env: &Env, nft_address: &Address) -> Option<Address> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::StakingPoolByNft(nft_address.clone()))
+}
+
+pub fn record_staking_pool(env: &Env, nft_address: &Address, pool_address: &Address) {
+    env.storage().persistent().set(
+        &DataKey::StakingPoolByNft(nft_address.clone()),
+        pool_address,
+    );
+    env.storage().persistent().extend_ttl(
+        &DataKey::StakingPoolByNft(nft_address.clone()),
+        TTL_THRESHOLD,
+        TTL_BUMP,
+    );
+}
+
 pub fn collections_by_creator(env: &Env, creator: &Address) -> Vec<CollectionRecord> {
     let count = creator_collection_count(env, creator);
     let mut result = Vec::new(env);

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1129,3 +1129,56 @@ fn deploy_events_include_kind_in_payload() {
     // Confirm total count covers both
     assert_eq!(client.get_collection_count(), 2u64);
 }
+
+fn setup_launchpad_with_staking(env: &Env) -> (LaunchpadClient<'_>, Address, Address) {
+    env.mock_all_auths();
+
+    let launchpad_id = env.register(Launchpad, ());
+    let client = LaunchpadClient::new(env, &launchpad_id);
+
+    let admin = Address::generate(env);
+    let creator = Address::generate(env);
+    let fee_receiver = Address::generate(env);
+
+    client.initialize(&admin, &fee_receiver, &0u32);
+
+    let wasm_staking_bytes = wasm_bytes("nft_staking");
+    let wasm_staking = env
+        .deployer()
+        .upload_contract_wasm(wasm_staking_bytes.as_slice());
+
+    client.set_staking_wasm_hash(&wasm_staking);
+
+    (client, admin, creator)
+}
+
+#[test]
+fn deploys_staking_pool_for_nft_collection() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, creator) = setup_launchpad_with_staking(&env);
+
+    let nft_address = Address::generate(&env);
+    let reward_token = Address::generate(&env);
+    let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
+
+    let pool_a = client.deploy_staking_pool(
+        &creator,
+        &nft_address,
+        &reward_token,
+        &1_000_000i128,
+        &salt,
+    );
+
+    let pool_b = client.get_staking_pool(&nft_address);
+    assert_eq!(Some(pool_a), pool_b);
+
+    let duplicate = client.try_deploy_staking_pool(
+        &creator,
+        &nft_address,
+        &reward_token,
+        &1_000_000i128,
+        &BytesN::from_array(&env, &[0xBBu8; 32]),
+    );
+    assert_eq!(duplicate, Err(Ok(Error::StakingPoolAlreadyExists)));
+}

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -8,6 +8,7 @@ pub enum Error {
     NotInitialized = 2,
     NotAdmin = 3,
     WasmHashNotSet = 4,
+    StakingPoolAlreadyExists = 5,
 }
 
 /// Which of the four collection types was deployed.
@@ -51,4 +52,8 @@ pub enum DataKey {
     CreatorCollectionByIndex(Address, u64),
     /// Lookup a collection record by its deployed address
     CollectionByAddress(Address),
+    /// WASM hash for NftStaking clone deployments
+    WasmStaking,
+    /// Maps an NFT collection address to its staking pool clone
+    StakingPoolByNft(Address),
 }

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -4,13 +4,39 @@ use crate::events::*;
 use crate::storage::*;
 use crate::types::*;
 
-const REWARDS_PER_SECOND: i128 = 1_000_000;
-
 #[contract]
 pub struct NftStaking;
 
 #[contractimpl]
 impl NftStaking {
+    /// One-shot initializer called by the Launchpad factory after clone deploy.
+    /// Locks in the NFT collection, reward token, and emission rate for this pool.
+    pub fn init(
+        env: Env,
+        admin: Address,
+        nft_address: Address,
+        reward_token: Address,
+        reward_rate: i128,
+    ) {
+        if is_initialized(&env) {
+            panic_with_error!(&env, StakingError::AlreadyInitialized);
+        }
+        if reward_rate <= 0 {
+            panic_with_error!(&env, StakingError::InvalidDuration);
+        }
+
+        set_initialized(&env);
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+        set_nft_address(&env, &nft_address);
+        set_reward_token(&env, &reward_token);
+        set_reward_config(
+            &env,
+            &RewardConfig {
+                rewards_per_second: reward_rate,
+            },
+        );
+    }
+
     pub fn set_admin(env: Env, admin: Address) {
         let key = DataKey::Admin;
         if env.storage().persistent().get::<_, Address>(&key).is_some() {
@@ -26,10 +52,38 @@ impl NftStaking {
             .get::<_, Address>(&DataKey::Admin)
     }
 
+    pub fn get_nft_address(env: Env) -> Address {
+        get_nft_address(&env).unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized))
+    }
+
+    pub fn get_reward_token(env: Env) -> Address {
+        get_reward_token(&env).unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized))
+    }
+
+    pub fn get_reward_rate(env: Env) -> i128 {
+        get_reward_config(&env)
+            .map(|c| c.rewards_per_second)
+            .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized))
+    }
+
     fn require_admin(env: &Env) {
         let admin = Self::get_admin(env.clone())
             .unwrap_or_else(|| panic_with_error!(env, StakingError::Unauthorized));
         admin.require_auth();
+    }
+
+    fn rewards_per_second(env: &Env) -> i128 {
+        get_reward_config(env)
+            .map(|c| c.rewards_per_second)
+            .unwrap_or(0)
+    }
+
+    fn require_pool_nft(env: &Env, token_address: &Address) {
+        let expected = get_nft_address(env)
+            .unwrap_or_else(|| panic_with_error!(env, StakingError::NotInitialized));
+        if *token_address != expected {
+            panic_with_error!(env, StakingError::InvalidToken);
+        }
     }
 
     pub fn set_paused(env: Env, paused: bool) {
@@ -49,6 +103,7 @@ impl NftStaking {
             panic_with_error!(&env, StakingError::ContractPaused);
         }
         user.require_auth();
+        Self::require_pool_nft(&env, &token_address);
 
         let position_key = DataKey::StakedPosition(user.clone(), token_address.clone(), token_id);
 
@@ -98,6 +153,7 @@ impl NftStaking {
             panic_with_error!(&env, StakingError::ContractPaused);
         }
         user.require_auth();
+        Self::require_pool_nft(&env, &token_address);
 
         let position_key = DataKey::StakedPosition(user.clone(), token_address.clone(), token_id);
         let mut position = load_staked_position(&env, &position_key)
@@ -107,8 +163,9 @@ impl NftStaking {
             panic_with_error!(&env, StakingError::Unauthorized);
         }
 
+        let rate = Self::rewards_per_second(&env);
         let elapsed = env.ledger().timestamp() - position.staked_at;
-        let rewards = (elapsed as i128) * REWARDS_PER_SECOND;
+        let rewards = (elapsed as i128) * rate;
         position.rewards_earned += rewards;
 
         env.invoke_contract::<()>(
@@ -143,13 +200,14 @@ impl NftStaking {
         }
         user.require_auth();
 
+        let rate = Self::rewards_per_second(&env);
         let stake_keys = get_user_stakes(&env, &user);
         let mut total_rewards: i128 = 0;
 
         for key in stake_keys.iter() {
             if let Some(mut position) = load_staked_position(&env, &key) {
                 let elapsed = env.ledger().timestamp() - position.staked_at;
-                let rewards = (elapsed as i128) * REWARDS_PER_SECOND;
+                let rewards = (elapsed as i128) * rate;
                 position.rewards_earned += rewards;
                 position.staked_at = env.ledger().timestamp();
                 total_rewards += rewards;
@@ -197,12 +255,13 @@ impl NftStaking {
     }
 
     pub fn calculate_rewards(env: Env, user: Address) -> i128 {
+        let rate = Self::rewards_per_second(&env);
         let stake_keys = get_user_stakes(&env, &user);
         let mut total: i128 = 0;
         for key in stake_keys.iter() {
             if let Some(position) = load_staked_position(&env, &key) {
                 let elapsed = env.ledger().timestamp() - position.staked_at;
-                total += (elapsed as i128) * REWARDS_PER_SECOND + position.rewards_earned;
+                total += (elapsed as i128) * rate + position.rewards_earned;
             }
         }
         total

--- a/contracts/nft-staking/src/storage.rs
+++ b/contracts/nft-staking/src/storage.rs
@@ -11,6 +11,9 @@ pub enum DataKey {
     Admin,
     IsPaused,
     TokenWhitelist,
+    Initialized,
+    NftAddress,
+    RewardToken,
 }
 
 pub const LEDGER_TTL_BUMP: u32 = 432_000;
@@ -103,4 +106,48 @@ pub fn get_total_staked(env: &Env) -> u64 {
         .persistent()
         .get::<DataKey, u64>(&DataKey::TotalStaked)
         .unwrap_or(0)
+}
+
+pub fn is_initialized(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Initialized)
+        .unwrap_or(false)
+}
+
+pub fn set_initialized(env: &Env) {
+    env.storage().instance().set(&DataKey::Initialized, &true);
+}
+
+pub fn set_nft_address(env: &Env, addr: &Address) {
+    env.storage().instance().set(&DataKey::NftAddress, addr);
+}
+
+pub fn get_nft_address(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::NftAddress)
+}
+
+pub fn set_reward_token(env: &Env, addr: &Address) {
+    env.storage().instance().set(&DataKey::RewardToken, addr);
+}
+
+pub fn get_reward_token(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::RewardToken)
+}
+
+pub fn set_reward_config(env: &Env, config: &crate::types::RewardConfig) {
+    env.storage()
+        .persistent()
+        .set(&DataKey::RewardConfig, config);
+    env.storage().persistent().extend_ttl(
+        &DataKey::RewardConfig,
+        LEDGER_TTL_THRESHOLD,
+        LEDGER_TTL_BUMP,
+    );
+}
+
+pub fn get_reward_config(env: &Env) -> Option<crate::types::RewardConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::RewardConfig)
 }

--- a/contracts/nft-staking/src/test.rs
+++ b/contracts/nft-staking/src/test.rs
@@ -35,11 +35,13 @@ fn setup() -> (Env, NftStakingClient<'static>, Address, Address, Address) {
     let admin = Address::generate(&env);
     let user1 = Address::generate(&env);
     let user2 = Address::generate(&env);
+    let nft = Address::generate(&env);
+    let reward_token = Address::generate(&env);
 
     let staking_id = env.register_contract(None, crate::NftStaking);
     let staking = NftStakingClient::new(&env, &staking_id);
 
-    staking.set_admin(&admin);
+    staking.init(&admin, &nft, &reward_token, &1_000_000i128);
 
     (env, staking, admin, user1, user2)
 }
@@ -51,11 +53,12 @@ fn setup_with_mock() -> (Env, NftStakingClient<'static>, Address, Address, Addre
     let admin = Address::generate(&env);
     let user = Address::generate(&env);
     let collection = env.register_contract(None, mock_nft::MockNft);
+    let reward_token = Address::generate(&env);
 
     let staking_id = env.register_contract(None, crate::NftStaking);
     let staking = NftStakingClient::new(&env, &staking_id);
 
-    staking.set_admin(&admin);
+    staking.init(&admin, &collection, &reward_token, &1_000_000i128);
 
     (env, staking, user, collection, admin)
 }
@@ -96,11 +99,10 @@ fn test_total_staked() {
 
 #[test]
 fn test_multiple_stakes_per_user() {
-    let (env, staking, user, collection1, _admin) = setup_with_mock();
-    let collection2 = env.register_contract(None, mock_nft::MockNft);
+    let (_env, staking, user, collection1, _admin) = setup_with_mock();
 
     staking.stake(&user, &collection1, &0);
-    staking.stake(&user, &collection2, &1);
+    staking.stake(&user, &collection1, &1);
 
     let stakes = staking.get_user_stakes(&user);
     assert_eq!(stakes.len(), 2);

--- a/contracts/nft-staking/src/types.rs
+++ b/contracts/nft-staking/src/types.rs
@@ -11,6 +11,9 @@ pub enum StakingError {
     TransferFailed = 5,
     InvalidDuration = 6,
     ContractPaused = 7,
+    AlreadyInitialized = 8,
+    NotInitialized = 9,
+    InvalidToken = 10,
 }
 
 #[contracttype]

--- a/frontend/afristore-app/src/app/staking/page.tsx
+++ b/frontend/afristore-app/src/app/staking/page.tsx
@@ -1,17 +1,31 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, Suspense } from "react";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useWalletContext } from "@/context/WalletContext";
 import { useOwnedNFTs } from "@/hooks/useOwnedNFTs";
-import { OwnedToken } from "@/lib/indexer";
+import { getStakingPoolByNft } from "@/lib/launchpad";
+import {
+  calculateRewards,
+  estimateApyPercent,
+  formatRewardRatePerDay,
+  formatAnnualYieldPerNft,
+  getStakingPoolConfig,
+  type StakingPoolConfig,
+} from "@/lib/staking";
+import { config } from "@/lib/config";
 import {
   AlertCircle,
   Lock,
   Unlock,
   Coins,
-  RefreshCw,
   Wallet,
   Layers,
+  Search,
+  Loader2,
+  Settings,
+  TrendingUp,
 } from "lucide-react";
 
 interface StakedItem {
@@ -24,9 +38,18 @@ interface StakedItem {
   rewardsEarned: string;
 }
 
-export default function StakingPage() {
+function StakingPageContent() {
+  const searchParams = useSearchParams();
   const { publicKey, isConnected, isConnecting } = useWalletContext();
-  const { tokens: ownedNfts, isLoading: nftsLoading, refresh: refreshNFTs } = useOwnedNFTs(publicKey);
+  const { tokens: ownedNfts, isLoading: nftsLoading, refresh: refreshNFTs } =
+    useOwnedNFTs(publicKey);
+
+  const [collectionInput, setCollectionInput] = useState("");
+  const [activeCollection, setActiveCollection] = useState("");
+  const [poolAddress, setPoolAddress] = useState<string | null>(null);
+  const [poolConfig, setPoolConfig] = useState<StakingPoolConfig | null>(null);
+  const [poolStakedCount, setPoolStakedCount] = useState(0);
+  const [isLoadingPool, setIsLoadingPool] = useState(false);
 
   const [stakedNfts, setStakedNfts] = useState<StakedItem[]>([]);
   const [isLoadingStaked, setIsLoadingStaked] = useState(false);
@@ -37,40 +60,123 @@ export default function StakingPage() {
   const [error, setError] = useState<string | null>(null);
   const [pendingRewards, setPendingRewards] = useState(0);
   const [activeTab, setActiveTab] = useState<"unstaked" | "staked">("unstaked");
-  const [totalStakedCount, setTotalStakedCount] = useState(0);
+
+  const loadPool = useCallback(async (nftAddress: string) => {
+    const trimmed = nftAddress.trim();
+    if (!trimmed.startsWith("C") || trimmed.length < 56) {
+      setError("Enter a valid NFT contract address (starts with C).");
+      return;
+    }
+    setError(null);
+    setIsLoadingPool(true);
+    setPoolAddress(null);
+    setPoolConfig(null);
+    try {
+      const pool = await getStakingPoolByNft(trimmed);
+      if (!pool) {
+        setError(
+          "No staking pool found for this collection. Creators can deploy one from the setup page.",
+        );
+        setActiveCollection(trimmed);
+        return;
+      }
+      setActiveCollection(trimmed);
+      setPoolAddress(pool);
+      const [cfg, stakedTotal] = await Promise.all([
+        getStakingPoolConfig(pool),
+        import("@/lib/staking").then((m) => m.totalStaked(pool)),
+      ]);
+      setPoolConfig(cfg);
+      setPoolStakedCount(stakedTotal);
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to load staking pool");
+    } finally {
+      setIsLoadingPool(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const fromQuery = searchParams.get("collection");
+    if (fromQuery) {
+      setCollectionInput(fromQuery);
+      loadPool(fromQuery);
+    }
+  }, [searchParams, loadPool]);
 
   const fetchStakedNfts = useCallback(async () => {
-    if (!publicKey) return;
+    if (!publicKey || !activeCollection) return;
     setIsLoadingStaked(true);
     try {
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_INDEXER_URL || "http://localhost:4000"}/wallets/${encodeURIComponent(publicKey)}/staked`,
+        `${config.indexerUrl}/wallets/${encodeURIComponent(publicKey)}/staked`,
       );
       if (res.ok) {
         const data = await res.json();
-        const mapped = (data || []).map((item: any) => ({
-          id: `${item.tokenAddress}-${item.tokenId}`,
-          collectionAddress: item.tokenAddress,
-          tokenId: Number(item.tokenId),
-          name: `NFT #${item.tokenId}`,
-          stakedAt: item.stakedAt,
-          rewardsEarned: item.rewardsEarned || "0",
-        }));
+        const mapped = (data || [])
+          .filter(
+            (item: { tokenAddress: string }) =>
+              item.tokenAddress === activeCollection,
+          )
+          .map((item: {
+            tokenAddress: string;
+            tokenId: string;
+            stakedAt: string;
+            rewardsEarned?: string;
+          }) => ({
+            id: `${item.tokenAddress}-${item.tokenId}`,
+            collectionAddress: item.tokenAddress,
+            tokenId: Number(item.tokenId),
+            name: `NFT #${item.tokenId}`,
+            stakedAt: item.stakedAt,
+            rewardsEarned: item.rewardsEarned || "0",
+          }));
         setStakedNfts(mapped);
-        setTotalStakedCount(mapped.length);
       }
     } catch {
-      // Indexer might not have staking support yet
+      // Indexer may not have staking support yet — fall back to on-chain
+      if (poolAddress) {
+        try {
+          const { getUserStakes } = await import("@/lib/staking");
+          const positions = await getUserStakes(publicKey, poolAddress);
+          const mapped = positions
+            .filter((p) => p.token_address === activeCollection)
+            .map((p) => ({
+              id: `${p.token_address}-${p.token_id}`,
+              collectionAddress: p.token_address,
+              tokenId: p.token_id,
+              name: `NFT #${p.token_id}`,
+              stakedAt: String(p.staked_at),
+              rewardsEarned: p.rewards_earned,
+            }));
+          setStakedNfts(mapped);
+        } catch {
+          /* ignore */
+        }
+      }
     } finally {
       setIsLoadingStaked(false);
     }
-  }, [publicKey]);
+  }, [publicKey, activeCollection, poolAddress]);
+
+  const fetchPendingRewards = useCallback(async () => {
+    if (!publicKey || !poolAddress) {
+      setPendingRewards(0);
+      return;
+    }
+    try {
+      const rewards = await calculateRewards(publicKey, poolAddress);
+      setPendingRewards(rewards);
+    } catch {
+      setPendingRewards(0);
+    }
+  }, [publicKey, poolAddress]);
 
   useEffect(() => {
-    if (publicKey) {
+    if (publicKey && activeCollection && poolAddress) {
       fetchStakedNfts();
+      fetchPendingRewards();
     }
-  }, [publicKey, fetchStakedNfts]);
+  }, [publicKey, activeCollection, poolAddress, fetchStakedNfts, fetchPendingRewards]);
 
   const toggleSelect = (id: string) => {
     setSelectedIds((prev) => {
@@ -82,20 +188,26 @@ export default function StakingPage() {
   };
 
   const handleStakeSelected = async () => {
-    if (!publicKey || selectedIds.size === 0) return;
+    if (!publicKey || !poolAddress || selectedIds.size === 0) return;
     setIsStaking(true);
     setError(null);
     try {
       const { stake } = await import("@/lib/staking");
-      const selected = ownedNfts.filter((nft) =>
+      const selected = collectionNfts.filter((nft) =>
         selectedIds.has(`${nft.collectionAddress}-${nft.tokenId}`),
       );
       for (const nft of selected) {
-        await stake(publicKey, nft.collectionAddress, nft.tokenId);
+        await stake(
+          publicKey,
+          nft.collectionAddress,
+          nft.tokenId,
+          poolAddress,
+        );
       }
       setSelectedIds(new Set());
       await refreshNFTs();
       await fetchStakedNfts();
+      await fetchPendingRewards();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Staking failed");
     } finally {
@@ -104,14 +216,15 @@ export default function StakingPage() {
   };
 
   const handleUnstake = async (collectionAddress: string, tokenId: number) => {
-    if (!publicKey) return;
+    if (!publicKey || !poolAddress) return;
     setIsUnstaking(true);
     setError(null);
     try {
       const { unstake } = await import("@/lib/staking");
-      await unstake(publicKey, collectionAddress, tokenId);
+      await unstake(publicKey, collectionAddress, tokenId, poolAddress);
       await fetchStakedNfts();
       await refreshNFTs();
+      await fetchPendingRewards();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Unstaking failed");
     } finally {
@@ -120,13 +233,14 @@ export default function StakingPage() {
   };
 
   const handleClaimRewards = async () => {
-    if (!publicKey) return;
+    if (!publicKey || !poolAddress) return;
     setIsClaiming(true);
     setError(null);
     try {
       const { claimRewards } = await import("@/lib/staking");
-      await claimRewards(publicKey);
+      await claimRewards(publicKey, poolAddress);
       await fetchStakedNfts();
+      await fetchPendingRewards();
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : "Claim failed");
     } finally {
@@ -134,42 +248,57 @@ export default function StakingPage() {
     }
   };
 
+  const collectionNfts = activeCollection
+    ? ownedNfts.filter((n) => n.collectionAddress === activeCollection)
+    : [];
+
+  const unstakedNfts = collectionNfts.filter(
+    (nft) =>
+      !stakedNfts.some(
+        (s) =>
+          s.collectionAddress === nft.collectionAddress &&
+          s.tokenId === nft.tokenId,
+      ),
+  );
+
+  const apyDisplay = poolConfig
+    ? estimateApyPercent(poolConfig.rewardRate, poolStakedCount || 1)
+    : "—";
+
   if (!isConnected) {
     return (
-      <div className="min-h-screen bg-gray-50">
-        <div className="bg-midnight-900 pt-32 pb-16">
+      <main className="min-h-screen bg-midnight-950 text-white selection:bg-brand-500 selection:text-white">
+        <div className="pt-32 pb-16">
           <div className="mx-auto max-w-7xl px-4 sm:px-6">
             <h1 className="text-5xl font-display font-bold text-white tracking-tight">
               NFT Staking
             </h1>
             <p className="mt-4 max-w-xl text-xl text-white/60 font-inter leading-relaxed">
-              Stake your NFTs to earn platform rewards
+              Stake NFTs from any collection to earn custom reward tokens
             </p>
           </div>
         </div>
         <div className="flex flex-col items-center justify-center py-20">
-          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-brand-50 text-brand-500 mb-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/5 border border-white/10 text-brand-400 mb-4">
             <Wallet size={32} />
           </div>
-          <h3 className="font-display font-bold text-gray-900 text-lg">
+          <h3 className="font-display font-bold text-white text-lg">
             Connect your wallet
           </h3>
-          <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
-            Connect your Freighter or Magic wallet to stake NFTs and earn rewards.
+          <p className="mt-1 text-sm text-white/60 max-w-sm text-center">
+            {isConnecting
+              ? "Connecting..."
+              : "Connect your Freighter wallet to stake NFTs and earn rewards."}
           </p>
         </div>
-      </div>
+      </main>
     );
   }
 
-  const unstakedNfts = ownedNfts.filter(
-    (nft) => !stakedNfts.some((s) => s.collectionAddress === nft.collectionAddress && s.tokenId === nft.tokenId),
-  );
-
   return (
-    <div className="min-h-screen bg-gray-50">
+    <main className="min-h-screen bg-midnight-950 text-white selection:bg-brand-500 selection:text-white pb-20">
       {/* Header */}
-      <div className="bg-midnight-900 pt-32 pb-16">
+      <div className="pt-32 pb-12">
         <div className="mx-auto max-w-7xl px-4 sm:px-6">
           <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-8">
             <div className="space-y-4">
@@ -177,78 +306,190 @@ export default function StakingPage() {
                 NFT Staking
               </h1>
               <p className="max-w-xl text-xl text-white/60 font-inter leading-relaxed">
-                Stake your NFTs to earn platform rewards
+                Load a collection&apos;s staking pool to stake NFTs and earn
+                rewards
               </p>
             </div>
-            <div className="flex flex-wrap gap-8 md:gap-12">
-              <div className="relative">
-                <span className="text-3xl font-display font-bold text-white block">
-                  {totalStakedCount}
-                </span>
-                <span className="text-sm font-bold uppercase tracking-widest text-brand-500">
-                  Staked
-                </span>
-              </div>
-              <div className="relative">
-                <span className="text-3xl font-display font-bold text-white block">
-                  {ownedNfts.length}
-                </span>
-                <span className="text-sm font-bold uppercase tracking-widest text-brand-500">
-                  Owned
-                </span>
-              </div>
-            </div>
+            <Link
+              href="/staking/setup"
+              className="inline-flex items-center gap-2 rounded-xl bg-white/5 border border-white/10 px-5 py-2.5 text-sm font-bold text-white/80 hover:bg-white/10 hover:text-white transition-all"
+            >
+              <Settings size={16} />
+              Creator Setup
+            </Link>
           </div>
         </div>
       </div>
 
-      {/* Tabs */}
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-8">
-        <div className="flex gap-4 border-b border-gray-200">
-          <button
-            onClick={() => setActiveTab("unstaked")}
-            className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
-              activeTab === "unstaked"
-                ? "text-brand-600 border-b-2 border-brand-500"
-                : "text-gray-400 hover:text-gray-600"
-            }`}
-          >
-            Your Unstaked NFTs
-          </button>
-          <button
-            onClick={() => setActiveTab("staked")}
-            className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
-              activeTab === "staked"
-                ? "text-brand-600 border-b-2 border-brand-500"
-                : "text-gray-400 hover:text-gray-600"
-            }`}
-          >
-            Your Staked Vault
-          </button>
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 space-y-6">
+        {/* Collection lookup */}
+        <div className="glass-card rounded-3xl p-6 border border-white/5">
+          <h2 className="text-sm font-bold uppercase tracking-widest text-white/40 mb-4">
+            NFT Collection Address
+          </h2>
+          <div className="flex flex-col sm:flex-row gap-3">
+            <input
+              type="text"
+              value={collectionInput}
+              onChange={(e) => setCollectionInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") loadPool(collectionInput);
+              }}
+              placeholder="Paste NFT contract address (C...)"
+              className="flex-1 rounded-xl bg-white/5 border border-white/5 px-4 py-3 text-sm font-mono text-white placeholder:text-white/30 focus:outline-none focus:border-brand-500/50"
+            />
+            <button
+              onClick={() => loadPool(collectionInput)}
+              disabled={isLoadingPool || !collectionInput.trim()}
+              className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-500 px-6 py-3 text-sm font-bold text-white hover:bg-brand-600 disabled:opacity-50 transition-all"
+            >
+              {isLoadingPool ? (
+                <Loader2 size={16} className="animate-spin" />
+              ) : (
+                <Search size={16} />
+              )}
+              Load Pool
+            </button>
+          </div>
         </div>
-      </div>
 
-      {/* Error */}
-      {error && (
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
-          <div className="flex items-center gap-3 rounded-xl bg-red-50 border border-red-100 p-4">
-            <AlertCircle size={20} className="text-red-500 shrink-0" />
-            <p className="text-sm text-red-700">{error}</p>
+        {/* Pool stats */}
+        {poolConfig && poolAddress && (
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="glass-card rounded-2xl p-5 border border-white/5">
+              <p className="text-xs font-bold uppercase tracking-widest text-white/40">
+                Reward Token
+              </p>
+              <p className="font-mono text-sm text-white/80 mt-2 truncate">
+                {poolConfig.rewardToken}
+              </p>
+            </div>
+            <div className="glass-card rounded-2xl p-5 border border-white/5">
+              <p className="text-xs font-bold uppercase tracking-widest text-white/40">
+                Daily Rate / NFT
+              </p>
+              <p className="text-2xl font-display font-bold text-white mt-2">
+                {formatRewardRatePerDay(poolConfig.rewardRate)}
+              </p>
+            </div>
+            <div className="glass-card rounded-2xl p-5 border border-white/5">
+              <div className="flex items-center gap-1.5">
+                <TrendingUp size={14} className="text-mint-400" />
+                <p className="text-xs font-bold uppercase tracking-widest text-white/40">
+                  Est. APY
+                </p>
+              </div>
+              <p className="text-2xl font-display font-bold text-mint-400 mt-2">
+                {apyDisplay}
+                {apyDisplay !== "—" && apyDisplay !== "0" && (
+                  <span className="text-sm font-normal text-white/40 ml-1">
+                    tokens/NFT/yr
+                  </span>
+                )}
+              </p>
+            </div>
+            <div className="glass-card rounded-2xl p-5 border border-white/5">
+              <p className="text-xs font-bold uppercase tracking-widest text-white/40">
+                Pool TVL
+              </p>
+              <p className="text-2xl font-display font-bold text-white mt-2">
+                {poolStakedCount}{" "}
+                <span className="text-sm font-normal text-white/40">staked</span>
+              </p>
+              <p className="text-xs text-white/40 mt-1 truncate font-mono">
+                {poolAddress.slice(0, 16)}...
+              </p>
+            </div>
+          </div>
+        )}
+
+        {!poolAddress && activeCollection && !isLoadingPool && (
+          <div className="glass-card rounded-2xl p-6 border border-white/5 text-center">
+            <p className="text-white/60 text-sm">
+              No staking pool deployed for this collection.{" "}
+              <Link
+                href="/staking/setup"
+                className="text-brand-400 hover:text-brand-300 font-medium"
+              >
+                Deploy one as a creator
+              </Link>
+            </p>
+          </div>
+        )}
+
+        {poolAddress && (
+          <>
+            {/* Stats row */}
+            <div className="flex flex-wrap gap-8">
+              <div>
+                <span className="text-3xl font-display font-bold text-white block">
+                  {stakedNfts.length}
+                </span>
+                <span className="text-sm font-bold uppercase tracking-widest text-brand-400">
+                  Your Staked
+                </span>
+              </div>
+              <div>
+                <span className="text-3xl font-display font-bold text-white block">
+                  {collectionNfts.length}
+                </span>
+                <span className="text-sm font-bold uppercase tracking-widest text-brand-400">
+                  You Own
+                </span>
+              </div>
+              <div>
+                <span className="text-3xl font-display font-bold text-white block">
+                  {formatAnnualYieldPerNft(poolConfig!.rewardRate)}
+                </span>
+                <span className="text-sm font-bold uppercase tracking-widest text-brand-400">
+                  Annual / NFT
+                </span>
+              </div>
+            </div>
+
+            {/* Tabs */}
+            <div className="flex gap-4 border-b border-white/5">
+              <button
+                onClick={() => setActiveTab("unstaked")}
+                className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
+                  activeTab === "unstaked"
+                    ? "text-brand-400 border-b-2 border-brand-500"
+                    : "text-white/40 hover:text-white/60"
+                }`}
+              >
+                Unstaked NFTs
+              </button>
+              <button
+                onClick={() => setActiveTab("staked")}
+                className={`pb-3 px-1 text-sm font-bold uppercase tracking-wider transition-colors ${
+                  activeTab === "staked"
+                    ? "text-brand-400 border-b-2 border-brand-500"
+                    : "text-white/40 hover:text-white/60"
+                }`}
+              >
+                Staked Vault
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="flex items-center gap-3 rounded-xl bg-red-500/10 border border-red-500/20 p-4">
+            <AlertCircle size={20} className="text-red-400 shrink-0" />
+            <p className="text-sm text-red-300">{error}</p>
             <button
               onClick={() => setError(null)}
-              className="ml-auto text-red-400 hover:text-red-600 text-sm font-medium"
+              className="ml-auto text-red-400/60 hover:text-red-300 text-sm font-medium"
             >
               Dismiss
             </button>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Actions bar */}
-      {activeTab === "unstaked" && selectedIds.size > 0 && (
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
-          <div className="flex items-center justify-between rounded-xl bg-brand-50 border border-brand-100 p-4">
-            <span className="text-sm font-medium text-brand-900">
+        {poolAddress && activeTab === "unstaked" && selectedIds.size > 0 && (
+          <div className="flex items-center justify-between rounded-xl bg-brand-500/10 border border-brand-500/20 p-4">
+            <span className="text-sm font-medium text-white/80">
               {selectedIds.size} NFT{selectedIds.size > 1 ? "s" : ""} selected
             </span>
             <button
@@ -260,70 +501,47 @@ export default function StakingPage() {
               {isStaking ? "Staking..." : "Stake Selected"}
             </button>
           </div>
-        </div>
-      )}
+        )}
 
-      {activeTab === "staked" && stakedNfts.length > 0 && (
-        <div className="mx-auto max-w-7xl px-4 sm:px-6 pt-6">
-          <div className="flex items-center justify-between rounded-xl bg-mint-50 border border-mint-100 p-4">
+        {poolAddress && activeTab === "staked" && stakedNfts.length > 0 && (
+          <div className="flex items-center justify-between rounded-xl bg-mint-500/10 border border-mint-500/20 p-4">
             <div className="flex items-center gap-2">
-              <Coins size={20} className="text-mint-600" />
-              <span className="text-sm font-medium text-mint-900">
-                Pending Rewards
+              <Coins size={20} className="text-mint-400" />
+              <span className="text-sm font-medium text-white/80">
+                Pending Rewards:{" "}
+                <span className="text-mint-400 font-bold">
+                  {(pendingRewards / 10_000_000).toLocaleString(undefined, {
+                    maximumFractionDigits: 7,
+                  })}
+                </span>
               </span>
             </div>
             <button
               onClick={handleClaimRewards}
-              disabled={isClaiming}
-              className="flex items-center gap-2 rounded-xl bg-mint-500 px-6 py-2.5 text-sm font-bold text-white hover:bg-mint-600 disabled:opacity-50 transition-all"
+              disabled={isClaiming || pendingRewards <= 0}
+              className="flex items-center gap-2 rounded-xl bg-mint-500 px-6 py-2.5 text-sm font-bold text-midnight-950 hover:bg-mint-400 disabled:opacity-50 transition-all"
             >
               <Coins size={14} />
               {isClaiming ? "Claiming..." : "Claim All Rewards"}
             </button>
           </div>
-        </div>
-      )}
+        )}
 
-      {/* Content */}
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 py-8">
-        {activeTab === "unstaked" && (
+        {/* Content grids */}
+        {poolAddress && activeTab === "unstaked" && (
           <>
-            {/* Loading */}
-            {nftsLoading && (
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className="animate-pulse rounded-2xl border border-gray-100 bg-white overflow-hidden"
-                  >
-                    <div className="aspect-square bg-gray-100" />
-                    <div className="p-4 space-y-3">
-                      <div className="h-4 w-3/4 rounded bg-gray-100" />
-                      <div className="h-3 w-1/2 rounded bg-gray-100" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Empty */}
+            {nftsLoading && <LoadingGrid />}
             {!nftsLoading && unstakedNfts.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-20">
-                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-brand-50 text-brand-500 mb-4">
-                  <Layers size={32} />
-                </div>
-                <h3 className="font-display font-bold text-gray-900 text-lg">
-                  No unstaked NFTs
-                </h3>
-                <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
-                  {stakedNfts.length > 0
-                    ? "All your NFTs are staked. Come back after unstaking to re-stake."
-                    : "You don't own any NFTs yet. Explore the marketplace to find artworks to collect."}
-                </p>
-              </div>
+              <EmptyState
+                icon={<Layers size={32} />}
+                title="No unstaked NFTs"
+                description={
+                  stakedNfts.length > 0
+                    ? "All your NFTs from this collection are staked."
+                    : "You don't own any NFTs from this collection."
+                }
+              />
             )}
-
-            {/* Grid */}
             {!nftsLoading && unstakedNfts.length > 0 && (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {unstakedNfts.map((nft) => {
@@ -333,10 +551,10 @@ export default function StakingPage() {
                     <button
                       key={nftId}
                       onClick={() => toggleSelect(nftId)}
-                      className={`relative rounded-2xl border-2 overflow-hidden bg-white text-left transition-all ${
+                      className={`relative rounded-2xl border overflow-hidden bg-white/5 backdrop-blur-md text-left transition-all hover-lift ${
                         isSelected
                           ? "border-brand-500 shadow-lg shadow-brand-500/20"
-                          : "border-gray-100 hover:border-brand-200 hover:shadow-md"
+                          : "border-white/5 hover:border-white/10"
                       }`}
                     >
                       {isSelected && (
@@ -344,7 +562,7 @@ export default function StakingPage() {
                           ✓
                         </div>
                       )}
-                      <div className="aspect-square bg-gray-50 flex items-center justify-center">
+                      <div className="aspect-square bg-white/5 flex items-center justify-center">
                         {nft.image ? (
                           <img
                             src={nft.image}
@@ -352,15 +570,15 @@ export default function StakingPage() {
                             className="w-full h-full object-cover"
                           />
                         ) : (
-                          <Layers size={48} className="text-gray-300" />
+                          <Layers size={48} className="text-white/20" />
                         )}
                       </div>
                       <div className="p-4">
-                        <p className="font-display font-bold text-gray-900 truncate">
+                        <p className="font-display font-bold text-white truncate">
                           {nft.name || `NFT #${nft.tokenId}`}
                         </p>
-                        <p className="text-xs font-mono text-gray-400 truncate mt-1">
-                          {nft.collectionAddress.slice(0, 8)}...
+                        <p className="text-xs font-mono text-white/40 truncate mt-1">
+                          #{nft.tokenId}
                         </p>
                       </div>
                     </button>
@@ -371,65 +589,35 @@ export default function StakingPage() {
           </>
         )}
 
-        {activeTab === "staked" && (
+        {poolAddress && activeTab === "staked" && (
           <>
-            {/* Loading */}
-            {isLoadingStaked && (
-              <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-                {Array.from({ length: 4 }).map((_, i) => (
-                  <div
-                    key={i}
-                    className="animate-pulse rounded-2xl border border-gray-100 bg-white overflow-hidden"
-                  >
-                    <div className="aspect-square bg-gray-100" />
-                    <div className="p-4 space-y-3">
-                      <div className="h-4 w-3/4 rounded bg-gray-100" />
-                      <div className="h-3 w-1/2 rounded bg-gray-100" />
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-
-            {/* Empty */}
+            {isLoadingStaked && <LoadingGrid />}
             {!isLoadingStaked && stakedNfts.length === 0 && (
-              <div className="flex flex-col items-center justify-center py-20">
-                <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-mint-50 text-mint-500 mb-4">
-                  <Lock size={32} />
-                </div>
-                <h3 className="font-display font-bold text-gray-900 text-lg">
-                  No staked NFTs
-                </h3>
-                <p className="mt-1 text-sm text-gray-500 max-w-sm text-center">
-                  You haven&apos;t staked any NFTs yet. Browse your unstaked NFTs and
-                  start staking to earn rewards.
-                </p>
-              </div>
+              <EmptyState
+                icon={<Lock size={32} />}
+                title="No staked NFTs"
+                description="Select unstaked NFTs and stake them to start earning rewards."
+              />
             )}
-
-            {/* Grid */}
             {!isLoadingStaked && stakedNfts.length > 0 && (
               <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {stakedNfts.map((nft) => (
                   <div
                     key={nft.id}
-                    className="relative rounded-2xl border border-gray-100 bg-white overflow-hidden"
+                    className="relative rounded-2xl border border-white/5 bg-white/5 backdrop-blur-md overflow-hidden"
                   >
-                    <div className="absolute top-3 left-3 z-10 flex items-center gap-1.5 rounded-full bg-mint-500/90 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-white">
+                    <div className="absolute top-3 left-3 z-10 flex items-center gap-1.5 rounded-full bg-mint-500/90 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-midnight-950">
                       <Lock size={10} />
                       Staked
                     </div>
-                    <div className="aspect-square bg-gray-50 flex items-center justify-center">
-                      <Layers size={48} className="text-gray-300" />
+                    <div className="aspect-square bg-white/5 flex items-center justify-center">
+                      <Layers size={48} className="text-white/20" />
                     </div>
                     <div className="p-4 space-y-3">
-                      <p className="font-display font-bold text-gray-900 truncate">
+                      <p className="font-display font-bold text-white truncate">
                         {nft.name || `NFT #${nft.tokenId}`}
                       </p>
-                      <p className="text-xs font-mono text-gray-400 truncate">
-                        {nft.collectionAddress.slice(0, 8)}...
-                      </p>
-                      <div className="flex items-center gap-1.5 text-sm text-mint-600">
+                      <div className="flex items-center gap-1.5 text-sm text-mint-400">
                         <Coins size={14} />
                         <span className="font-medium">{nft.rewardsEarned}</span>
                       </div>
@@ -438,7 +626,7 @@ export default function StakingPage() {
                           handleUnstake(nft.collectionAddress, nft.tokenId)
                         }
                         disabled={isUnstaking}
-                        className="w-full flex items-center justify-center gap-2 rounded-xl border border-gray-200 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50 hover:border-gray-300 disabled:opacity-50 transition-all"
+                        className="w-full flex items-center justify-center gap-2 rounded-xl border border-white/10 px-4 py-2 text-sm font-medium text-white/60 hover:bg-white/5 hover:text-white disabled:opacity-50 transition-all"
                       >
                         <Unlock size={14} />
                         {isUnstaking ? "Unstaking..." : "Unstake"}
@@ -450,7 +638,70 @@ export default function StakingPage() {
             )}
           </>
         )}
+
+        {!poolAddress && !isLoadingPool && !activeCollection && (
+          <EmptyState
+            icon={<Search size={32} />}
+            title="Select a collection"
+            description="Paste an NFT contract address above to load its staking pool and start earning rewards."
+          />
+        )}
       </div>
+    </main>
+  );
+}
+
+function LoadingGrid() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div
+          key={i}
+          className="animate-pulse rounded-2xl border border-white/5 bg-white/5 overflow-hidden"
+        >
+          <div className="aspect-square bg-white/5" />
+          <div className="p-4 space-y-3">
+            <div className="h-4 w-3/4 rounded bg-white/5" />
+            <div className="h-3 w-1/2 rounded bg-white/5" />
+          </div>
+        </div>
+      ))}
     </div>
+  );
+}
+
+function EmptyState({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center py-20">
+      <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white/5 border border-white/10 text-brand-400 mb-4">
+        {icon}
+      </div>
+      <h3 className="font-display font-bold text-white text-lg">{title}</h3>
+      <p className="mt-1 text-sm text-white/60 max-w-sm text-center">
+        {description}
+      </p>
+    </div>
+  );
+}
+
+export default function StakingPage() {
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen bg-midnight-950 flex items-center justify-center">
+          <Loader2 size={32} className="animate-spin text-brand-400" />
+        </main>
+      }
+    >
+      <StakingPageContent />
+    </Suspense>
   );
 }

--- a/frontend/afristore-app/src/app/staking/setup/page.tsx
+++ b/frontend/afristore-app/src/app/staking/setup/page.tsx
@@ -1,0 +1,336 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import Link from "next/link";
+import { useWalletContext } from "@/context/WalletContext";
+import { WalletGuard } from "@/components/WalletGuard";
+import {
+  getStakingPoolByNft,
+  deployStakingPool,
+} from "@/lib/launchpad";
+import {
+  getStakingPoolConfig,
+  formatRewardRatePerDay,
+  formatAnnualYieldPerNft,
+} from "@/lib/staking";
+import { assertSupportedTokenAddress } from "@/lib/token-support";
+import {
+  ArrowLeft,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  Lock,
+  Search,
+  Sparkles,
+} from "lucide-react";
+
+function isValidContractAddress(addr: string): boolean {
+  const t = addr.trim();
+  return t.startsWith("C") && t.length >= 56;
+}
+
+export default function StakingSetupPage() {
+  const { publicKey } = useWalletContext();
+
+  const [nftAddress, setNftAddress] = useState("");
+  const [lookupAddress, setLookupAddress] = useState("");
+  const [existingPool, setExistingPool] = useState<string | null>(null);
+  const [poolConfig, setPoolConfig] = useState<{
+    rewardToken: string;
+    rewardRate: bigint;
+  } | null>(null);
+  const [isChecking, setIsChecking] = useState(false);
+  const [rewardToken, setRewardToken] = useState("");
+  const [rewardRate, setRewardRate] = useState("");
+  const [isDeploying, setIsDeploying] = useState(false);
+  const [deployedPool, setDeployedPool] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkPool = useCallback(async (address: string) => {
+    if (!isValidContractAddress(address)) {
+      setError("Enter a valid Stellar contract address (starts with C).");
+      return;
+    }
+    setError(null);
+    setIsChecking(true);
+    setExistingPool(null);
+    setPoolConfig(null);
+    setDeployedPool(null);
+    try {
+      const pool = await getStakingPoolByNft(address);
+      setLookupAddress(address);
+      if (pool) {
+        setExistingPool(pool);
+        const config = await getStakingPoolConfig(pool);
+        setPoolConfig({
+          rewardToken: config.rewardToken,
+          rewardRate: config.rewardRate,
+        });
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Failed to check pool");
+    } finally {
+      setIsChecking(false);
+    }
+  }, []);
+
+  const handleDeploy = async () => {
+    if (!publicKey || !lookupAddress) return;
+    setError(null);
+    setIsDeploying(true);
+    try {
+      const token = await assertSupportedTokenAddress(
+        rewardToken,
+        "reward",
+      );
+      const rateNum = parseFloat(rewardRate);
+      if (isNaN(rateNum) || rateNum <= 0) {
+        throw new Error("Reward rate must be a positive number (tokens per second).");
+      }
+      const rateStroops = BigInt(Math.round(rateNum * 10_000_000));
+      const salt = Buffer.alloc(32);
+      window.crypto.getRandomValues(salt);
+
+      const poolAddress = await deployStakingPool(
+        publicKey,
+        lookupAddress,
+        token.address,
+        rateStroops,
+        salt,
+      );
+      setDeployedPool(poolAddress);
+      setExistingPool(poolAddress);
+      setPoolConfig({
+        rewardToken: token.address,
+        rewardRate: rateStroops,
+      });
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : "Deployment failed");
+    } finally {
+      setIsDeploying(false);
+    }
+  };
+
+  const showForm = lookupAddress && !existingPool && !deployedPool;
+
+  return (
+    <main className="min-h-screen bg-midnight-950 text-white selection:bg-brand-500 selection:text-white">
+      <div className="pt-24 pb-20">
+        <div className="mx-auto max-w-3xl px-4 sm:px-6">
+          <Link
+            href="/staking"
+            className="inline-flex items-center gap-2 text-sm text-white/60 hover:text-white transition-colors mb-8"
+          >
+            <ArrowLeft size={16} />
+            Back to Staking Dashboard
+          </Link>
+
+          <div className="mb-10">
+            <span className="inline-block px-4 py-1.5 rounded-full bg-brand-500/20 text-brand-400 text-xs font-bold uppercase tracking-widest mb-4">
+              Creator Tools
+            </span>
+            <h1 className="text-4xl font-display font-black text-white mb-3">
+              Staking Pool Setup
+            </h1>
+            <p className="text-white/60 font-inter leading-relaxed max-w-xl">
+              Deploy a dedicated staking pool for your NFT collection. Each
+              collection gets its own clone with custom reward token and emission
+              rate.
+            </p>
+          </div>
+
+          <WalletGuard actionName="To deploy a staking pool">
+            {/* Step 1: NFT address lookup */}
+            <div className="glass-card rounded-3xl p-8 mb-6">
+              <h2 className="text-lg font-display font-bold text-white mb-1">
+                NFT Collection Address
+              </h2>
+              <p className="text-sm text-white/60 mb-6">
+                Paste your deployed NFT contract address to check if a staking
+                pool already exists.
+              </p>
+              <div className="flex flex-col sm:flex-row gap-3">
+                <input
+                  type="text"
+                  value={nftAddress}
+                  onChange={(e) => setNftAddress(e.target.value)}
+                  placeholder="C..."
+                  className="flex-1 rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-mono text-white placeholder:text-white/30 focus:outline-none focus:border-brand-500/50 focus:ring-1 focus:ring-brand-500/30"
+                />
+                <button
+                  onClick={() => checkPool(nftAddress.trim())}
+                  disabled={isChecking || !nftAddress.trim()}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-500 px-6 py-3 text-sm font-bold text-white hover:bg-brand-600 disabled:opacity-50 transition-all"
+                >
+                  {isChecking ? (
+                    <Loader2 size={16} className="animate-spin" />
+                  ) : (
+                    <Search size={16} />
+                  )}
+                  Check Pool
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <div className="flex items-center gap-3 rounded-xl bg-red-500/10 border border-red-500/20 p-4 mb-6">
+                <AlertCircle size={20} className="text-red-400 shrink-0" />
+                <p className="text-sm text-red-300">{error}</p>
+              </div>
+            )}
+
+            {/* Existing pool found */}
+            {existingPool && poolConfig && (
+              <div className="glass-card rounded-3xl p-8 mb-6 border border-mint-500/20">
+                <div className="flex items-start gap-4">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-mint-500/20 text-mint-400 shrink-0">
+                    <CheckCircle2 size={24} />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="text-lg font-display font-bold text-white">
+                      Staking Pool Active
+                    </h3>
+                    <p className="text-sm text-white/60 mt-1">
+                      A pool already exists for this collection.
+                    </p>
+                    <dl className="mt-6 space-y-3 text-sm">
+                      <div>
+                        <dt className="text-white/40 uppercase tracking-wider text-xs font-bold">
+                          Pool Contract
+                        </dt>
+                        <dd className="font-mono text-white/80 mt-1 break-all">
+                          {existingPool}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-white/40 uppercase tracking-wider text-xs font-bold">
+                          Reward Token
+                        </dt>
+                        <dd className="font-mono text-white/80 mt-1 break-all">
+                          {poolConfig.rewardToken}
+                        </dd>
+                      </div>
+                      <div className="grid grid-cols-2 gap-4">
+                        <div>
+                          <dt className="text-white/40 uppercase tracking-wider text-xs font-bold">
+                            Daily Rate / NFT
+                          </dt>
+                          <dd className="text-white mt-1 font-medium">
+                            {formatRewardRatePerDay(poolConfig.rewardRate)} tokens
+                          </dd>
+                        </div>
+                        <div>
+                          <dt className="text-white/40 uppercase tracking-wider text-xs font-bold">
+                            Annual Yield / NFT
+                          </dt>
+                          <dd className="text-white mt-1 font-medium">
+                            {formatAnnualYieldPerNft(poolConfig.rewardRate)} tokens
+                          </dd>
+                        </div>
+                      </div>
+                    </dl>
+                    <Link
+                      href={`/staking?collection=${encodeURIComponent(lookupAddress)}`}
+                      className="inline-flex items-center gap-2 mt-6 rounded-xl bg-white/10 border border-white/10 px-5 py-2.5 text-sm font-bold text-white hover:bg-white/15 transition-all"
+                    >
+                      <Lock size={14} />
+                      Open Staking Dashboard
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Deploy form */}
+            {showForm && (
+              <div className="glass-card rounded-3xl p-8">
+                <div className="flex items-center gap-3 mb-6">
+                  <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-brand-500/20 text-brand-400">
+                    <Sparkles size={20} />
+                  </div>
+                  <div>
+                    <h3 className="text-lg font-display font-bold text-white">
+                      Deploy New Pool
+                    </h3>
+                    <p className="text-sm text-white/60">
+                      No pool found for{" "}
+                      <span className="font-mono text-white/80">
+                        {lookupAddress.slice(0, 12)}...
+                      </span>
+                    </p>
+                  </div>
+                </div>
+
+                <div className="space-y-5">
+                  <div>
+                    <label className="block text-xs font-bold uppercase tracking-wider text-white/40 mb-2">
+                      Reward Token Address
+                    </label>
+                    <input
+                      type="text"
+                      value={rewardToken}
+                      onChange={(e) => setRewardToken(e.target.value)}
+                      placeholder="SAC contract address (C...)"
+                      className="w-full rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-sm font-mono text-white placeholder:text-white/30 focus:outline-none focus:border-brand-500/50"
+                    />
+                  </div>
+                  <div>
+                    <label className="block text-xs font-bold uppercase tracking-wider text-white/40 mb-2">
+                      Reward Rate (tokens per second)
+                    </label>
+                    <input
+                      type="number"
+                      min="0"
+                      step="0.0000001"
+                      value={rewardRate}
+                      onChange={(e) => setRewardRate(e.target.value)}
+                      placeholder="e.g. 0.1"
+                      className="w-full rounded-xl bg-white/5 border border-white/10 px-4 py-3 text-sm text-white placeholder:text-white/30 focus:outline-none focus:border-brand-500/50"
+                    />
+                    <p className="text-xs text-white/40 mt-2">
+                      Each staked NFT earns this many reward tokens per second.
+                    </p>
+                  </div>
+                  <button
+                    onClick={handleDeploy}
+                    disabled={isDeploying || !rewardToken || !rewardRate}
+                    className="w-full inline-flex items-center justify-center gap-2 rounded-xl bg-brand-500 px-6 py-3.5 text-sm font-bold text-white hover:bg-brand-600 disabled:opacity-50 transition-all"
+                  >
+                    {isDeploying ? (
+                      <>
+                        <Loader2 size={16} className="animate-spin" />
+                        Deploying Pool...
+                      </>
+                    ) : (
+                      <>
+                        <Sparkles size={16} />
+                        Deploy Staking Pool
+                      </>
+                    )}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {deployedPool && (
+              <div className="glass-card-warm rounded-3xl p-8 mt-6 border border-brand-500/20">
+                <h3 className="text-lg font-display font-bold text-white mb-2">
+                  Pool Deployed Successfully
+                </h3>
+                <p className="font-mono text-sm text-white/80 break-all">
+                  {deployedPool}
+                </p>
+                <Link
+                  href={`/staking?collection=${encodeURIComponent(lookupAddress)}`}
+                  className="inline-flex items-center gap-2 mt-4 rounded-xl bg-brand-500 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-600 transition-all"
+                >
+                  Go to Staking Dashboard
+                </Link>
+              </div>
+            )}
+          </WalletGuard>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -217,6 +217,56 @@ export async function getCollectionRecordByAddress(
   return all.find((c) => c.address === collectionAddress) ?? null;
 }
 
+// ── Staking pool factory ──────────────────────────────────────
+
+/**
+ * Look up the staking pool clone for an NFT collection address.
+ */
+export async function getStakingPoolByNft(
+  nftAddress: string,
+): Promise<string | null> {
+  const DUMMY_KEY =
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const retVal = await invokeContract(
+    DUMMY_KEY,
+    "get_staking_pool",
+    [toAddressScVal(nftAddress)],
+    true,
+    config.launchpadContractId,
+  );
+  const native = scValToNative(retVal);
+  if (!native) return null;
+  return (native as Address).toString();
+}
+
+/**
+ * Deploy a dedicated NftStaking clone for an NFT collection via the Launchpad.
+ */
+export async function deployStakingPool(
+  creatorPublicKey: string,
+  nftAddress: string,
+  rewardToken: string,
+  rewardRate: bigint,
+  salt: Buffer,
+): Promise<string> {
+  const args: xdr.ScVal[] = [
+    toAddressScVal(creatorPublicKey),
+    toAddressScVal(nftAddress),
+    toAddressScVal(rewardToken),
+    nativeToScVal(rewardRate, { type: "i128" }),
+    nativeToScVal(Uint8Array.from(salt), { type: "bytes" }),
+  ];
+
+  const retVal = await invokeContract(
+    creatorPublicKey,
+    "deploy_staking_pool",
+    args,
+    false,
+    config.launchpadContractId,
+  );
+  return (scValToNative(retVal) as Address).toString();
+}
+
 /**
  * collection_count
  */

--- a/frontend/afristore-app/src/lib/staking.ts
+++ b/frontend/afristore-app/src/lib/staking.ts
@@ -22,6 +22,12 @@ export interface StakedPosition {
   rewards_earned: string;
 }
 
+export interface StakingPoolConfig {
+  nftAddress: string;
+  rewardToken: string;
+  rewardRate: bigint;
+}
+
 export interface StakedNFTIndexerRow {
   id: number;
   owner: string;
@@ -38,12 +44,22 @@ export interface StakedNFTIndexerRow {
 export const STAKING_CONTRACT_ID =
   process.env.NEXT_PUBLIC_STAKING_CONTRACT_ID || "";
 
+const SECONDS_PER_YEAR = 31_536_000n;
+
 function getRpc(): SorobanRpc.Server {
   return new SorobanRpc.Server(config.rpcUrl, { allowHttp: false });
 }
 
-export function getStakingContract(): Contract {
-  return new Contract(STAKING_CONTRACT_ID);
+function resolveStakingContractId(poolContractId?: string): string {
+  const id = poolContractId || STAKING_CONTRACT_ID;
+  if (!id) {
+    throw new Error("Staking pool contract ID not configured");
+  }
+  return id;
+}
+
+export function getStakingContract(poolContractId?: string): Contract {
+  return new Contract(resolveStakingContractId(poolContractId));
 }
 
 function getNetworkPassphrase(): string {
@@ -55,10 +71,9 @@ async function invokeStakingContract(
   method: string,
   args: xdr.ScVal[],
   readonly = false,
+  poolContractId?: string,
 ): Promise<xdr.ScVal> {
-  if (!STAKING_CONTRACT_ID) {
-    throw new Error("STAKING_CONTRACT_ID not configured");
-  }
+  const contractId = resolveStakingContractId(poolContractId);
 
   const readableError = (raw: string, fallback: string): Error => {
     const mapped = mapSorobanErrorMessage(raw);
@@ -66,7 +81,7 @@ async function invokeStakingContract(
   };
 
   const rpc = getRpc();
-  const contract = getStakingContract();
+  const contract = new Contract(contractId);
 
   const account = await rpc.getAccount(callerPublicKey);
   const tx = new TransactionBuilder(account, {
@@ -125,33 +140,42 @@ export async function stake(
   userPublicKey: string,
   tokenAddress: string,
   tokenId: number,
+  poolContractId?: string,
 ): Promise<void> {
   const args: xdr.ScVal[] = [
     new Address(userPublicKey).toScVal(),
     new Address(tokenAddress).toScVal(),
     nativeToScVal(BigInt(tokenId), { type: "u64" }),
   ];
-  await invokeStakingContract(userPublicKey, "stake", args);
+  await invokeStakingContract(userPublicKey, "stake", args, false, poolContractId);
 }
 
 export async function unstake(
   userPublicKey: string,
   tokenAddress: string,
   tokenId: number,
+  poolContractId?: string,
 ): Promise<void> {
   const args: xdr.ScVal[] = [
     new Address(userPublicKey).toScVal(),
     new Address(tokenAddress).toScVal(),
     nativeToScVal(BigInt(tokenId), { type: "u64" }),
   ];
-  await invokeStakingContract(userPublicKey, "unstake", args);
+  await invokeStakingContract(userPublicKey, "unstake", args, false, poolContractId);
 }
 
 export async function claimRewards(
   userPublicKey: string,
+  poolContractId?: string,
 ): Promise<number> {
   const args: xdr.ScVal[] = [new Address(userPublicKey).toScVal()];
-  const retVal = await invokeStakingContract(userPublicKey, "claim_rewards", args);
+  const retVal = await invokeStakingContract(
+    userPublicKey,
+    "claim_rewards",
+    args,
+    false,
+    poolContractId,
+  );
   return Number(scValToNative(retVal));
 }
 
@@ -159,6 +183,7 @@ export async function getStakedPosition(
   userPublicKey: string,
   tokenAddress: string,
   tokenId: number,
+  poolContractId?: string,
 ): Promise<StakedPosition | null> {
   const caller = await getConnectedPublicKey();
   const pk = caller ?? userPublicKey;
@@ -171,13 +196,14 @@ export async function getStakedPosition(
       nativeToScVal(BigInt(tokenId), { type: "u64" }),
     ],
     true,
+    poolContractId,
   );
   const raw = scValToNative(retVal);
   if (!raw) return null;
   const obj = raw as Record<string, unknown>;
   return {
-    owner: (obj["owner"] as any).toString(),
-    token_address: (obj["token_address"] as any).toString(),
+    owner: (obj["owner"] as Address).toString(),
+    token_address: (obj["token_address"] as Address).toString(),
     token_id: Number(obj["token_id"]),
     staked_at: Number(obj["staked_at"]),
     rewards_earned: String(obj["rewards_earned"] ?? "0"),
@@ -186,6 +212,7 @@ export async function getStakedPosition(
 
 export async function getUserStakes(
   userPublicKey: string,
+  poolContractId?: string,
 ): Promise<StakedPosition[]> {
   const caller = await getConnectedPublicKey();
   const pk = caller ?? userPublicKey;
@@ -194,11 +221,12 @@ export async function getUserStakes(
     "get_user_stakes",
     [new Address(userPublicKey).toScVal()],
     true,
+    poolContractId,
   );
-  const raw = scValToNative(retVal) as any[];
-  return raw.map((obj: Record<string, unknown>) => ({
-    owner: (obj["owner"] as any).toString(),
-    token_address: (obj["token_address"] as any).toString(),
+  const raw = scValToNative(retVal) as Record<string, unknown>[];
+  return raw.map((obj) => ({
+    owner: (obj["owner"] as Address).toString(),
+    token_address: (obj["token_address"] as Address).toString(),
     token_id: Number(obj["token_id"]),
     staked_at: Number(obj["staked_at"]),
     rewards_earned: String(obj["rewards_earned"] ?? "0"),
@@ -207,6 +235,7 @@ export async function getUserStakes(
 
 export async function calculateRewards(
   userPublicKey: string,
+  poolContractId?: string,
 ): Promise<number> {
   const caller = await getConnectedPublicKey();
   const pk = caller ?? userPublicKey;
@@ -215,11 +244,14 @@ export async function calculateRewards(
     "calculate_rewards",
     [new Address(userPublicKey).toScVal()],
     true,
+    poolContractId,
   );
   return Number(scValToNative(retVal));
 }
 
-export async function isStakingPaused(): Promise<boolean> {
+export async function isStakingPaused(
+  poolContractId?: string,
+): Promise<boolean> {
   const caller = await getConnectedPublicKey();
   if (!caller) return false;
   const retVal = await invokeStakingContract(
@@ -227,13 +259,75 @@ export async function isStakingPaused(): Promise<boolean> {
     "is_paused",
     [],
     true,
+    poolContractId,
   );
   return Boolean(scValToNative(retVal));
 }
 
-export async function totalStaked(): Promise<number> {
+export async function totalStaked(poolContractId?: string): Promise<number> {
   const caller = await getConnectedPublicKey();
   if (!caller) return 0;
-  const retVal = await invokeStakingContract(caller, "total_staked", [], true);
+  const retVal = await invokeStakingContract(
+    caller,
+    "total_staked",
+    [],
+    true,
+    poolContractId,
+  );
   return Number(scValToNative(retVal));
+}
+
+export async function getStakingPoolConfig(
+  poolContractId: string,
+): Promise<StakingPoolConfig> {
+  const DUMMY_KEY =
+    "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+  const [nftVal, tokenVal, rateVal] = await Promise.all([
+    invokeStakingContract(DUMMY_KEY, "get_nft_address", [], true, poolContractId),
+    invokeStakingContract(DUMMY_KEY, "get_reward_token", [], true, poolContractId),
+    invokeStakingContract(DUMMY_KEY, "get_reward_rate", [], true, poolContractId),
+  ]);
+
+  return {
+    nftAddress: (scValToNative(nftVal) as Address).toString(),
+    rewardToken: (scValToNative(tokenVal) as Address).toString(),
+    rewardRate: BigInt(scValToNative(rateVal) as string | number | bigint),
+  };
+}
+
+/** Estimated annual reward tokens per staked NFT (7 decimal stroops). */
+export function formatAnnualYieldPerNft(rewardRate: bigint): string {
+  const annual = rewardRate * SECONDS_PER_YEAR;
+  const whole = annual / 10_000_000n;
+  const frac = annual % 10_000_000n;
+  if (frac === 0n) return whole.toString();
+  const fracStr = frac.toString().padStart(7, "0").replace(/0+$/, "");
+  return `${whole}.${fracStr}`;
+}
+
+/** Simple APY proxy: annual tokens per NFT when exactly one NFT is staked. */
+export function estimateApyPercent(
+  rewardRate: bigint,
+  stakedCount: number,
+): string {
+  if (stakedCount <= 0 || rewardRate <= 0n) {
+    const annual = rewardRate * SECONDS_PER_YEAR;
+    if (annual <= 0n) return "0";
+    return "—";
+  }
+  const annualPerNft =
+    Number(rewardRate * SECONDS_PER_YEAR) / stakedCount / 10_000_000;
+  return annualPerNft.toLocaleString(undefined, {
+    maximumFractionDigits: 2,
+  });
+}
+
+export function formatRewardRatePerDay(rewardRate: bigint): string {
+  const daily = rewardRate * 86_400n;
+  const whole = daily / 10_000_000n;
+  const frac = daily % 10_000_000n;
+  if (frac === 0n) return whole.toString();
+  const fracStr = frac.toString().padStart(7, "0").replace(/0+$/, "");
+  return `${whole}.${fracStr}`;
 }


### PR DESCRIPTION
## Summary

- **#370 — Launchpad staking factory:** Adds `deploy_staking_pool` to the Launchpad contract using `deployer().with_current_contract(salt).deploy_v2()` to clone `NftStaking` instances. Refactors `NftStaking` with an `init()` function that locks in `nft_address`, `reward_token`, and `reward_rate`. Includes `get_staking_pool` lookup and admin `set_staking_wasm_hash`.
- **#371 — Creator setup flow:** New page at `/staking/setup` where creators paste an NFT contract address, check if a pool exists, and deploy a new clone with custom reward token and rate via the Launchpad.
- **#372 — Collection-scoped dashboard:** Updates `/staking` so users paste an NFT contract address to load that collection's pool, displaying its reward token, daily rate, estimated APY, and TVL. Stake/unstake/claim target the specific pool contract.
- **#373 — Dark theme:** Replaces light-mode Tailwind classes on the staking page with the premium African dark-mode aesthetic (`bg-midnight-950`, glassmorphism cards, `text-white/60`, `border-white/5`).

Closes #370
Closes #371
Closes #372
Closes #373

## Test plan

- [ ] `cargo test -p nft-staking` — all 7 tests pass
- [ ] `cargo test -p soroban-launchpad deploys_staking_pool` — staking clone deploy test passes
- [ ] Build staking WASM: `cargo build --target wasm32v1-none --release -p nft-staking`
- [ ] Admin calls `set_staking_wasm_hash` on Launchpad after uploading WASM
- [ ] Visit `/staking/setup` — paste NFT address, verify pool lookup and deploy form
- [ ] Visit `/staking?collection=C...` — verify pool stats, NFT grid, stake/unstake/claim against pool contract
- [ ] Confirm staking pages use dark glassmorphism theme (no `bg-gray-50` / white cards)


Made with [Cursor](https://cursor.com)