### PR TITLE
feat: ERC-1155 amount support, splitter UI, event indexing, deploy script fix

### DIFF
--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -223,6 +223,7 @@ impl MarketplaceContract {
         token: Address,
         collection: Address,
         token_id: u64,
+        amount: u64,
         recipients: Vec<Recipient>,
     ) -> u64 {
         if crate::storage::is_paused(&env) {
@@ -267,6 +268,7 @@ impl MarketplaceContract {
             token,
             collection,
             token_id,
+            amount,
             recipients,
             status: ListingStatus::Active,
             owner: None,
@@ -414,7 +416,7 @@ impl MarketplaceContract {
             true,
         );
 
-        // Transfer the NFT
+        // Transfer the NFT (ERC-1155 requires amount as 5th arg; ERC-721 amount is always 1)
         env.invoke_contract::<()>(
             &listing.collection,
             &soroban_sdk::Symbol::new(&env, "transfer_from"),
@@ -423,7 +425,8 @@ impl MarketplaceContract {
                 env.current_contract_address().into_val(&env),
                 listing.artist.into_val(&env),
                 buyer.into_val(&env),
-                listing.token_id.into_val(&env)
+                listing.token_id.into_val(&env),
+                listing.amount.into_val(&env)
             ],
         );
 
@@ -527,6 +530,7 @@ impl MarketplaceContract {
         token: Address,
         collection: Address,
         token_id: u64,
+        amount: u64,
         reserve_price: i128,
         duration: u64,
         recipients: Vec<Recipient>,
@@ -552,6 +556,7 @@ impl MarketplaceContract {
             token: token.clone(),
             collection: collection.clone(),
             token_id,
+            amount,
             reserve_price,
             highest_bid: 0,
             highest_bidder: None,
@@ -665,7 +670,7 @@ impl MarketplaceContract {
                     false,
                 );
 
-                // Transfer the NFT
+                // Transfer the NFT (ERC-1155 requires amount as 5th arg; ERC-721 amount is always 1)
                 env.invoke_contract::<()>(
                     &auction.collection,
                     &soroban_sdk::Symbol::new(&env, "transfer_from"),
@@ -674,7 +679,8 @@ impl MarketplaceContract {
                         env.current_contract_address().into_val(&env),
                         auction.creator.into_val(&env),
                         winner.into_val(&env),
-                        auction.token_id.into_val(&env)
+                        auction.token_id.into_val(&env),
+                        auction.amount.into_val(&env)
                     ],
                 );
 
@@ -851,7 +857,7 @@ impl MarketplaceContract {
             false,
         );
 
-        // Transfer the NFT
+        // Transfer the NFT (ERC-1155 requires amount as 5th arg; ERC-721 amount is always 1)
         env.invoke_contract::<()>(
             &listing.collection,
             &soroban_sdk::Symbol::new(&env, "transfer_from"),
@@ -860,7 +866,8 @@ impl MarketplaceContract {
                 env.current_contract_address().into_val(&env),
                 artist.into_val(&env),
                 offer.offerer.into_val(&env),
-                listing.token_id.into_val(&env)
+                listing.token_id.into_val(&env),
+                listing.amount.into_val(&env)
             ],
         );
         let accepted_offerer = offer.offerer.clone();

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -538,7 +538,6 @@ fn test_artist_revocation_and_reinstatement() {
             &1u64,
             &1_000_000_i128,
             &3600u64,
-            &1u64,
             &valid_recipients(&env, &artist_to_revoke),
         );
         assert!(r.is_err());
@@ -2383,7 +2382,6 @@ fn test_create_auction_royalty_bps_max_allowed() {
         &1u64,
         &1_000_000_i128,
         &3600u64,
-        &1u64,
         &valid_recipients(&env, &artist),
     );
     assert_eq!(auction_id, 1u64);
@@ -2404,7 +2402,6 @@ fn test_create_auction_royalty_bps_too_high() {
         &1u64,
         &1_000_000_i128,
         &3600u64,
-        &1u64,
         &valid_recipients(&env, &artist),
     );
 }
@@ -2551,7 +2548,6 @@ fn test_create_auction_blocked_when_paused() {
         &1u64,
         &5_000_000_i128,
         &3600u64,
-        &1u64,
         &valid_recipients(&env, &artist),
     );
 }

--- a/contracts/soroban-marketplace/src/test.rs
+++ b/contracts/soroban-marketplace/src/test.rs
@@ -35,6 +35,7 @@ mod mock_nft {
             _from: Address,
             _to: Address,
             _token_id: u64,
+            _amount: u64,
         ) {
         }
     }
@@ -124,6 +125,7 @@ fn test_set_treasury_and_protocol_fee() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     let result = client.buy_artwork(&buyer, &id);
@@ -156,6 +158,7 @@ fn test_buy_artwork_no_treasury_fee_set() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -216,6 +219,7 @@ fn test_create_listing_success() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 
@@ -243,6 +247,7 @@ fn test_create_listing_zero_price() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 }
@@ -259,6 +264,7 @@ fn test_create_listing_empty_cid() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -284,6 +290,7 @@ fn test_create_listing_invalid_split() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &recipients,
     );
