### PR TITLE
fix: overhaul reward accounting, fix transfer_from args, remove duplicate APIs, add currency whitelist

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -175,7 +175,7 @@ impl Launchpad {
     pub fn deploy_normal_721(
         env: Env,
         creator: Address,
-        currency: Address, // [NEW] SAC address for fee payment
+        currency: Address,
         name: String,
         symbol: String,
         max_supply: u64,
@@ -185,6 +185,7 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#54)
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -239,6 +240,7 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#54)
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -296,6 +298,7 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#54)
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -350,6 +353,7 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#54)
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -413,6 +417,7 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -465,6 +470,27 @@ impl Launchpad {
         Ok(())
     }
 
+    /// Add a token address to the approved currency whitelist.
+    pub fn add_approved_currency(env: Env, currency: Address) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
+        storage::require_admin(&env)?;
+        storage::set_approved_currency(&env, &currency, true);
+        Ok(())
+    }
+
+    /// Remove a token address from the approved currency whitelist.
+    pub fn remove_approved_currency(env: Env, currency: Address) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
+        storage::require_admin(&env)?;
+        storage::set_approved_currency(&env, &currency, false);
+        Ok(())
+    }
+
+    /// Check whether a token address is on the approved currency whitelist.
+    pub fn is_approved_currency(env: Env, currency: Address) -> bool {
+        storage::is_approved_currency(&env, &currency)
+    }
+
     // ── View functions ────────────────────────────────────────────────────
 
     /// All collections deployed by a specific creator.
