### PR TITLE
Feat: Prevent Microscopic Bid Sniping

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -589,8 +589,17 @@ impl MarketplaceContract {
         if env.ledger().timestamp() >= auction.end_time {
             panic_with_error!(&env, MarketplaceError::AuctionExpired);
         }
-        if amount <= auction.highest_bid || amount < auction.reserve_price {
-            panic_with_error!(&env, MarketplaceError::BidTooLow);
+
+        // Enforce minimum bid increment to prevent griefing.
+        // If there's an existing bid, the new bid must be at least 5% higher.
+        // Otherwise, it must meet the reserve price.
+        let min_bid = if auction.highest_bid > 0 {
+            auction.highest_bid + (auction.highest_bid * 5 / 100)
+        } else {
+            auction.reserve_price
+        };
+        if amount < min_bid {
+            panic_with_error!(&env, MarketplaceError::BidTooLow)
         }
 
         let token_client = TokenClient::new(&env, &auction.token);


### PR DESCRIPTION
### Summary
closes #396 
This pull request introduces a minimum bid increment to the auction functionality, preventing "auction griefing" where participants can outbid others by an infinitesimally small amount (e.g., 1 stroop). New bids must now be at least 5% higher than the current highest bid, ensuring meaningful price progression and a fairer auction environment.

### Problem

The previous implementation of `place_bid` only checked if the new `amount` was greater than the `auction.highest_bid`. This allowed a user or bot to place a new bid that was just one stroop (0.0000001 XLM) higher than the current one.

This leads to several issues:
- **Auction Griefing:** Automated bots can endlessly outbid legitimate users with trivial increments, frustrating them and potentially driving them away.
- **Poor User Experience:** The auction becomes a game of speed rather than value assessment, as users are forced into a rapid-fire bidding war of tiny amounts.
- **Unnecessary Network Churn:** Each tiny bid is a separate transaction, creating noise on the ledger for insignificant value changes.

### Solution

To address this, the `place_bid` function in `contracts/soroban-marketplace/src/contract.rs` has been updated with new validation logic:

1.  A `min_bid` is calculated before validating the bid amount.
2.  If an auction already has a `highest_bid` (i.e., it's not the first bid), the `min_bid` is set to `highest_bid + 5%`.
3.  If it is the first bid (`highest_bid == 0`), the `min_bid` is simply the `reserve_price`.
4.  The transaction panics with `MarketplaceError::BidTooLow` if the incoming `amount` is less than the calculated `min_bid`.

This ensures that every new bid represents a significant and competitive increase in price.
