### PR TITLE
Fix Staking Storage Archival Bug

### DIFF
--- a/contracts/nft-staking/src/storage.rs
+++ b/contracts/nft-staking/src/storage.rs
@@ -65,9 +65,11 @@ pub fn get_user_stakes(env: &Env, user: &Address) -> Vec<DataKey> {
         .get::<_, Vec<DataKey>>(&key)
         .unwrap_or_else(|| Vec::new(env));
 
-    env.storage()
-        .persistent()
-        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    if env.storage().persistent().has(&key) {
+        env.storage()
+            .persistent()
+            .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+    }
 
     stakes
 }

--- a/contracts/nft-staking/src/storage.rs
+++ b/contracts/nft-staking/src/storage.rs
@@ -59,10 +59,17 @@ pub fn add_user_stake(env: &Env, user: &Address, position_key: DataKey) {
 
 pub fn get_user_stakes(env: &Env, user: &Address) -> Vec<DataKey> {
     let key = DataKey::UserStakes(user.clone());
-    env.storage()
+    let stakes = env
+        .storage()
         .persistent()
         .get::<_, Vec<DataKey>>(&key)
-        .unwrap_or_else(|| Vec::new(env))
+        .unwrap_or_else(|| Vec::new(env));
+
+    env.storage()
+        .persistent()
+        .extend_ttl(&key, LEDGER_TTL_THRESHOLD, LEDGER_TTL_BUMP);
+
+    stakes
 }
 
 pub fn remove_user_stake(env: &Env, user: &Address, position_key: &DataKey) {


### PR DESCRIPTION
## fix(staking): Extend TTL on read to prevent data archival
closes #399 
### Description

This pull request addresses a critical data persistence issue in the `nft-staking` contract related to Soroban's state archival rules.

On Soroban, any piece of storage that is not accessed (i.e., written to or has its Time-to-Live extended) within a specific timeframe will be archived and removed from the ledger.

The `get_user_stakes` function, which is a read-only operation used to display a user's staked NFTs, was not extending the TTL of the user's stake list (`DataKey::UserStakes`). This created a scenario where a user who frequently views their dashboard but does not perform any new stake/unstake operations could have their stake list archived. When archived, the function would return an empty vector, causing the UI to incorrectly display that the user has 0 staked NFTs.

### The Fix

This PR modifies the `get_user_stakes` function to call `env.storage().persistent().extend_ttl(...)` every time it is read.

This change ensures that read-only activity, such as a user checking their dashboard, is sufficient to keep their on-chain data alive, preventing unexpected data loss and providing a more reliable user experience. This aligns with the best practices for Soroban development outlined in `contracts/CONTRIBUTING.md`.

### How to Verify

1.  Review the `get_user_stakes` function in `contracts/nft-staking/src/storage.rs`.
2.  Confirm that it now calls `env.storage().persistent().extend_ttl(...)` after reading the user's stakes.
3.  This ensures the data's TTL is bumped on every read, preventing it from being archived due to read-only access.