@@ -326,6 +333,7 @@ fn test_create_listing_too_many_recipients() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &recipients,
     );
 }
@@ -344,6 +352,7 @@ fn test_cancel_listing_success() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -388,6 +397,7 @@ fn test_cancel_listing_wrong_artist() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     client.cancel_listing(&buyer, &id);
@@ -407,6 +417,7 @@ fn test_update_listing_success() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -436,6 +447,7 @@ fn test_update_listing_empty_cid() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 
@@ -456,6 +468,7 @@ fn test_update_listing_wrong_artist() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -478,6 +491,7 @@ fn test_update_listing_not_active() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -508,6 +522,7 @@ fn test_artist_revocation_and_reinstatement() {
             &token_id,
             &collection_id,
             &1u64,
+            &1u64,
             &valid_recipients(&env, &artist_to_revoke),
         );
         assert!(r.is_err());
@@ -520,8 +535,10 @@ fn test_artist_revocation_and_reinstatement() {
             &token_id,
             &collection_id,
             &1u64,
+            &1u64,
             &1_000_000_i128,
             &3600u64,
+            &1u64,
             &valid_recipients(&env, &artist_to_revoke),
         );
         assert!(r.is_err());
@@ -538,6 +555,7 @@ fn test_artist_revocation_and_reinstatement() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist_to_revoke),
     );
@@ -576,6 +594,7 @@ fn test_get_artist_listings() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     client.create_listing(
@@ -585,6 +604,7 @@ fn test_get_artist_listings() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     client.create_listing(
@@ -593,6 +613,7 @@ fn test_get_artist_listings() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -618,6 +639,7 @@ fn test_buy_artwork_success() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -664,6 +686,7 @@ fn test_buy_artwork_complex_split() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &recipients,
     );
@@ -714,6 +737,7 @@ fn test_add_and_remove_token_whitelist() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     assert_eq!(listing_id, 1u64);
@@ -736,6 +760,7 @@ fn test_create_listing_with_non_whitelisted_token_panics() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 }
@@ -752,6 +777,7 @@ fn test_create_listing_with_whitelisted_token_succeeds() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -775,6 +801,7 @@ fn test_buy_artwork_fee_greater_than_price() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -804,6 +831,7 @@ fn test_buy_artwork_fee_rounding_precision() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     let result = client.buy_artwork(&buyer, &id);
@@ -830,6 +858,7 @@ fn test_royalty_zero_percent() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -858,6 +887,7 @@ fn test_royalty_hundred_percent() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     let result = client.buy_artwork(&buyer, &id);
@@ -885,6 +915,7 @@ fn test_royalty_rounding_precision() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     let result = client.buy_artwork(&buyer, &id);
@@ -909,6 +940,7 @@ fn test_royalty_secondary_sale() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -971,6 +1003,7 @@ fn test_create_auction_success() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &reserve_price,
         &duration,
         &valid_recipients(&env, &artist),
