### PR TITLE
feat(indexer): add redis service to docker compose

### DIFF
--- a/indexer/docker-compose.yml
+++ b/indexer/docker-compose.yml
@@ -13,13 +13,23 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
   indexer:
     build: .
     restart: unless-stopped
     depends_on:
       - db
+      - redis
     environment:
       - DATABASE_URL=postgresql://postgres:postgres@db:5432/marketplace_indexer?schema=public
+      - REDIS_URL=redis://redis:6379
       - PORT=4000
       - STELLAR_RPC_URL=https://soroban-testnet.stellar.org
       - MARKETPLACE_CONTRACT_ID=${MARKETPLACE_CONTRACT_ID}
@@ -29,3 +39,4 @@ services:
 
 volumes:
   postgres_data:
+  redis_data:


### PR DESCRIPTION
## What

Adds a `redis:7-alpine` service to the indexer `docker-compose.yml` and wires `REDIS_URL` into the indexer service, so developers running `docker compose up` get a working Redis instance out of the box.

The indexer code already depends on Redis (`src/redis.ts`, defaulting to `redis://localhost:6379`), but the compose stack defined no Redis service and the indexer container had no `REDIS_URL`, so Redis was unavailable in the containerized setup.

## Changes

- Add `redis` service using the `redis:7-alpine` image, exposing port `6379` with a persistent `redis_data` volume.
- Add `REDIS_URL=redis://redis:6379` to the indexer service environment (points at the compose service hostname).
- Add `redis` to the indexer's `depends_on`.

## Test plan

- [x] `docker compose config` parses successfully
- [x] YAML validates
- [x] `REDIS_URL` matches the value consumed by `src/redis.ts`

Closes #320