### PR TITLE
Fix multiple issues

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -405,6 +405,7 @@ impl Launchpad {
     pub fn deploy_staking_pool(
         env: Env,
         creator: Address,
+        currency: Address,
         nft_address: Address,
         reward_token: Address,
         reward_rate: i128,
@@ -412,6 +413,16 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+
+        // [FEE] Collect deployment fee
+        let (receiver, fee) = storage::get_platform_fee(&env);
+        if fee > 0 {
+            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+                &creator,
+                &receiver,
+                &(fee as i128),
+            );
+        }
 
         if storage::staking_pool_by_nft(&env, &nft_address).is_some() {
             return Err(Error::StakingPoolAlreadyExists);
@@ -442,6 +453,7 @@ impl Launchpad {
     pub fn transfer_admin(env: Env, new_admin: Address) -> Result<(), Error> {
         storage::extend_instance_ttl(&env);
         storage::require_admin(&env)?;
+        new_admin.require_auth();
         storage::set_admin(&env, &new_admin);
         Ok(())
     }

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1163,13 +1163,14 @@ fn deploys_staking_pool_for_nft_collection() {
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
 
     let pool_a =
-        client.deploy_staking_pool(&creator, &nft_address, &reward_token, &1_000_000i128, &salt);
+        client.deploy_staking_pool(&creator, &reward_token, &nft_address, &reward_token, &1_000_000i128, &salt);
 
     let pool_b = client.get_staking_pool(&nft_address);
     assert_eq!(Some(pool_a), pool_b);
 
     let duplicate = client.try_deploy_staking_pool(
         &creator,
+        &reward_token,
         &nft_address,
         &reward_token,
         &1_000_000i128,

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1162,8 +1162,14 @@ fn deploys_staking_pool_for_nft_collection() {
     let reward_token = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
 
-    let pool_a =
-        client.deploy_staking_pool(&creator, &reward_token, &nft_address, &reward_token, &1_000_000i128, &salt);
+    let pool_a = client.deploy_staking_pool(
+        &creator,
+        &reward_token,
+        &nft_address,
+        &reward_token,
+        &1_000_000i128,
+        &salt,
+    );
 
     let pool_b = client.get_staking_pool(&nft_address);
     assert_eq!(Some(pool_a), pool_b);

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -18,6 +18,7 @@ impl NftStaking {
         reward_token: Address,
         reward_rate: i128,
     ) {
+        admin.require_auth();
         if is_initialized(&env) {
             panic_with_error!(&env, StakingError::AlreadyInitialized);
         }
@@ -38,11 +39,9 @@ impl NftStaking {
     }
 
     pub fn set_admin(env: Env, admin: Address) {
-        let key = DataKey::Admin;
-        if env.storage().persistent().get::<_, Address>(&key).is_some() {
-            panic_with_error!(&env, StakingError::Unauthorized);
-        }
+        Self::require_admin(&env);
         admin.require_auth();
+        let key = DataKey::Admin;
         env.storage().persistent().set(&key, &admin);
     }
 

--- a/frontend/afristore-app/next.config.js
+++ b/frontend/afristore-app/next.config.js
@@ -25,6 +25,14 @@ const nextConfig = {
         protocol: "https",
         hostname: "images.unsplash.com",
       },
+      ...(process.env.NEXT_PUBLIC_PINATA_GATEWAY
+        ? [
+            {
+              protocol: "https",
+              hostname: new URL(process.env.NEXT_PUBLIC_PINATA_GATEWAY).hostname,
+            },
+          ]
+        : []),
     ],
   },
   webpack: (config, { isServer }) => {

--- a/frontend/afristore-app/src/app/staking/setup/page.tsx
+++ b/frontend/afristore-app/src/app/staking/setup/page.tsx
@@ -93,8 +93,9 @@ export default function StakingSetupPage() {
 
       const poolAddress = await deployStakingPool(
         publicKey,
+        token.address, // currency
         lookupAddress,
-        token.address,
+        token.address, // reward token
         rateStroops,
         salt,
       );

--- a/frontend/afristore-app/src/lib/config.ts
+++ b/frontend/afristore-app/src/lib/config.ts
@@ -27,7 +27,7 @@ export const config = {
     process.env.NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE ??
     "Test SDF Network ; September 2015",
   pinataGateway:
-    process.env.NEXT_PUBLIC_PINATA_GATEWAY ?? "https://gateway.pinata.cloud",
+    process.env.NEXT_PUBLIC_PINATA_GATEWAY ?? "",
   isDevelopment: process.env.NODE_ENV === "development",
 } as const;
 
@@ -36,6 +36,7 @@ export function assertConfig() {
   if (!config.contractId) missing.push("NEXT_PUBLIC_CONTRACT_ID");
   if (!config.launchpadContractId)
     missing.push("NEXT_PUBLIC_LAUNCHPAD_CONTRACT_ID");
+  if (!config.pinataGateway) missing.push("NEXT_PUBLIC_PINATA_GATEWAY");
   if (missing.length > 0) {
     console.warn(
       `[Afristore] Missing environment variables: ${missing.join(", ")}`,

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -265,6 +265,7 @@ export async function getStakingPoolByNft(
  */
 export async function deployStakingPool(
   creatorPublicKey: string,
+  currencyAddress: string,
   nftAddress: string,
   rewardToken: string,
   rewardRate: bigint,
@@ -272,6 +273,7 @@ export async function deployStakingPool(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
+    toAddressScVal(currencyAddress),
     toAddressScVal(nftAddress),
     toAddressScVal(rewardToken),
     nativeToScVal(rewardRate, { type: "i128" }),


### PR DESCRIPTION
## Overview
This PR addresses four outstanding issues related to critical access controls, missing platform fees, and strict environment configuration for our IPFS gateways. 

## Changes Made
- **Fixed Critical Access Control Bugs (Issue #387)**
  - Added `admin.require_auth()` to the `init()` function in the `nft-staking` contract to prevent front-running attacks.
  - Corrected the inverted logic in `set_admin` by properly verifying the current admin with `require_admin()` and ensuring authorization of the new admin via `new_admin.require_auth()`.

- **Enforced Platform Fee on `deploy_staking_pool` (Issue #386)**
  - Updated `deploy_staking_pool` in the `launchpad` contract to collect the platform deployment fee, aligning it with other deploy functions. 
  - Required tests and frontend clients have been updated to accept and utilize a `currency` parameter (defaulting to the staking reward token).

- **Fixed Missing `require_auth` on `transfer_admin` (Issue #383)**
  - Secured the `transfer_admin` function in the `launchpad` contract by invoking `new_admin.require_auth()`, preventing unauthorized takeovers.

- **Enforced Dedicated Pinata IPFS Gateway (Issue #378)**
  - Removed the fallback to the heavily rate-limited public Pinata gateway in `lib/config.ts`. The frontend now mandates the `NEXT_PUBLIC_PINATA_GATEWAY` environment variable.
  - Dynamically injected the dedicated gateway hostname into Next.js's image optimization `remotePatterns`.

## Related Issues
- Closes #378
- Closes #383
- Closes #386
- Closes #387

## Verification
- Validated updated access control paths locally.
- Confirmed that the Soroban tests compile and pass successfully (`cargo test`).
- Verified `next/image` respects the configured external image hostname.