@@ -1001,6 +1034,7 @@ fn test_create_auction_zero_reserve_rejected() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &0,
         &3600,
         &valid_recipients(&env, &artist),
@@ -1018,6 +1052,7 @@ fn test_place_bid_success() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000,
         &3600,
@@ -1042,6 +1077,7 @@ fn test_place_bid_too_low() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000,
         &3600,
         &valid_recipients(&env, &artist),
@@ -1060,6 +1096,7 @@ fn test_finalize_auction_with_winner() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000,
         &3600,
@@ -1087,6 +1124,7 @@ fn test_finalize_auction_no_bids() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000,
         &3600,
         &valid_recipients(&env, &artist),
@@ -1111,6 +1149,7 @@ fn test_finalize_auction_before_expiry_rejects_non_creator() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000,
         &3600,
         &valid_recipients(&env, &artist),
@@ -1130,6 +1169,7 @@ fn test_place_bid_after_expiration() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000,
         &3600,
@@ -1154,6 +1194,7 @@ fn test_outbid_refund_logic_check() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000,
         &3600,
@@ -1190,6 +1231,7 @@ fn create_test_listing(
         &symbol_short!("XLM"),
         token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(env, artist),
     )
@@ -1394,6 +1436,7 @@ fn test_artist_revocation_flow() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 
@@ -1408,6 +1451,7 @@ fn test_artist_revocation_flow() {
             &symbol_short!("XLM"),
             &token_id,
             &collection_id,
+            &1u64,
             &1u64,
             &valid_recipients(&env, &artist),
         )
@@ -1424,6 +1468,7 @@ fn test_artist_revocation_flow() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -1776,6 +1821,7 @@ fn test_create_auction_emits_auction_created_event() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000_i128,
         &3600_u64,
         &valid_recipients(&env, &artist),
@@ -1797,6 +1843,7 @@ fn test_place_bid_emits_bid_placed_event() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000_i128,
         &3600_u64,
@@ -1820,6 +1867,7 @@ fn test_finalize_auction_emits_auction_resolved_event() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000_i128,
         &3600_u64,
@@ -1855,6 +1903,7 @@ fn test_buy_artwork_transfers_correct_amounts_to_recipients() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 
@@ -1882,6 +1931,7 @@ fn test_buy_artwork_pays_royalty_on_secondary_sale() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -1939,6 +1989,7 @@ fn test_buy_artwork_pays_treasury_fee() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 
@@ -1981,6 +2032,7 @@ fn test_create_listing_while_paused_fails() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -2030,6 +2082,7 @@ fn test_create_auction_while_paused_fails() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000_i128,
         &3600_u64,
@@ -2174,6 +2227,7 @@ fn test_finalize_already_finalized_auction_fails() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000_i128,
         &3600_u64,
         &valid_recipients(&env, &artist),
@@ -2197,6 +2251,7 @@ fn test_bid_on_finalized_auction_fails() {
         &artist,
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &1_000_000_i128,
         &3600_u64,
@@ -2254,6 +2309,7 @@ fn test_revoked_artist_cannot_create_listing() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist2),
     );
 }
@@ -2288,6 +2344,7 @@ fn test_create_listing_royalty_bps_max_allowed() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     assert_eq!(id, 1u64);
@@ -2307,6 +2364,7 @@ fn test_create_listing_royalty_bps_too_high() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 }
@@ -2322,8 +2380,10 @@ fn test_create_auction_royalty_bps_max_allowed() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000_i128,
         &3600u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
     assert_eq!(auction_id, 1u64);
@@ -2341,8 +2401,10 @@ fn test_create_auction_royalty_bps_too_high() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &1_000_000_i128,
         &3600u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 }
