### PR TITLE
feat: add deploy_splitter to Launchpad using clone factory pattern

### DIFF
--- a/contracts/launchpad/Cargo.toml
+++ b/contracts/launchpad/Cargo.toml
@@ -17,3 +17,4 @@ soroban-sdk = { version = "25.3.0" }
 
 [dev-dependencies]
 soroban-sdk = { version = "25.3.0", features = ["testutils"] }
+royalty-splitter = { path = "../royalty-splitter", features = ["testutils"] }

--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -34,7 +34,7 @@ use crate::{
 // can call `initialize` on freshly deployed contracts in the same transaction.
 
 mod iface {
-    use soroban_sdk::{contractclient, Address, BytesN, Env, String};
+    use soroban_sdk::{contractclient, Address, BytesN, Env, String, Vec};
 
     #[contractclient(name = "Normal721Client")]
     pub trait INormal721 {
@@ -86,9 +86,14 @@ mod iface {
             royalty_receiver: Address,
         );
     }
+
+    #[contractclient(name = "SplitterClient")]
+    pub trait ISplitter {
+        fn initialize(env: Env, token: Address, beneficiaries: Vec<Address>, shares: Vec<u32>);
+    }
 }
 
-use iface::{Lazy1155Client, Lazy721Client, Normal1155Client, Normal721Client};
+use iface::{Lazy1155Client, Lazy721Client, Normal1155Client, Normal721Client, SplitterClient};
 
 // ─── Salt hardening (fix #53) ─────────────────────────────────────────────────
 /// Bind `raw_salt` to the caller so that two different creators can never
@@ -152,6 +157,15 @@ impl Launchpad {
             &wasm_lazy_721,
             &wasm_lazy_1155,
         );
+        Ok(())
+    }
+
+    /// Register the royalty-splitter WASM hash so `deploy_splitter` can clone it.
+    /// Must be called by admin after uploading the splitter WASM to the network.
+    pub fn set_splitter_wasm_hash(env: Env, wasm: BytesN<32>) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
+        storage::require_admin(&env)?;
+        storage::set_splitter_wasm_hash(&env, &wasm);
         Ok(())
     }
 
@@ -375,6 +389,42 @@ impl Launchpad {
             &addr,
             &CollectionKind::LazyMint1155,
         );
+        Ok(addr)
+    }
+
+    // ── Deploy: Royalty Splitter ──────────────────────────────────────────
+
+    /// Deploy a royalty-splitter clone that splits the given `token` among
+    /// the `beneficiaries` according to `shares` (BPS, must sum to 10 000).
+    ///
+    /// Uses the clone factory pattern (`deployer().with_current_contract(salt)`)
+    /// so the deploy cost is minimal — the splitter WASM is stored once and
+    /// every `deploy_splitter` call creates a lightweight clone sharing it.
+    ///
+    /// The freshly deployed clone is initialized in the same transaction so
+    /// no second call is required.
+    pub fn deploy_splitter(
+        env: Env,
+        creator: Address,
+        token: Address,
+        beneficiaries: Vec<Address>,
+        shares: Vec<u32>,
+        salt: BytesN<32>,
+    ) -> Result<Address, Error> {
+        storage::extend_instance_ttl(&env);
+        creator.require_auth();
+
+        let wasm = storage::get_splitter_wasm_hash(&env).ok_or(Error::WasmHashNotSet)?;
+
+        // Use a creator-bound salt to prevent front-running (fix #53).
+        let secure_salt = make_secure_salt(&env, &creator, &salt);
+        let addr = env
+            .deployer()
+            .with_current_contract(secure_salt)
+            .deploy_v2(wasm, ());
+
+        SplitterClient::new(&env, &addr).initialize(&token, &beneficiaries, &shares);
+
         Ok(addr)
     }
 

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -83,6 +83,16 @@ pub fn get_wasm_lazy_1155(env: &Env) -> Option<BytesN<32>> {
     env.storage().instance().get(&DataKey::WasmLazy1155)
 }
 
+pub fn set_splitter_wasm_hash(env: &Env, wasm: &BytesN<32>) {
+    env.storage()
+        .instance()
+        .set(&DataKey::WasmSplitter, wasm);
+}
+
+pub fn get_splitter_wasm_hash(env: &Env) -> Option<BytesN<32>> {
+    env.storage().instance().get(&DataKey::WasmSplitter)
+}
+
 pub fn collections_by_creator(env: &Env, creator: &Address) -> Vec<CollectionRecord> {
     let count = creator_collection_count(env, creator);
     let mut result = Vec::new(env);

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1,6 +1,6 @@
 extern crate std;
 
-use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String};
+use soroban_sdk::{testutils::Address as _, testutils::Ledger as _, Address, BytesN, Env, String, Vec};
 
 use crate::{CollectionKind, Error, Launchpad, LaunchpadClient};
 
@@ -70,6 +70,12 @@ fn setup_launchpad(env: &Env) -> (LaunchpadClient<'_>, Address, Address, Address
         &wasm_lazy_721,
         &wasm_lazy_1155,
     );
+
+    let wasm_splitter_bytes = wasm_bytes("royalty_splitter");
+    let wasm_splitter = env
+        .deployer()
+        .upload_contract_wasm(wasm_splitter_bytes.as_slice());
+    client.set_splitter_wasm_hash(&wasm_splitter);
 
     (client, admin, fee_receiver, creator)
 }
