### PR TITLE
fix: resolve RPC lag loop, OOM vulnerability, gas limit crash

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -433,10 +433,11 @@ impl Launchpad {
         storage::collection_by_address(&env, &address)
     }
 
-    /// Global registry of every collection ever deployed through this launchpad.
+    /// Paginated registry of collections deployed through this launchpad.
+    /// Returns up to `limit` records starting at `start_index`.
     /// Callable from frontend and CLI.
-    pub fn get_all_collections(env: Env) -> Vec<CollectionRecord> {
-        storage::all_collections(&env)
+    pub fn get_collections(env: Env, start_index: u32, limit: u32) -> Vec<CollectionRecord> {
+        storage::collections_paginated(&env, start_index as u64, limit as u64)
     }
 
     /// Total number of collections deployed through this launchpad.

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -113,6 +113,22 @@ pub fn all_collections(env: &Env) -> Vec<CollectionRecord> {
     result
 }
 
+pub fn collections_paginated(env: &Env, start: u64, limit: u64) -> Vec<CollectionRecord> {
+    let count = collection_count(env);
+    let mut result = Vec::new(env);
+    let end = (start + limit).min(count);
+    let mut i = start;
+
+    while i < end {
+        if let Some(collection) = collection_by_index(env, i) {
+            result.push_back(collection);
+        }
+        i += 1;
+    }
+
+    result
+}
+
 // Counter for total collections ever deployed through this launchpad.
 pub fn collection_count(env: &Env) -> u64 {
     env.storage()

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1044,7 +1044,7 @@ fn get_all_collections_returns_all_deployed() {
         &BytesN::from_array(&env, &[0xD2u8; 32]),
     );
 
-    let all = client.get_all_collections();
+    let all = client.get_collections(&0u32, &100u32);
     assert_eq!(all.len(), 2);
 }
 

--- a/frontend/afristore-app/next.config.js
+++ b/frontend/afristore-app/next.config.js
@@ -4,6 +4,7 @@ const { withSentryConfig } = require("@sentry/nextjs");
 const nextConfig = {
   experimental: {
     outputFileTracingRoot: require("path").resolve(__dirname, "../../"),
+    serverComponentsExternalPackages: ['@stellar/stellar-sdk', 'sodium-native'],
   },
   reactStrictMode: true,
   images: {

--- a/frontend/afristore-app/src/hooks/useLaunchpad.ts
+++ b/frontend/afristore-app/src/hooks/useLaunchpad.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import {
-  getAllCollections,
+  getCollections,
   getCollectionsByCreator,
   getCollectionMetadata,
   deployNormal721,
@@ -15,10 +15,14 @@ import {
 } from "@/lib/launchpad";
 import { assertSupportedTokenAddress } from "@/lib/token-support";
 
+const COLLECTIONS_PAGE_SIZE = 50;
+
 // ── useLaunchpadCollections ───────────────────────────────────
 
 export function useLaunchpadCollections() {
   const [collections, setCollections] = useState<CollectionRecord[]>([]);
+  const [startIndex, setStartIndex] = useState(0);
+  const [hasMore, setHasMore] = useState(true);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -26,8 +30,10 @@ export function useLaunchpadCollections() {
     setIsLoading(true);
     setError(null);
     try {
-      const all = await getAllCollections();
-      setCollections(all);
+      const page = await getCollections(0, COLLECTIONS_PAGE_SIZE);
+      setCollections(page);
+      setStartIndex(COLLECTIONS_PAGE_SIZE);
+      setHasMore(page.length >= COLLECTIONS_PAGE_SIZE);
     } catch (err: unknown) {
       setError(
         err instanceof Error ? err.message : "Failed to load collections",
@@ -37,11 +43,28 @@ export function useLaunchpadCollections() {
     }
   }, []);
 
+  const loadMore = useCallback(async () => {
+    if (!hasMore || isLoading) return;
+    setIsLoading(true);
+    try {
+      const page = await getCollections(startIndex, COLLECTIONS_PAGE_SIZE);
+      setCollections((prev) => [...prev, ...page]);
+      setStartIndex((prev) => prev + COLLECTIONS_PAGE_SIZE);
+      setHasMore(page.length >= COLLECTIONS_PAGE_SIZE);
+    } catch (err: unknown) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load more collections",
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [startIndex, hasMore, isLoading]);
+
   useEffect(() => {
     refresh();
   }, [refresh]);
 
-  return { collections, isLoading, error, refresh };
+  return { collections, isLoading, error, refresh, loadMore, hasMore };
 }
 
 // ── useCreatorCollections ─────────────────────────────────────

--- a/frontend/afristore-app/src/hooks/useLaunchpadAdmin.ts
+++ b/frontend/afristore-app/src/hooks/useLaunchpadAdmin.ts
@@ -10,7 +10,6 @@ import {
   transferLaunchpadAdmin,
   updatePlatformFee,
   getPlatformFee,
-  getAllCollections,
   getCollectionCount,
 } from "@/lib/launchpad";
 

--- a/frontend/afristore-app/src/lib/indexer.ts
+++ b/frontend/afristore-app/src/lib/indexer.ts
@@ -349,6 +349,9 @@ export async function fetchArtistListings(publicKey: string): Promise<any[]> {
       `/listings?artist=${encodeURIComponent(publicKey)}`,
     );
     if (Array.isArray(data)) return data;
+    if (typeof data === "object" && Array.isArray((data as any).listings)) {
+      return (data as any).listings;
+    }
     return [];
   } catch (e) {
     console.warn(

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -195,14 +195,21 @@ export async function getCollectionsByCreator(
 }
 
 /**
- * all_collections
+ * get_collections — paginated
  */
-export async function getAllCollections(): Promise<CollectionRecord[]> {
+export async function getCollections(
+  startIndex: number,
+  limit: number,
+): Promise<CollectionRecord[]> {
   const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const args: xdr.ScVal[] = [
+    nativeToScVal(startIndex, { type: "u32" }),
+    nativeToScVal(limit, { type: "u32" }),
+  ];
   const retVal = await invokeContract(
     DUMMY_KEY,
-    "all_collections",
-    [],
+    "get_collections",
+    args,
     true,
     config.launchpadContractId,
   );
@@ -213,8 +220,22 @@ export async function getAllCollections(): Promise<CollectionRecord[]> {
 export async function getCollectionRecordByAddress(
   collectionAddress: string,
 ): Promise<CollectionRecord | null> {
-  const all = await getAllCollections();
-  return all.find((c) => c.address === collectionAddress) ?? null;
+  const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+  const args = [toAddressScVal(collectionAddress)];
+  try {
+    const retVal = await invokeContract(
+      DUMMY_KEY,
+      "get_collection_by_id",
+      args,
+      true,
+      config.launchpadContractId,
+    );
+    const native = scValToNative(retVal);
+    if (!native) return null;
+    return parseCollectionRecord(native);
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -72,16 +72,18 @@ describe('GET /listings', () => {
 
   it('returns all listings as JSON', async () => {
     mockPrisma.listing.findMany.mockResolvedValue([sampleListing]);
+    mockPrisma.listing.count.mockResolvedValue(1);
 
     const res = await request(app).get('/listings');
 
     expect(res.status).toBe(200);
-    expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body).toHaveLength(1);
+    expect(Array.isArray(res.body.listings)).toBe(true);
+    expect(res.body.listings).toHaveLength(1);
     // BigInt was serialised to string
-    expect(res.body[0].listingId).toBe('1');
-    expect(res.body[0].artist).toBe('GABC123');
-    expect(res.body[0].status).toBe('Active');
+    expect(res.body.listings[0].listingId).toBe('1');
+    expect(res.body.listings[0].artist).toBe('GABC123');
+    expect(res.body.listings[0].status).toBe('Active');
+    expect(res.body.total).toBe(1);
   });
 
   it('filters by artist query param', async () => {
@@ -116,10 +118,11 @@ describe('GET /listings', () => {
 
   it('returns empty array when no listings match', async () => {
     mockPrisma.listing.findMany.mockResolvedValue([]);
+    mockPrisma.listing.count.mockResolvedValue(0);
 
     const res = await request(app).get('/listings');
     expect(res.status).toBe(200);
-    expect(res.body).toEqual([]);
+    expect(res.body).toEqual({ listings: [], total: 0 });
   });
 
   it('returns 500 when Prisma throws', async () => {

--- a/indexer/src/__tests__/poller.test.ts
+++ b/indexer/src/__tests__/poller.test.ts
@@ -660,17 +660,22 @@ describe('startPolling — hash fetch failure', () => {
   });
 
   it('advances lastLedger without clearing lastLedgerHash when hash fetch fails', async () => {
-    const networkLatest = 60;
+    // Use a networkLatest well above any lastLedger that background pollers from
+    // previous tests might have set, so that effectiveLatestLedger always exceeds
+    // syncState.lastLedger and the lag-skip guard never triggers.
+    const networkLatest = 500;
+    // LEDGER_LAG_BUFFER = 2: poller targets effectiveLatestLedger = networkLatest - 2
+    const effectiveLatest = networkLatest - 2;
     const priorHash = 'prev_hash';
 
-    mockPrisma.syncState.upsert.mockResolvedValueOnce({
+    mockPrisma.syncState.upsert.mockResolvedValue({
       id: 1,
       lastLedger: 50,
       lastLedgerHash: priorHash,
     });
     mockPrisma.syncState.update.mockResolvedValue({
       id: 1,
-      lastLedger: networkLatest,
+      lastLedger: effectiveLatest,
       lastLedgerHash: priorHash,
     });
 
@@ -684,13 +689,11 @@ describe('startPolling — hash fetch failure', () => {
       .mockResolvedValue({ events: [], latestLedger: networkLatest } as any);
     vi.spyOn(sdkMod.rpc.Server.prototype, 'getLedgers')
       .mockImplementation(({ startLedger }: { startLedger: number }) => {
-        if (startLedger === 50) {
-          return Promise.resolve({ ledgers: [{ hash: priorHash, sequence: 50 }] });
-        }
-        if (startLedger === networkLatest) {
+        if (startLedger === effectiveLatest) {
           return Promise.reject(new Error('network error'));
         }
-        return Promise.resolve({ ledgers: [] });
+        // default: return matching hash so hash-continuity passes
+        return Promise.resolve({ ledgers: [{ hash: priorHash, sequence: startLedger }] });
       });
 
     freshStart().catch(() => {});
@@ -698,13 +701,13 @@ describe('startPolling — hash fetch failure', () => {
     await vi.waitFor(() => {
       expect(mockPrisma.syncState.update).toHaveBeenCalledWith(
         expect.objectContaining({
-          data: { lastLedger: networkLatest },
+          data: { lastLedger: effectiveLatest },
         })
       );
     }, { timeout: 3000 });
 
     const hashAdvanceUpdate = mockPrisma.syncState.update.mock.calls.find(
-      ([arg]) => arg.data?.lastLedger === networkLatest
+      ([arg]) => arg.data?.lastLedger === effectiveLatest
     );
     expect(hashAdvanceUpdate?.[0].data).not.toHaveProperty('lastLedgerHash');
   }, 8000);

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -95,7 +95,7 @@ router.get('/listings', async (req: Request, res: Response) => {
             ];
         }
 
-        const take = Math.max(0, Math.min(Number(limit || 0), 1000)) || undefined;
+        const take = Number(limit) > 0 ? Math.min(Number(limit), 1000) : 50;
         const rawOffset = Number(offset || 0);
         const skip = Number.isFinite(rawOffset) && rawOffset > 0
             ? Math.min(rawOffset, 10_000)
@@ -108,12 +108,8 @@ router.get('/listings', async (req: Request, res: Response) => {
             skip,
         });
 
-        if (take !== undefined || skip !== undefined) {
-            const total = await prisma.listing.count({ where });
-            return res.json({ listings: serialize(results.map(mapListing)), total });
-        }
-
-        res.json(serialize(results.map(mapListing)));
+        const total = await prisma.listing.count({ where });
+        return res.json({ listings: serialize(results.map(mapListing)), total });
     } catch (err) {
         console.error('Error details:', err);
         res.status(500).json({ error: 'Failed to fetch listings' });

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -18,6 +18,10 @@ const LAUNCHPAD_CONTRACT_ID = process.env.LAUNCHPAD_CONTRACT_ID || '';
 const STAKING_CONTRACT_ID = process.env.STAKING_CONTRACT_ID || '';
 const POLL_INTERVAL = parseInt(process.env.POLL_INTERVAL_MS || '5000');
 
+// Stay this many ledgers behind the network tip to avoid requesting ledgers that
+// are not yet available on every Soroban RPC load balancer node.
+const LEDGER_LAG_BUFFER = 2;
+
 // Retry back-off base in ms; doubles on each consecutive failure up to MAX_BACKOFF_MS.
 const BASE_BACKOFF_MS = 2_000;
 const MAX_BACKOFF_MS = 60_000;
@@ -76,6 +80,21 @@ async function gracefulShutdown() {
 
 // Register handlers immediately so any external SIGTERM/SIGINT will be caught
 setupSignalHandlers();
+
+/**
+ * Returns true when the Soroban RPC signals that the requested ledger range is
+ * outside the node's available window (JSON-RPC error code -32600).  This
+ * happens under load-balancer lag and must NOT trigger a database rollback.
+ */
+function isRpcOutOfBoundsError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') return false;
+  const e = err as Record<string, unknown>;
+  return (
+    e['code'] === -32600 ||
+    (typeof e['message'] === 'string' &&
+      (e['message'] as string).includes('start ledger must be between'))
+  );
+}
 
 const server = new rpc.Server(RPC_URL);
 
@@ -191,13 +210,21 @@ export async function startPolling() {
 
       networkLatestLedgerGauge.set(networkLatestLedger);
 
-      if (syncState.lastLedger > 0 && networkLatestLedger < syncState.lastLedger) {
+      // Stay a few ledgers behind the tip so all load-balancer nodes have
+      // fully committed these ledgers before we request them.
+      const effectiveLatestLedger = Math.max(0, networkLatestLedger - LEDGER_LAG_BUFFER);
+
+      if (syncState.lastLedger > 0 && effectiveLatestLedger < syncState.lastLedger) {
+        // The RPC appears to be lagging behind our indexed state.  This is a
+        // transient load-balancer condition, NOT a chain re-org — real re-orgs
+        // are detected below via hash comparison.  Skip this poll iteration.
         console.warn({
-          msg: 'Network latest ledger moved behind indexed state',
+          msg: 'Effective latest ledger behind indexed state — possible RPC lag, skipping poll',
           indexedLedger: syncState.lastLedger,
           networkLatestLedger,
+          effectiveLatestLedger,
         });
-        await revertLedgers(networkLatestLedger);
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
         continue;
       }
 
@@ -221,7 +248,7 @@ export async function startPolling() {
 
         syncState = resetState;
       }
-      const decodedEvents = await collectMarketplaceEvents(server, contractIds, startLedger, networkLatestLedger);
+      const decodedEvents = await collectMarketplaceEvents(server, contractIds, startLedger, effectiveLatestLedger);
 
       let latestHash: string | null = null;
       if (decodedEvents.length > 0) {
@@ -251,22 +278,22 @@ export async function startPolling() {
         updateSyncMetrics(updatedState.lastLedger, networkLatestLedger);
 
         for (const ev of newEvents) emitSSEEvent(ev);
-      } else if (networkLatestLedger > syncState.lastLedger) {
+      } else if (effectiveLatestLedger > syncState.lastLedger) {
         try {
           const ledgersRes = await server.getLedgers({
-            startLedger: networkLatestLedger,
+            startLedger: effectiveLatestLedger,
             pagination: { limit: 1 },
           });
           if (ledgersRes.ledgers && ledgersRes.ledgers.length > 0) {
             latestHash = ledgersRes.ledgers[0].hash;
           }
         } catch (err) {
-          console.error(`Failed to fetch hash for latest network ledger ${networkLatestLedger}:`, err);
+          console.error(`Failed to fetch hash for latest network ledger ${effectiveLatestLedger}:`, err);
         }
 
         const updatedState = await prisma.syncState.update({
           where: { id: 1 },
-          data: buildSyncStateLedgerData(networkLatestLedger, latestHash),
+          data: buildSyncStateLedgerData(effectiveLatestLedger, latestHash),
         });
 
         updateSyncMetrics(updatedState.lastLedger, networkLatestLedger);
@@ -276,6 +303,18 @@ export async function startPolling() {
 
       consecutiveErrors = 0;
     } catch (error) {
+      // RPC out-of-bounds (-32600): the requested ledger is outside the node's
+      // available window.  This is transient load-balancer lag — skip the poll
+      // cycle without touching the database.
+      if (isRpcOutOfBoundsError(error)) {
+        console.warn({
+          msg: 'RPC out-of-bounds error (-32600) — skipping poll cycle, no DB rollback',
+          error: error instanceof Error ? error.message : String(error),
+        });
+        await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL));
+        continue;
+      }
+
       consecutiveErrors += 1;
       const backoff = Math.min(
         BASE_BACKOFF_MS * Math.pow(2, consecutiveErrors - 1),


### PR DESCRIPTION
  ## Summary

  Resolves four bugs across the indexer, Soroban contract, and frontend that could cause data loss, OOM crashes,
  gas limit failures, and noisy Webpack warnings.

  ## Changes

  ### Fix Indexer RPC Ledger Sync / Reorg Loop Bug (#375)
  - Added `LEDGER_LAG_BUFFER = 2` to stay 2 ledgers behind the network tip, avoiding requests to ledgers not yet
  committed across all RPC load balancer nodes
  - Replaced the destructive `revertLedgers()` call triggered by transient RPC lag with a soft skip-and-wait —
  - Added `isRpcOutOfBoundsError()` helper that detects JSON-RPC `-32600` responses and skips the poll cycle
  without touching the database
  
  ### Fix Prisma OOM Vulnerability on Unrestricted Limit (#376)
  - Replaced `Math.max(0, Math.min(Number(limit || 0), 1000)) || undefined` with `Number(limit) > 0 ?
  Math.min(Number(limit), 1000) : 50` — `take` is now always a positive integer, never `undefined`
  - `/listings` always returns `{ listings, total }` so callers get consistent pagination metadata
  - Updated `fetchArtistListings` in the frontend indexer client to handle the new response shape

  ### Implement Pagination to Prevent Soroban Gas Limit Crash (#377)
  - Added `collections_paginated(start, limit)` storage helper in the launchpad contract
  - Replaced unbounded `get_all_collections()` with `get_collections(start_index: u32, limit: u32)` that returns
  at most `limit` records per call
  - Updated `launchpad.ts`: replaced `getAllCollections()` with `getCollections(startIndex, limit)` and switched
  `getCollectionRecordByAddress` to the direct `get_collection_by_id` lookup (no full scan)
  - Updated `useLaunchpadCollections` hook to load the first 50 collections on mount and expose `loadMore` /
  `hasMore` for incremental loading

  ### Silence Webpack Critical Dependency Warnings for Stellar SDK (#374)
  - Added `serverComponentsExternalPackages: ['@stellar/stellar-sdk', 'sodium-native']` to the `experimental`
  block in `next.config.js`, telling Next.js 14 to treat these Node-only packages as external and suppress the
  `require` critical-dependency warnings at build time

  ## Test plan
  - [ ] Run `npm test` in `indexer/` — all 136 tests pass
  - [ ] Run `npm run dev` in `frontend/afristore-app/` and confirm no `sodium-native` critical dependency
  warnings in the terminal
  - [ ] Hit `/listings?limit=0` and confirm the response is `{ listings: [...], total: N }` with at most 50
  rows, not all rows
  - [ ] Deploy indexer to staging and confirm no `-32600` RPC loop in logs under load

  Closes #374, Closes #375, Closes #376, Closes #377