@@ -2365,6 +2427,7 @@ fn test_buy_artwork_fails_if_token_delisted() {
         &symbol_short!("XLM"),
         &token_id,
         &collection_id,
+        &1u64,
         &1u64,
         &valid_recipients(&env, &artist),
     );
@@ -2485,8 +2548,10 @@ fn test_create_auction_blocked_when_paused() {
         &token_id,
         &collection_id,
         &1u64,
+        &1u64,
         &5_000_000_i128,
         &3600u64,
+        &1u64,
         &valid_recipients(&env, &artist),
     );
 }

--- a/contracts/soroban-marketplace/src/types.rs
+++ b/contracts/soroban-marketplace/src/types.rs
@@ -59,6 +59,8 @@ pub struct Listing {
     pub token: Address,
     pub collection: Address,
     pub token_id: u64,
+    /// ERC-1155 quantity; always 1 for ERC-721 collections.
+    pub amount: u64,
     pub recipients: soroban_sdk::Vec<Recipient>,
     pub status: ListingStatus,
     pub owner: Option<Address>,
@@ -81,6 +83,8 @@ pub struct Auction {
     pub token: Address,
     pub collection: Address,
     pub token_id: u64,
+    /// ERC-1155 quantity; always 1 for ERC-721 collections.
+    pub amount: u64,
     pub reserve_price: i128,
     pub highest_bid: i128,
     pub highest_bidder: Option<Address>,

--- a/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
+++ b/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
@@ -56,7 +56,7 @@ jest.mock("@/components/WalletGuard", () => ({
 
 jest.mock("lucide-react", () =>
   Object.fromEntries(
-    ["Loader2", "Rocket", "CheckCircle", "ArrowRight"].map((name) => [
+    ["Loader2", "Rocket", "CheckCircle", "ArrowRight", "Info", "ChevronDown"].map((name) => [
       name,
       () => <span />,
     ]),

--- a/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
+++ b/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
@@ -8,7 +8,9 @@ import userEvent from "@testing-library/user-event";
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 const mockDeploy = jest.fn();
-let mockPublicKey: string | null = "GPUBKEY";
+// Must be 56 chars (valid Stellar key length) so isStellarAddress passes
+// and the deploy button isn't disabled by our address validator.
+let mockPublicKey: string | null = "G" + "A".repeat(55);
 
 jest.mock("@/context/WalletContext", () => ({
   useWalletContext: () => ({ publicKey: mockPublicKey }),

--- a/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
+++ b/frontend/afristore-app/src/__tests__/CollectionForm.test.tsx
@@ -72,7 +72,7 @@ import { CollectionForm } from "@/components/CollectionForm";
 describe("CollectionForm", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockPublicKey = "GPUBKEY";
+    mockPublicKey = "G" + "A".repeat(55);
   });
 
   it("renders the collection name input", () => {

--- a/frontend/afristore-app/src/components/CollectionForm.tsx
+++ b/frontend/afristore-app/src/components/CollectionForm.tsx
@@ -6,12 +6,44 @@ import {
   DeployCollectionInput,
 } from "@/hooks/useLaunchpad";
 import { useWalletContext } from "@/context/WalletContext";
-import { Loader2, Rocket, CheckCircle, ArrowRight } from "lucide-react";
+import { Loader2, Rocket, CheckCircle, ArrowRight, Info, ChevronDown } from "lucide-react";
 import { GuardButton } from "./WalletGuard";
 import { CollectionKind } from "@/lib/launchpad";
 import { DEFAULT_TOKEN } from "@/config/tokens";
 import { useSupportedTokens } from "@/hooks/useSupportedTokens";
 import { getDefaultSupportedToken } from "@/lib/token-support";
+
+const SPLITTER_TOOLTIP =
+  "If you want to split royalties with multiple people, paste your deployed Royalty Splitter contract address here, or deploy one first via Launchpad → Royalty Splitter.";
+
+function SplitterTooltip() {
+  const [open, setOpen] = useState(false);
+  return (
+    <span className="relative inline-flex items-center">
+      <button
+        type="button"
+        aria-label="Royalty splitter info"
+        onClick={() => setOpen((o) => !o)}
+        onBlur={() => setOpen(false)}
+        className="ml-1.5 text-gray-400 hover:text-brand-500 transition-colors focus:outline-none"
+      >
+        <Info size={13} />
+      </button>
+      {open && (
+        <span
+          role="tooltip"
+          className="absolute left-6 top-0 z-50 w-72 rounded-2xl bg-gray-900 px-4 py-3 text-xs text-white shadow-xl font-inter leading-relaxed"
+        >
+          {SPLITTER_TOOLTIP}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function isStellarAddress(v: string) {
+  return (v.startsWith("G") || v.startsWith("C")) && v.length >= 50;
+}
 
 export function CollectionForm() {
   const { publicKey } = useWalletContext();
@@ -20,6 +52,11 @@ export function CollectionForm() {
   const hasSupportedTokens = supportedTokens.length > 0;
 
   const [successAddress, setSuccessAddress] = useState<string | null>(null);
+
+  // Splitter addresses the user has deployed (persisted in localStorage under their pubkey)
+  const [savedSplitters, setSavedSplitters] = useState<string[]>([]);
+  const [showSplitterPicker, setShowSplitterPicker] = useState(false);
+
   const [form, setForm] = useState({
     name: "",
     symbol: "",
@@ -44,6 +81,17 @@ export function CollectionForm() {
       }));
     }
   }, [form.currencyAddress, supportedTokens]);
+
+  // Load saved splitter addresses from localStorage when the wallet connects
+  useEffect(() => {
+    if (!publicKey) return;
+    try {
+      const raw = localStorage.getItem(`splitters:${publicKey}`);
+      setSavedSplitters(raw ? (JSON.parse(raw) as string[]) : []);
+    } catch {
+      setSavedSplitters([]);
+    }
+  }, [publicKey]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -104,6 +152,8 @@ export function CollectionForm() {
   }
 
   const is721 = form.kind.includes("721");
+  const royaltyAddressValid =
+    !form.royaltyReceiver || isStellarAddress(form.royaltyReceiver);
 
   return (
     <div className="max-w-3xl mx-auto px-4 py-8">
@@ -274,18 +324,70 @@ export function CollectionForm() {
               </select>
             </div>
 
+            {/* ── Royalty Receiver Address ─────────────────────────── */}
             <div className="sm:col-span-2 space-y-2">
-              <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
-                Royalty Receiver Address
-              </label>
+              <div className="flex items-center justify-between">
+                <label className="flex items-center text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
+                  Royalty Receiver Address
+                  <SplitterTooltip />
+                </label>
+
+                {/* "Use my Splitter" picker — shown when saved splitters exist */}
+                {savedSplitters.length > 0 && (
+                  <div className="relative">
+                    <button
+                      type="button"
+                      onClick={() => setShowSplitterPicker((o) => !o)}
+                      className="inline-flex items-center gap-1.5 rounded-xl bg-brand-50 border border-brand-200 px-3 py-1.5 text-xs font-bold text-brand-700 hover:bg-brand-100 transition-colors"
+                    >
+                      Select my Splitter
+                      <ChevronDown size={12} />
+                    </button>
+                    {showSplitterPicker && (
+                      <div className="absolute right-0 top-8 z-40 w-80 rounded-2xl border border-gray-200 bg-white shadow-xl overflow-hidden">
+                        <p className="px-4 pt-3 pb-1 text-xs font-bold text-gray-400 uppercase tracking-widest">
+                          Your deployed splitters
+                        </p>
+                        {savedSplitters.map((addr) => (
+                          <button
+                            key={addr}
+                            type="button"
+                            onClick={() => {
+                              setForm({ ...form, royaltyReceiver: addr });
+                              setShowSplitterPicker(false);
+                            }}
+                            className="w-full text-left px-4 py-3 font-mono text-xs text-gray-700 hover:bg-brand-50 truncate border-t border-gray-100 first:border-0"
+                          >
+                            {addr}
+                          </button>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+
               <input
                 value={form.royaltyReceiver}
                 onChange={(e) =>
                   setForm({ ...form, royaltyReceiver: e.target.value })
                 }
-                className="w-full rounded-2xl border border-gray-200 bg-gray-50/50 px-5 py-4 text-base focus:border-brand-500 focus:bg-white focus:outline-none transition-all shadow-sm font-inter font-mono text-sm"
-                placeholder={publicKey || "G... (defaults to creator)"}
+                className={`w-full rounded-2xl border bg-gray-50/50 px-5 py-4 text-base focus:bg-white focus:outline-none transition-all shadow-sm font-inter font-mono text-sm ${
+                  form.royaltyReceiver && !royaltyAddressValid
+                    ? "border-red-400 focus:border-red-500"
+                    : "border-gray-200 focus:border-brand-500"
+                }`}
+                placeholder={publicKey || "G… wallet or C… contract address (defaults to creator)"}
+                aria-describedby="royalty-receiver-hint"
               />
+              <p id="royalty-receiver-hint" className="text-xs text-gray-400 font-inter">
+                Accepts any Stellar address: a regular wallet (G…) or a Royalty Splitter contract (C…).
+              </p>
+              {form.royaltyReceiver && !royaltyAddressValid && (
+                <p className="text-xs text-red-500 font-inter">
+                  Must be a valid Stellar address starting with G or C.
+                </p>
+              )}
             </div>
           </div>
 
@@ -297,7 +399,7 @@ export function CollectionForm() {
 
           <GuardButton
             type="submit"
-            disabled={isDeploying || !hasSupportedTokens}
+            disabled={isDeploying || !hasSupportedTokens || (!!form.royaltyReceiver && !royaltyAddressValid)}
             actionName="to deploy your collection"
             className="w-full flex items-center justify-center gap-3 rounded-2xl bg-brand-500 py-5 text-xl font-bold text-white shadow-2xl shadow-brand-500/30 hover:bg-brand-600 hover:scale-[1.01] transition-all active:scale-[0.98] disabled:opacity-50 disabled:hover:scale-100"
           >

--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -26,6 +26,7 @@ model Listing {
   currency        String
   collection      String
   nftTokenId      BigInt
+  amount          Int      @default(1)
   token           String
   metadataCid     String?
   status          String   // "Active", "Sold", "Cancelled", "Auction"
@@ -42,6 +43,7 @@ model Auction {
   creator         String
   collection      String
   nftTokenId      BigInt
+  amount          Int      @default(1)
   token           String
   metadataCid     String?
   reservePrice    Decimal  @db.Decimal(32, 7)
@@ -102,12 +104,13 @@ model StakedNFT {
   tokenAddress    String
   tokenId         BigInt
   collection      String
+  amount          Int      @default(1)
   stakedAt        DateTime
   status          String   // "Active", "Unstaked"
   rewardsEarned   Decimal  @default(0) @db.Decimal(32, 7)
   createdAtLedger Int
   updatedAtLedger Int
-  @@unique([owner, tokenAddress, tokenId])
   @@index([owner])
+  @@index([owner, tokenAddress, tokenId])
   @@index([status])
 }

--- a/indexer/src/parser.ts
+++ b/indexer/src/parser.ts
@@ -93,8 +93,21 @@ export function parseMarketplaceEvent(
 }
 
 /**
+ * Extracts the ERC-1155 token quantity from a decoded event data object.
+ * Returns 1 for ERC-721 events that do not carry an amount field.
+ */
+export function extractAmount(nativeData: any): number {
+  if (nativeData === null || nativeData === undefined) return 1;
+  if (typeof nativeData !== 'object' || Array.isArray(nativeData)) return 1;
+  const raw = nativeData.amount ?? nativeData.quantity ?? nativeData.value;
+  if (raw === undefined || raw === null) return 1;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? n : 1;
+}
+
+/**
  * Helper to convert BigInts in an object to strings for JSON storage if needed,
- * though Prisma handles BigInt natively in some cases. 
+ * though Prisma handles BigInt natively in some cases.
  * For 'Json' field in Prisma, we should convert them to strings or numbers.
  */
 function convertBigInts(obj: any): any {

--- a/scripts/deploy/deploy_launchpad.sh
+++ b/scripts/deploy/deploy_launchpad.sh
@@ -65,6 +65,8 @@ echo "  Launchpad ID: $LAUNCHPAD_ID"
 
 # 5. Initialize Launchpad
 echo "Step 5/6  Initializing Launchpad..."
+# Native XLM token address on Soroban testnet (override via PLATFORM_FEE_TOKEN env var)
+PLATFORM_FEE_TOKEN="${PLATFORM_FEE_TOKEN:-CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2BNROLN}"
 stellar contract invoke \
   --id "$LAUNCHPAD_ID" \
   --source "$STELLAR_SECRET" \
@@ -73,7 +75,8 @@ stellar contract invoke \
   -- initialize \
   --admin "$STELLAR_PUBLIC" \
   --platform_fee_receiver "$STELLAR_PUBLIC" \
-  --platform_fee_bps 0
+  --platform_fee_bps 0 \
+  --platform_fee_token "$PLATFORM_FEE_TOKEN"
 
 stellar contract invoke \
   --id "$LAUNCHPAD_ID" \


### PR DESCRIPTION
Closes #441

---

Closes #445

---

Closes #446

---

Closes #338

---

## Summary

- **#441** — `contracts/soroban-marketplace/src/types.rs` + `contract.rs`: added `amount: u64` field to `Listing` and `Auction` structs; updated `create_listing` and `create_auction` to accept the new parameter; fixed `buy_artwork`, `finalize_auction`, and `accept_offer` to pass `amount` as the 5th argument to `transfer_from`, enabling ERC-1155 purchases without a contract panic
- **#445** — `indexer/prisma/schema.prisma`: added `amount Int @default(1)` to `Listing`, `Auction`, and `StakedNFT` models; replaced the problematic `@@unique([owner, tokenAddress, tokenId])` constraint on `StakedNFT` with a plain `@@index` so multiple stake deposits for the same ERC-1155 token no longer cause database conflicts; `indexer/src/parser.ts`: added `extractAmount()` helper to pull the `amount`/`quantity` field out of decoded event data
- **#446** — `scripts/deploy/deploy_launchpad.sh`: added `PLATFORM_FEE_TOKEN` variable (defaults to the Soroban testnet native XLM contract address) and passes it as `--platform_fee_token` to the `initialize` invocation, keeping the script in sync with the updated contract signature
- **#338** — `frontend/afristore-app/src/components/CollectionForm.tsx`: the Royalty Receiver field now accepts any valid Stellar address (G… wallets or C… contract addresses); added inline validation with a clear error message; added a tooltip explaining how to use a Royalty Splitter contract; added a "Select my Splitter" dropdown that reads saved splitter addresses from `localStorage` keyed to the connected wallet

## Test plan

- [ ] Deploy to testnet via `scripts/deploy/deploy_launchpad.sh` — confirm `initialize` succeeds with `PLATFORM_FEE_TOKEN` set and with the default
- [ ] Create an ERC-1155 listing with `amount > 1` and buy it — confirm no contract panic and correct token quantity is transferred
- [ ] Finalize an ERC-1155 auction and accept an ERC-1155 offer — same amount assertion
- [ ] Run indexer against a testnet with ERC-1155 stake events — confirm `StakedNFT.amount` is populated and multiple deposits for the same token don't conflict
- [ ] In the UI, enter a C… contract address in the Royalty Receiver field — confirm it is accepted; enter an invalid string — confirm the error appears and the submit button is disabled