@@ -491,12 +517,6 @@ impl Launchpad {
 
     // ── Query API (issue: launchpad contract query API + deploy events) ───
 
-    /// All collections deployed by a specific creator address.
-    /// Callable from frontend and CLI.
-    pub fn get_creator_collections(env: Env, creator: Address) -> Vec<CollectionRecord> {
-        storage::collections_by_creator(&env, &creator)
-    }
-
     /// Look up a single collection record by its deployed contract address.
     /// Returns `None` if the address was not deployed through this launchpad.
     /// Callable from frontend and CLI.
@@ -509,12 +529,6 @@ impl Launchpad {
     /// Callable from frontend and CLI.
     pub fn get_collections(env: Env, start_index: u32, limit: u32) -> Vec<CollectionRecord> {
         storage::collections_paginated(&env, start_index as u64, limit as u64)
-    }
-
-    /// Total number of collections deployed through this launchpad.
-    /// Callable from frontend and CLI.
-    pub fn get_collection_count(env: Env) -> u64 {
-        storage::collection_count(&env)
     }
 
     /// Look up the staking pool clone deployed for an NFT collection address.

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -267,3 +267,23 @@ pub fn creator_collection_by_index(
         .persistent()
         .get(&DataKey::CreatorCollectionByIndex(creator.clone(), index))
 }
+
+pub fn set_approved_currency(env: &Env, currency: &Address, approved: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ApprovedCurrency(currency.clone()), &approved);
+}
+
+pub fn is_approved_currency(env: &Env, currency: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get::<DataKey, bool>(&DataKey::ApprovedCurrency(currency.clone()))
+        .unwrap_or(false)
+}
+
+pub fn require_approved_currency(env: &Env, currency: &Address) -> Result<(), crate::types::Error> {
+    if !is_approved_currency(env, currency) {
+        return Err(crate::types::Error::InvalidCurrency);
+    }
+    Ok(())
+}

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -91,6 +91,26 @@ pub fn get_staking_wasm_hash(env: &Env) -> Option<BytesN<32>> {
     env.storage().instance().get(&DataKey::WasmStaking)
 }
 
+pub fn set_approved_currency(env: &Env, currency: &Address, approved: bool) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ApprovedCurrency(currency.clone()), &approved);
+}
+
+pub fn is_approved_currency(env: &Env, currency: &Address) -> bool {
+    env.storage()
+        .instance()
+        .get::<_, bool>(&DataKey::ApprovedCurrency(currency.clone()))
+        .unwrap_or(false)
+}
+
+pub fn require_approved_currency(env: &Env, currency: &Address) -> Result<(), Error> {
+    if !is_approved_currency(env, currency) {
+        return Err(Error::InvalidCurrency);
+    }
+    Ok(())
+}
+
 pub fn staking_pool_by_nft(env: &Env, nft_address: &Address) -> Option<Address> {
     env.storage()
         .persistent()

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1006,6 +1006,7 @@ fn get_creator_collections_returns_only_caller_collections() {
     let other = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     client.deploy_normal_721(
         &creator,
@@ -1045,6 +1046,7 @@ fn get_all_collections_returns_all_deployed() {
     let alice = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     client.deploy_normal_721(
         &creator,
@@ -1080,6 +1082,7 @@ fn get_collection_count_increments_per_deploy() {
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
     let creator_pubkey = BytesN::from_array(&env, &[0x05u8; 32]);
+    approve_currency(&client, &currency);
 
     assert_eq!(client.collection_count(), 0u64);
 
@@ -1116,6 +1119,7 @@ fn deploy_events_include_kind_in_payload() {
 
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     // Deploy one of each type and confirm no panic (events are emitted).
     // The soroban test SDK exposes env.events().all() to inspect events.
@@ -1183,6 +1187,7 @@ fn deploys_staking_pool_for_nft_collection() {
     let nft_address = Address::generate(&env);
     let reward_token = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
+    approve_currency(&client, &reward_token);
 
     let pool_a = client.deploy_staking_pool(
         &creator,

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -74,6 +74,10 @@ fn setup_launchpad(env: &Env) -> (LaunchpadClient<'_>, Address, Address, Address
     (client, admin, fee_receiver, creator)
 }
 
+fn approve_currency(client: &LaunchpadClient, currency: &Address) {
+    client.add_approved_currency(currency);
+}
+
 #[test]
 fn deploys_normal_721_twice_with_unique_addresses() {
     let env = Env::default();
@@ -84,6 +88,7 @@ fn deploys_normal_721_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[11u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_normal_721(
         &creator,
@@ -132,6 +137,7 @@ fn deploys_normal_1155_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[21u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_normal_1155(
         &creator,
@@ -177,6 +183,7 @@ fn deploys_lazy_721_twice_with_unique_addresses() {
     let creator_pubkey = BytesN::from_array(&env, &[7u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_lazy_721(
         &creator,
@@ -228,6 +235,7 @@ fn deploys_lazy_1155_twice_with_unique_addresses() {
     let creator_pubkey = BytesN::from_array(&env, &[9u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_lazy_1155(
         &creator,
@@ -272,6 +280,7 @@ fn deploy_calls_extend_instance_ttl() {
 
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     // After initialize(), instance TTL is bumped to 100_000 ledgers.
     // Move forward so remaining TTL is below threshold (50_000),
@@ -345,6 +354,7 @@ fn same_salt_different_creators_normal_721_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_normal_721(
         &alice,
@@ -387,6 +397,7 @@ fn same_salt_different_creators_normal_1155_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xBBu8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_normal_1155(
         &alice,
@@ -422,6 +433,7 @@ fn same_salt_different_creators_lazy_721_yields_different_addresses() {
     let creator_pubkey = BytesN::from_array(&env, &[0x01u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_lazy_721(
         &alice,
@@ -463,6 +475,7 @@ fn same_salt_different_creators_lazy_1155_yields_different_addresses() {
     let creator_pubkey = BytesN::from_array(&env, &[0x02u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_lazy_1155(
         &alice,
@@ -505,6 +518,7 @@ fn front_runner_cannot_grief_normal_721() {
     let salt = BytesN::from_array(&env, &[0x11u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     // Bob front-runs using Alice's raw salt.
     let addr_bob = client.deploy_normal_721(
@@ -548,6 +562,7 @@ fn front_runner_cannot_grief_normal_1155() {
     let salt = BytesN::from_array(&env, &[0x22u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_normal_1155(
         &bob,
@@ -583,6 +598,7 @@ fn front_runner_cannot_grief_lazy_721() {
     let creator_pubkey = BytesN::from_array(&env, &[0x03u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_lazy_721(
         &bob,
@@ -624,6 +640,7 @@ fn front_runner_cannot_grief_lazy_1155() {
     let creator_pubkey = BytesN::from_array(&env, &[0x04u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_lazy_1155(
         &bob,
@@ -682,6 +699,7 @@ fn deploy_without_wasm_hashes_fails() {
 
     let salt = BytesN::from_array(&env, &[0x99u8; 32]);
     let currency = Address::generate(&env);
+    client.add_approved_currency(&currency);
     let royalty_receiver = Address::generate(&env);
 
     let result = client.try_deploy_normal_721(
@@ -768,6 +786,7 @@ fn collections_by_creator_returns_correct_collections() {
     let other = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0x55u8; 32]);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
     let royalty_receiver = Address::generate(&env);
 
     client.deploy_normal_721(
@@ -850,6 +869,7 @@ fn deployed_lazy_721_rejects_invalid_ed25519_signature() {
     let creator_pubkey = BytesN::from_array(&env, &[1u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
     let salt = BytesN::from_array(&env, &[0xA1u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
@@ -892,6 +912,7 @@ fn deployed_lazy_721_rejects_expired_voucher() {
     let creator_pubkey = BytesN::from_array(&env, &[2u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
     let salt = BytesN::from_array(&env, &[0xA2u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
@@ -942,6 +963,7 @@ fn get_collection_by_id_returns_record() {
     let salt = BytesN::from_array(&env, &[0xB1u8; 32]);
     let royalty_receiver = Address::generate(&env);
     let currency = Address::generate(&env);
+    approve_currency(&client, &currency);
 
     let addr = client.deploy_normal_721(
         &creator,
@@ -974,7 +996,7 @@ fn get_collection_by_id_returns_none_for_unknown_address() {
     assert!(record.is_none());
 }
 
-/// get_creator_collections returns only the caller's collections.
+/// collections_by_creator returns only the caller's collections.
 #[test]
 fn get_creator_collections_returns_only_caller_collections() {
     let env = Env::default();
@@ -1006,10 +1028,10 @@ fn get_creator_collections_returns_only_caller_collections() {
     );
 
     // creator has 2 collections, other has 0
-    let creator_colls = client.get_creator_collections(&creator);
+    let creator_colls = client.collections_by_creator(&creator);
     assert_eq!(creator_colls.len(), 2);
 
-    let other_colls = client.get_creator_collections(&other);
+    let other_colls = client.collections_by_creator(&other);
     assert_eq!(other_colls.len(), 0);
 }
 
@@ -1048,7 +1070,7 @@ fn get_all_collections_returns_all_deployed() {
     assert_eq!(all.len(), 2);
 }
 
-/// get_collection_count matches the number of deploys.
+/// collection_count matches the number of deploys.
 #[test]
 fn get_collection_count_increments_per_deploy() {
     let env = Env::default();
@@ -1059,7 +1081,7 @@ fn get_collection_count_increments_per_deploy() {
     let currency = Address::generate(&env);
     let creator_pubkey = BytesN::from_array(&env, &[0x05u8; 32]);
 
-    assert_eq!(client.get_collection_count(), 0u64);
+    assert_eq!(client.collection_count(), 0u64);
 
     client.deploy_normal_721(
         &creator,
@@ -1071,7 +1093,7 @@ fn get_collection_count_increments_per_deploy() {
         &royalty_receiver,
         &BytesN::from_array(&env, &[0xE1u8; 32]),
     );
-    assert_eq!(client.get_collection_count(), 1u64);
+    assert_eq!(client.collection_count(), 1u64);
 
     client.deploy_lazy_1155(
         &creator,
@@ -1082,7 +1104,7 @@ fn get_collection_count_increments_per_deploy() {
         &royalty_receiver,
         &BytesN::from_array(&env, &[0xE2u8; 32]),
     );
-    assert_eq!(client.get_collection_count(), 2u64);
+    assert_eq!(client.collection_count(), 2u64);
 }
 
 /// Deploy events carry (creator, collection_address, kind) in the data payload.
@@ -1127,7 +1149,7 @@ fn deploy_events_include_kind_in_payload() {
     assert_eq!(rec_n1155.creator, creator);
 
     // Confirm total count covers both
-    assert_eq!(client.get_collection_count(), 2u64);
+    assert_eq!(client.collection_count(), 2u64);
 }
 
 fn setup_launchpad_with_staking(env: &Env) -> (LaunchpadClient<'_>, Address, Address) {

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -9,6 +9,7 @@ pub enum Error {
     NotAdmin = 3,
     WasmHashNotSet = 4,
     StakingPoolAlreadyExists = 5,
+    InvalidCurrency = 6,
 }
 
 /// Which of the four collection types was deployed.
@@ -56,4 +57,6 @@ pub enum DataKey {
     WasmStaking,
     /// Maps an NFT collection address to its staking pool clone
     StakingPoolByNft(Address),
+    /// Tracks which token addresses are approved as payment currencies
+    ApprovedCurrency(Address),
 }

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -59,4 +59,6 @@ pub enum DataKey {
     StakingPoolByNft(Address),
     /// WASM hash for RoyaltySplitter clone deployments
     WasmRoyaltySplitter,
+    /// Tracks which token addresses are approved as payment currencies
+    ApprovedCurrency(Address),
 }

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -129,7 +129,7 @@ impl NftStaking {
                 &env,
                 user.clone().into_val(&env),
                 env.current_contract_address().into_val(&env),
-                (token_id as u64).into_val(&env),
+                token_id.into_val(&env),
             ],
         );
 
@@ -184,7 +184,7 @@ impl NftStaking {
                 &env,
                 user.clone().into_val(&env),
                 env.current_contract_address().into_val(&env),
-                (token_id as u64).into_val(&env),
+                token_id.into_val(&env),
                 (amount as i128).into_val(&env),
                 soroban_sdk::Bytes::new(&env).into_val(&env),
             ],
@@ -259,7 +259,7 @@ impl NftStaking {
                 &env,
                 env.current_contract_address().into_val(&env),
                 user.clone().into_val(&env),
-                (token_id as u64).into_val(&env),
+                token_id.into_val(&env),
             ],
         );
 
@@ -310,7 +310,7 @@ impl NftStaking {
                 &env,
                 env.current_contract_address().into_val(&env),
                 user.clone().into_val(&env),
-                (token_id as u64).into_val(&env),
+                token_id.into_val(&env),
                 (amount as i128).into_val(&env),
                 soroban_sdk::Bytes::new(&env).into_val(&env),
             ],

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -4,6 +4,8 @@ use crate::events::*;
 use crate::storage::*;
 use crate::types::*;
 
+const MAX_REWARD_RATE: i128 = 1_000_000_000_000_000;
+
 #[contract]
 pub struct NftStaking;
 
@@ -24,6 +26,9 @@ impl NftStaking {
         }
         if reward_rate <= 0 {
             panic_with_error!(&env, StakingError::InvalidDuration);
+        }
+        if reward_rate > MAX_REWARD_RATE {
+            panic_with_error!(&env, StakingError::RewardRateTooHigh);
         }
 
         set_initialized(&env);
@@ -112,12 +117,12 @@ impl NftStaking {
             panic_with_error!(&env, StakingError::AlreadyStaked);
         }
 
+        // User is the current owner; transfer directly without requiring a prior approve().
         env.invoke_contract::<()>(
             &token_address,
-            &soroban_sdk::Symbol::new(&env, "transfer_from"),
+            &soroban_sdk::Symbol::new(&env, "transfer"),
             soroban_sdk::vec![
                 &env,
-                env.current_contract_address().into_val(&env),
                 user.clone().into_val(&env),
                 env.current_contract_address().into_val(&env),
                 (token_id as u64).into_val(&env),
@@ -157,24 +162,37 @@ impl NftStaking {
         Self::require_pool_nft(&env, &token_address);
 
         let position_key = DataKey::StakedPosition(user.clone(), token_address.clone(), token_id);
-        let mut position = load_staked_position(&env, &position_key)
+        let position = load_staked_position(&env, &position_key)
             .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotStaked));
 
         if position.owner != user {
             panic_with_error!(&env, StakingError::Unauthorized);
         }
 
+        // Accrue any rewards still owed since the last checkpoint, then pay out
+        // before the position record is wiped.
         let rate = Self::rewards_per_second(&env);
         let elapsed = env.ledger().timestamp() - position.staked_at;
-        let rewards = (elapsed as i128) * rate;
-        position.rewards_earned += rewards;
+        let pending = position.rewards_earned + (elapsed as i128) * rate;
 
+        if pending > 0 {
+            let reward_token_addr = get_reward_token(&env)
+                .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized));
+            let token_client =
+                soroban_sdk::token::TokenClient::new(&env, &reward_token_addr);
+            let balance = token_client.balance(&env.current_contract_address());
+            if balance < pending {
+                panic_with_error!(&env, StakingError::InsufficientRewardBalance);
+            }
+            token_client.transfer(&env.current_contract_address(), &user, &pending);
+        }
+
+        // Contract is the current owner; return the NFT directly.
         env.invoke_contract::<()>(
             &token_address,
-            &soroban_sdk::Symbol::new(&env, "transfer_from"),
+            &soroban_sdk::Symbol::new(&env, "transfer"),
             soroban_sdk::vec![
                 &env,
-                env.current_contract_address().into_val(&env),
                 env.current_contract_address().into_val(&env),
                 user.clone().into_val(&env),
                 (token_id as u64).into_val(&env),
@@ -189,7 +207,7 @@ impl NftStaking {
             user,
             token_address,
             token_id,
-            rewards_paid: position.rewards_earned,
+            rewards_paid: pending,
             timestamp: env.ledger().timestamp(),
         }
         .publish(&env);
@@ -208,10 +226,12 @@ impl NftStaking {
         for key in stake_keys.iter() {
             if let Some(mut position) = load_staked_position(&env, &key) {
                 let elapsed = env.ledger().timestamp() - position.staked_at;
-                let rewards = (elapsed as i128) * rate;
-                position.rewards_earned += rewards;
+                // Collect all pending rewards: previously accrued + newly elapsed.
+                let claimable = position.rewards_earned + (elapsed as i128) * rate;
+                total_rewards += claimable;
+                // Reset so the same rewards are never counted twice.
+                position.rewards_earned = 0;
                 position.staked_at = env.ledger().timestamp();
-                total_rewards += rewards;
                 save_staked_position(&env, &key, &position);
             }
         }
@@ -219,6 +239,15 @@ impl NftStaking {
         if total_rewards <= 0 {
             panic_with_error!(&env, StakingError::NoRewardsToClaim);
         }
+
+        let reward_token_addr = get_reward_token(&env)
+            .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized));
+        let token_client = soroban_sdk::token::TokenClient::new(&env, &reward_token_addr);
+        let balance = token_client.balance(&env.current_contract_address());
+        if balance < total_rewards {
+            panic_with_error!(&env, StakingError::InsufficientRewardBalance);
+        }
+        token_client.transfer(&env.current_contract_address(), &user, &total_rewards);
 
         RewardsClaimedEvent {
             user,
@@ -262,6 +291,7 @@ impl NftStaking {
         for key in stake_keys.iter() {
             if let Some(position) = load_staked_position(&env, &key) {
                 let elapsed = env.ledger().timestamp() - position.staked_at;
+                // rewards_earned holds only the pending (not-yet-claimed) portion.
                 total += (elapsed as i128) * rate + position.rewards_earned;
             }
         }

--- a/contracts/nft-staking/src/contract.rs
+++ b/contracts/nft-staking/src/contract.rs
@@ -178,8 +178,7 @@ impl NftStaking {
         if pending > 0 {
             let reward_token_addr = get_reward_token(&env)
                 .unwrap_or_else(|| panic_with_error!(&env, StakingError::NotInitialized));
-            let token_client =
-                soroban_sdk::token::TokenClient::new(&env, &reward_token_addr);
+            let token_client = soroban_sdk::token::TokenClient::new(&env, &reward_token_addr);
             let balance = token_client.balance(&env.current_contract_address());
             if balance < pending {
                 panic_with_error!(&env, StakingError::InsufficientRewardBalance);

--- a/contracts/nft-staking/src/test.rs
+++ b/contracts/nft-staking/src/test.rs
@@ -6,6 +6,7 @@ mod mock_nft {
     pub struct MockNft;
     #[contractimpl]
     impl MockNft {
+        pub fn transfer(_env: Env, _from: Address, _to: Address, _token_id: u64) {}
         pub fn transfer_from(
             _env: Env,
             _spender: Address,

--- a/contracts/nft-staking/src/types.rs
+++ b/contracts/nft-staking/src/types.rs
@@ -14,6 +14,8 @@ pub enum StakingError {
     AlreadyInitialized = 8,
     NotInitialized = 9,
     InvalidToken = 10,
+    InsufficientRewardBalance = 11,
+    RewardRateTooHigh = 12,
 }
 
 #[contracttype]


### PR DESCRIPTION
Closes #388
Closes #389
Closes #385
Closes #384

## Summary

### #388 — Fix Fatal transfer_from Arguments (`contracts/nft-staking/src/contract.rs`)

- **stake**: replaced `transfer_from(spender=contract, from=user, to=contract)` with `transfer(from=user, to=contract)`. The NFT owner authorises the deposit through their own `stake()` call; no prior `approve()` is needed.
- **unstake**: replaced `transfer_from(spender=contract, from=contract, to=contract)` with `transfer(from=contract, to=user)`. The vault, as current token owner, returns the NFT directly via `transfer` which is auto-authorised in a cross-contract call.

### #389 — Overhaul Reward Accounting & Payouts (`contracts/nft-staking/src/contract.rs`)

- **Overflow risk**: `init` rejects `reward_rate > MAX_REWARD_RATE` (1 × 10¹⁵) with `RewardRateTooHigh`.
- **Double-counting**: `claim_rewards` now computes `claimable = position.rewards_earned + elapsed * rate`, adds it to `total_rewards`, then resets `position.rewards_earned = 0` and `position.staked_at = now` so already-paid rewards are never counted again.
- **No payout**: `claim_rewards` now executes `TokenClient::transfer` to actually send tokens to the user.
- **Balance check**: both `claim_rewards` and `unstake` verify the contract holds enough reward tokens before transferring, panicking with `InsufficientRewardBalance` if underfunded.
- **Lost rewards on unstake**: `unstake` accrues and pays out all pending rewards via `TokenClient::transfer` **before** removing the position record.

### #385 — Remove Duplicate Public APIs (`contracts/launchpad/src/contract.rs`)

- Removed `get_creator_collections` (duplicate of `collections_by_creator`).
- Removed `get_collection_count` (duplicate of `collection_count`).
- Updated all affected tests to use the canonical names.

### #384 — Enforce Whitelist Check on Currency (`contracts/launchpad/src/contract.rs`)

- Added `InvalidCurrency = 6` to the `Error` enum and `ApprovedCurrency(Address)` to `DataKey`.
- Added storage helpers: `set_approved_currency`, `is_approved_currency`, `require_approved_currency`.
- Added admin functions: `add_approved_currency`, `remove_approved_currency`, `is_approved_currency`.
- All five `deploy_*` functions now call `require_approved_currency` after `creator.require_auth()`.
- Updated all deploy tests to pre-approve the currency via `add_approved_currency`.

## Test plan

- [ ] `cargo test -p nft-staking` passes with corrected transfer and reward logic
- [ ] `cargo test -p launchpad` passes with canonical API names and pre-approved currencies
- [ ] `claim_rewards` returns the correct non-inflated amount after multiple partial claims
- [ ] `unstake` pays pending rewards before removing the position
- [ ] Deploying with an unapproved currency returns `InvalidCurrency`