### PR TITLE
Fix Issue 421

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ Thumbs.db
 # Generated test snapshots
 **/test_snapshots/
 **/issues.md
+fix.md

--- a/frontend/afristore-app/jest.config.js
+++ b/frontend/afristore-app/jest.config.js
@@ -7,7 +7,7 @@ const createJestConfig = nextJest({
 
 // Add any custom config to be passed to Jest
 const customJestConfig = {
-  setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+  setupFilesAfterEnv: ["<rootDir>/jest.setup.ts"],
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/e2e/", "<rootDir>/tests/e2e/"],
   moduleNameMapper: {

--- a/frontend/afristore-app/jest.setup.js
+++ b/frontend/afristore-app/jest.setup.js
@@ -1,1 +1,0 @@
-import "@testing-library/jest-dom";


### PR DESCRIPTION
## Description

There were duplicate `jest.setup` files (`jest.setup.js` and `jest.setup.ts`) in `frontend/afristore-app/`, causing potential test config overrides and conflicts. This PR removes the `.js` duplicate and points `jest.config.js` to the `.ts` version.

## Soroban Safety Checklist

N/A — this is a frontend Jest configuration change, not a Soroban/smart contract change.

## Testing

- [x] Verified `jest.setup.js` deleted
- [x] Verified `jest.config.js` references `<rootDir>/jest.setup.ts`
- [ ] All tests pass locally (`cd frontend/afristore-app && npm test`)

Closes #421 