### PR TITLE
Feat: Prevent Zero-Duration Auctions

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -31,6 +31,8 @@ use crate::{
 #[contract]
 pub struct MarketplaceContract;
 
+const MIN_DURATION_SECONDS: u64 = 60;
+
 #[contractimpl]
 impl MarketplaceContract {
     // ── Admin & Global Configuration ───────────────────────
@@ -545,7 +547,7 @@ impl MarketplaceContract {
             panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
         // A duration of less than a minute is not practical.
-        if duration < 60 {
+        if duration < MIN_DURATION_SECONDS {
             panic_with_error!(&env, MarketplaceError::InvalidAuctionDuration);
         }
 

--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -544,6 +544,11 @@ impl MarketplaceContract {
         if !Self::is_token_whitelisted(&env, &token) {
             panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
+        // A duration of less than a minute is not practical.
+        if duration < 60 {
+            panic_with_error!(&env, MarketplaceError::InvalidAuctionDuration);
+        }
+
         let auction_id = increment_auction_count(&env);
         let end_time = env.ledger().timestamp() + duration;
         let auction = Auction {

--- a/contracts/soroban-marketplace/src/types.rs
+++ b/contracts/soroban-marketplace/src/types.rs
@@ -32,6 +32,7 @@ pub enum MarketplaceError {
     InvalidRoyalty = 24,
     /// Token attempted at purchase time but is no longer whitelisted
     TokenNotWhitelisted = 25,
+    InvalidAuctionDuration = 26,
 }
 
 #[contracttype]


### PR DESCRIPTION
### Summary
closes #395 
This pull request addresses a critical validation issue where auctions could be created with a `duration` of zero, causing them to expire instantly. This behavior breaks the user interface and makes it impossible for users to place bids.

A check has been added to the `create_auction` function to enforce a minimum duration of 60 seconds, preventing the creation of these invalid auctions.

### Problem

The `create_auction` function lacked any validation for the `duration` parameter. A malicious or mistaken user could pass `duration = 0`. When the contract calculates the `end_time` using `env.ledger().timestamp() + duration`, the auction would be set to expire at the exact moment of its creation.

This resulted in:
- A broken UI that could not correctly display the auction's state or countdown.
- An auction that was impossible to bid on, as it was already considered expired.

### Solution

To resolve this, a validation check has been implemented at the beginning of the `create_auction` function in `contracts/soroban-marketplace/src/contract.rs`.

- The contract now checks if `duration < 60`.
- If the duration is less than 60 seconds, the transaction will panic with a new, specific error: `MarketplaceError::InvalidAuctionDuration`.
- A new error variant, `InvalidAuctionDuration`, has been added to the `MarketplaceError` enum in `contracts/soroban-marketplace/src/types.rs`.

This change ensures that all auctions have a practical, non-zero lifetime, improving contract robustness and providing a better user experience.