@@ -1083,6 +1089,128 @@ fn get_collection_count_increments_per_deploy() {
         &BytesN::from_array(&env, &[0xE2u8; 32]),
     );
     assert_eq!(client.get_collection_count(), 2u64);
+}
+
+// ── Royalty Splitter deployment tests ─────────────────────────────────────
+
+#[test]
+fn deploy_splitter_twice_with_unique_addresses() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt_a = BytesN::from_array(&env, &[0xA1u8; 32]);
+    let salt_b = BytesN::from_array(&env, &[0xA2u8; 32]);
+    let token = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let addr_a = client.deploy_splitter(
+        &creator,
+        &token,
+        &Vec::from_array(&env, [alice.clone(), bob.clone()]),
+        &Vec::from_array(&env, [6_000u32, 4_000u32]),
+        &salt_a,
+    );
+
+    let addr_b = client.deploy_splitter(
+        &creator,
+        &token,
+        &Vec::from_array(&env, [alice, bob]),
+        &Vec::from_array(&env, [6_000u32, 4_000u32]),
+        &salt_b,
+    );
+
+    assert_ne!(addr_a, addr_b);
+}
+
+#[test]
+fn deploy_splitter_initializes_correctly() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0xB1u8; 32]);
+    let token = Address::generate(&env);
+    let alice = Address::generate(&env);
+    let bob = Address::generate(&env);
+
+    let addr = client.deploy_splitter(
+        &creator,
+        &token,
+        &Vec::from_array(&env, [alice.clone(), bob.clone()]),
+        &Vec::from_array(&env, [6_000u32, 4_000u32]),
+        &salt,
+    );
+
+    let splitter = royalty_splitter::RoyaltySplitterClient::new(&env, &addr);
+    let stored_token = splitter.get_token();
+    assert_eq!(stored_token, token);
+
+    let stored_beneficiaries = splitter.get_beneficiaries();
+    assert_eq!(stored_beneficiaries.len(), 2);
+    assert_eq!(stored_beneficiaries.get(0).unwrap(), alice);
+    assert_eq!(stored_beneficiaries.get(1).unwrap(), bob);
+
+    let stored_shares = splitter.get_shares();
+    assert_eq!(stored_shares.len(), 2);
+    assert_eq!(stored_shares.get(0).unwrap(), 6_000);
+    assert_eq!(stored_shares.get(1).unwrap(), 4_000);
+}
+
+#[test]
+fn deploy_splitter_without_wasm_hash_fails() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    env.mock_all_auths();
+
+    let launchpad_id = env.register(Launchpad, ());
+    let client = LaunchpadClient::new(&env, &launchpad_id);
+
+    let admin = Address::generate(&env);
+    let fee_receiver = Address::generate(&env);
+    client.initialize(&admin, &fee_receiver, &0u32);
+
+    let salt = BytesN::from_array(&env, &[0x99u8; 32]);
+    let token = Address::generate(&env);
+
+    let result = client.try_deploy_splitter(
+        &Address::generate(&env),
+        &token,
+        &Vec::from_array(&env, [Address::generate(&env)]),
+        &Vec::from_array(&env, [10_000u32]),
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::WasmHashNotSet)));
+}
+
+#[test]
+fn same_salt_different_creators_splitter_yields_different_addresses() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, alice) = setup_launchpad(&env);
+    let bob = Address::generate(&env);
+
+    let salt = BytesN::from_array(&env, &[0xCCu8; 32]);
+    let token = Address::generate(&env);
+
+    let addr_alice = client.deploy_splitter(
+        &alice,
+        &token,
+        &Vec::from_array(&env, [alice.clone()]),
+        &Vec::from_array(&env, [10_000u32]),
+        &salt,
+    );
+
+    let addr_bob = client.deploy_splitter(
+        &bob,
+        &token,
+        &Vec::from_array(&env, [bob]),
+        &Vec::from_array(&env, [10_000u32]),
+        &salt,
+    );
+
+    assert_ne!(addr_alice, addr_bob);
 }
 
 /// Deploy events carry (creator, collection_address, kind) in the data payload.

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -40,6 +40,7 @@ pub enum DataKey {
     WasmNormal1155,
     WasmLazy721,
     WasmLazy1155,
+    WasmSplitter,
     CollectionCount,
     ByCreator(Address), // Address → Vec<CollectionRecord> (legacy, will be removed)
     AllCollections,     // Vec<CollectionRecord> (legacy, will be removed)


### PR DESCRIPTION
Instead of deploying a brand new Royalty Splitter WASM every time an artist wants a splitter, this update saves massive gas by using the Stellar clone factory pattern.

### Changes
- **`types.rs`** — Added `WasmSplitter` variant to `DataKey`
- **`storage.rs`** — Added `set_splitter_wasm_hash` / `get_splitter_wasm_hash`
- **`contract.rs`** — Added `ISplitter` cross-contract interface, `set_splitter_wasm_hash` admin function, and `deploy_splitter` that deploys a lightweight clone via `deployer().with_current_contract(salt).deploy_v2()` and initializes it in the same transaction
- **`Cargo.toml`** — Added `royalty-splitter` dev-dependency for tests
- **`test.rs`** — 4 new tests covering unique addresses, correct initialization, missing WASM hash error, and salt front-running prevention

Closes #345