### PR TITLE
fix: Launchpad fee token spoofing, lazy mint double deduction, and ERC-1155 quantity support

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -190,7 +190,6 @@ impl Launchpad {
     pub fn deploy_normal_721(
         env: Env,
         creator: Address,
-        currency: Address,
         name: String,
         symbol: String,
         max_supply: u64,
@@ -200,7 +199,6 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
-        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee using admin-set token (#442)
         let (receiver, fee) = storage::get_platform_fee(&env);

--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -138,6 +138,7 @@ impl Launchpad {
         admin: Address,
         platform_fee_receiver: Address,
         platform_fee_bps: u32,
+        platform_fee_token: Address,
     ) -> Result<(), Error> {
         if storage::is_initialized(&env) {
             return Err(Error::AlreadyInitialized);
@@ -146,6 +147,7 @@ impl Launchpad {
         storage::set_initialized(&env);
         storage::set_admin(&env, &admin);
         storage::set_platform_fee(&env, &platform_fee_receiver, platform_fee_bps);
+        storage::set_platform_fee_token(&env, &platform_fee_token);
         Ok(())
     }
 
@@ -188,7 +190,6 @@ impl Launchpad {
     pub fn deploy_normal_721(
         env: Env,
         creator: Address,
-        currency: Address, // [NEW] SAC address for fee payment
         name: String,
         symbol: String,
         max_supply: u64,
@@ -199,10 +200,12 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
-        // [FEE] Collect deployment fee (#54)
+        // [FEE] Collect deployment fee using admin-set token (#442)
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+            let fee_token = storage::get_platform_fee_token(&env)
+                .ok_or(Error::PlatformFeeTokenNotSet)?;
+            soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,
                 &(fee as i128),
@@ -244,7 +247,6 @@ impl Launchpad {
     pub fn deploy_normal_1155(
         env: Env,
         creator: Address,
-        currency: Address,
         name: String,
         royalty_bps: u32,
         royalty_receiver: Address,
@@ -253,10 +255,12 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
-        // [FEE] Collect deployment fee (#54)
+        // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+            let fee_token =
+                storage::get_platform_fee_token(&env).ok_or(Error::PlatformFeeTokenNotSet)?;
+            soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,
                 &(fee as i128),
@@ -298,7 +302,6 @@ impl Launchpad {
     pub fn deploy_lazy_721(
         env: Env,
         creator: Address,
-        currency: Address,
         creator_pubkey: BytesN<32>,
         name: String,
         symbol: String,
@@ -310,10 +313,12 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
-        // [FEE] Collect deployment fee (#54)
+        // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+            let fee_token =
+                storage::get_platform_fee_token(&env).ok_or(Error::PlatformFeeTokenNotSet)?;
+            soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,
                 &(fee as i128),
@@ -354,7 +359,6 @@ impl Launchpad {
     pub fn deploy_lazy_1155(
         env: Env,
         creator: Address,
-        currency: Address,
         creator_pubkey: BytesN<32>,
         name: String,
         royalty_bps: u32,
@@ -364,10 +368,12 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
-        // [FEE] Collect deployment fee (#54)
+        // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+            let fee_token =
+                storage::get_platform_fee_token(&env).ok_or(Error::PlatformFeeTokenNotSet)?;
+            soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,
                 &(fee as i128),
@@ -463,7 +469,6 @@ impl Launchpad {
     pub fn deploy_staking_pool(
         env: Env,
         creator: Address,
-        currency: Address,
         nft_address: Address,
         reward_token: Address,
         reward_rate: i128,
@@ -472,10 +477,12 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
-        // [FEE] Collect deployment fee
+        // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            soroban_sdk::token::TokenClient::new(&env, &currency).transfer(
+            let fee_token =
+                storage::get_platform_fee_token(&env).ok_or(Error::PlatformFeeTokenNotSet)?;
+            soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,
                 &(fee as i128),
@@ -523,6 +530,15 @@ impl Launchpad {
         Ok(())
     }
 
+    /// Admin sets the token used for platform fee collection.
+    /// Deploy functions will use this token instead of the caller-supplied currency.
+    pub fn set_platform_fee_token(env: Env, token: Address) -> Result<(), Error> {
+        storage::extend_instance_ttl(&env);
+        storage::require_admin(&env)?;
+        storage::set_platform_fee_token(&env, &token);
+        Ok(())
+    }
+
     // ── View functions ────────────────────────────────────────────────────
 
     /// All collections deployed by a specific creator.
@@ -545,6 +561,10 @@ impl Launchpad {
 
     pub fn platform_fee(env: Env) -> (Address, u32) {
         storage::get_platform_fee(&env)
+    }
+
+    pub fn platform_fee_token(env: Env) -> Option<Address> {
+        storage::get_platform_fee_token(&env)
     }
 
     // ── Query API (issue: launchpad contract query API + deploy events) ───

--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -256,7 +256,6 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
-        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -315,7 +314,6 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
-        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -371,7 +369,6 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
-        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -481,7 +478,6 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
-        storage::require_approved_currency(&env, &currency)?;
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);

--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -203,8 +203,8 @@ impl Launchpad {
         // [FEE] Collect deployment fee using admin-set token (#442)
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
-            let fee_token = storage::get_platform_fee_token(&env)
-                .ok_or(Error::PlatformFeeTokenNotSet)?;
+            let fee_token =
+                storage::get_platform_fee_token(&env).ok_or(Error::PlatformFeeTokenNotSet)?;
             soroban_sdk::token::TokenClient::new(&env, &fee_token).transfer(
                 &creator,
                 &receiver,

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -64,9 +64,7 @@ pub fn set_platform_fee_token(env: &Env, token: &Address) {
 }
 
 pub fn get_platform_fee_token(env: &Env) -> Option<Address> {
-    env.storage()
-        .instance()
-        .get(&DataKey::PlatformFeeToken)
+    env.storage().instance().get(&DataKey::PlatformFeeToken)
 }
 
 pub fn set_wasm_hashes(

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -46,6 +46,29 @@ pub fn get_platform_fee(env: &Env) -> (Address, u32) {
     )
 }
 
+pub fn set_platform_fee_token(env: &Env, token: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PlatformFeeToken, token);
+}
+
+pub fn get_platform_fee_token(env: &Env) -> Option<Address> {
+    env.storage().instance().get(&DataKey::PlatformFeeToken)
+}
+
+pub fn set_platform_fee_token(env: &Env, token: &Address) {
+    env.storage()
+        .instance()
+        .set(&DataKey::PlatformFeeToken, token);
+    extend_instance_ttl(env);
+}
+
+pub fn get_platform_fee_token(env: &Env) -> Option<Address> {
+    env.storage()
+        .instance()
+        .get(&DataKey::PlatformFeeToken)
+}
+
 pub fn set_wasm_hashes(
     env: &Env,
     normal_721: &BytesN<32>,

--- a/contracts/launchpad/src/storage.rs
+++ b/contracts/launchpad/src/storage.rs
@@ -50,16 +50,6 @@ pub fn set_platform_fee_token(env: &Env, token: &Address) {
     env.storage()
         .instance()
         .set(&DataKey::PlatformFeeToken, token);
-}
-
-pub fn get_platform_fee_token(env: &Env) -> Option<Address> {
-    env.storage().instance().get(&DataKey::PlatformFeeToken)
-}
-
-pub fn set_platform_fee_token(env: &Env, token: &Address) {
-    env.storage()
-        .instance()
-        .set(&DataKey::PlatformFeeToken, token);
     extend_instance_ttl(env);
 }
 

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -1105,13 +1105,8 @@ fn deploys_staking_pool_for_nft_collection() {
     let reward_token = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
 
-    let pool_a = client.deploy_staking_pool(
-        &creator,
-        &nft_address,
-        &reward_token,
-        &1_000_000i128,
-        &salt,
-    );
+    let pool_a =
+        client.deploy_staking_pool(&creator, &nft_address, &reward_token, &1_000_000i128, &salt);
 
     let pool_b = client.get_staking_pool(&nft_address);
     assert_eq!(Some(pool_a), pool_b);

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -43,8 +43,9 @@ fn setup_launchpad(env: &Env) -> (LaunchpadClient<'_>, Address, Address, Address
     let admin = Address::generate(env);
     let fee_receiver = Address::generate(env);
     let creator = Address::generate(env);
+    let fee_token = Address::generate(env);
 
-    client.initialize(&admin, &fee_receiver, &0u32);
+    client.initialize(&admin, &fee_receiver, &0u32, &fee_token);
 
     let wasm_normal_721_bytes = wasm_bytes("collection_nft_erc721");
     let wasm_normal_1155_bytes = wasm_bytes("collection_nft_erc1155");
@@ -83,11 +84,9 @@ fn deploys_normal_721_twice_with_unique_addresses() {
     let salt_a = BytesN::from_array(&env, &[10u8; 32]);
     let salt_b = BytesN::from_array(&env, &[11u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let deployed_a = client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator 721 A"),
         &String::from_str(&env, "C721A"),
         &1_000u64,
@@ -98,7 +97,6 @@ fn deploys_normal_721_twice_with_unique_addresses() {
 
     let deployed_b = client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator 721 B"),
         &String::from_str(&env, "C721B"),
         &1_500u64,
@@ -131,11 +129,9 @@ fn deploys_normal_1155_twice_with_unique_addresses() {
     let salt_a = BytesN::from_array(&env, &[20u8; 32]);
     let salt_b = BytesN::from_array(&env, &[21u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let deployed_a = client.deploy_normal_1155(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator 1155 A"),
         &500u32,
         &royalty_receiver,
@@ -144,7 +140,6 @@ fn deploys_normal_1155_twice_with_unique_addresses() {
 
     let deployed_b = client.deploy_normal_1155(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator 1155 B"),
         &500u32,
         &royalty_receiver,
@@ -176,11 +171,9 @@ fn deploys_lazy_721_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[31u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[7u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let deployed_a = client.deploy_lazy_721(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Lazy 721 A"),
         &String::from_str(&env, "LZ7A"),
@@ -192,7 +185,6 @@ fn deploys_lazy_721_twice_with_unique_addresses() {
 
     let deployed_b = client.deploy_lazy_721(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Lazy 721 B"),
         &String::from_str(&env, "LZ7B"),
@@ -227,11 +219,9 @@ fn deploys_lazy_1155_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[41u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[9u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let deployed_a = client.deploy_lazy_1155(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Lazy 1155 A"),
         &600u32,
@@ -241,7 +231,6 @@ fn deploys_lazy_1155_twice_with_unique_addresses() {
 
     let deployed_b = client.deploy_lazy_1155(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Lazy 1155 B"),
         &600u32,
@@ -271,7 +260,6 @@ fn deploy_calls_extend_instance_ttl() {
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     // After initialize(), instance TTL is bumped to 100_000 ledgers.
     // Move forward so remaining TTL is below threshold (50_000),
@@ -281,7 +269,6 @@ fn deploy_calls_extend_instance_ttl() {
     let salt_a = BytesN::from_array(&env, &[60u8; 32]);
     let _deployed_a = client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "TTL A"),
         &String::from_str(&env, "TTLA"),
         &100u64,
@@ -297,7 +284,6 @@ fn deploy_calls_extend_instance_ttl() {
     let salt_b = BytesN::from_array(&env, &[61u8; 32]);
     let _deployed_b = client.deploy_normal_1155(
         &creator,
-        &currency,
         &String::from_str(&env, "TTL B"),
         &500u32,
         &royalty_receiver,
@@ -344,11 +330,9 @@ fn same_salt_different_creators_normal_721_yields_different_addresses() {
 
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_alice = client.deploy_normal_721(
         &alice,
-        &currency,
         &String::from_str(&env, "Alice 721"),
         &String::from_str(&env, "AL7"),
         &100u64,
@@ -359,7 +343,6 @@ fn same_salt_different_creators_normal_721_yields_different_addresses() {
 
     let addr_bob = client.deploy_normal_721(
         &bob,
-        &currency,
         &String::from_str(&env, "Bob 721"),
         &String::from_str(&env, "BO7"),
         &100u64,
@@ -386,11 +369,9 @@ fn same_salt_different_creators_normal_1155_yields_different_addresses() {
 
     let salt = BytesN::from_array(&env, &[0xBBu8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_alice = client.deploy_normal_1155(
         &alice,
-        &currency,
         &String::from_str(&env, "Alice 1155"),
         &500u32,
         &royalty_receiver,
@@ -399,7 +380,6 @@ fn same_salt_different_creators_normal_1155_yields_different_addresses() {
 
     let addr_bob = client.deploy_normal_1155(
         &bob,
-        &currency,
         &String::from_str(&env, "Bob 1155"),
         &500u32,
         &royalty_receiver,
@@ -421,11 +401,9 @@ fn same_salt_different_creators_lazy_721_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xCCu8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x01u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_alice = client.deploy_lazy_721(
         &alice,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Alice L721"),
         &String::from_str(&env, "AL7L"),
@@ -437,7 +415,6 @@ fn same_salt_different_creators_lazy_721_yields_different_addresses() {
 
     let addr_bob = client.deploy_lazy_721(
         &bob,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Bob L721"),
         &String::from_str(&env, "BO7L"),
@@ -462,11 +439,9 @@ fn same_salt_different_creators_lazy_1155_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xDDu8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x02u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_alice = client.deploy_lazy_1155(
         &alice,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Alice L1155"),
         &400u32,
@@ -476,7 +451,6 @@ fn same_salt_different_creators_lazy_1155_yields_different_addresses() {
 
     let addr_bob = client.deploy_lazy_1155(
         &bob,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Bob L1155"),
         &400u32,
@@ -504,12 +478,10 @@ fn front_runner_cannot_grief_normal_721() {
 
     let salt = BytesN::from_array(&env, &[0x11u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     // Bob front-runs using Alice's raw salt.
     let addr_bob = client.deploy_normal_721(
         &bob,
-        &currency,
         &String::from_str(&env, "Bob Grief 721"),
         &String::from_str(&env, "BG7"),
         &100u64,
@@ -521,7 +493,6 @@ fn front_runner_cannot_grief_normal_721() {
     // Alice's transaction must still succeed (no panic / error).
     let addr_alice = client.deploy_normal_721(
         &alice,
-        &currency,
         &String::from_str(&env, "Alice 721"),
         &String::from_str(&env, "AL7"),
         &100u64,
@@ -547,11 +518,9 @@ fn front_runner_cannot_grief_normal_1155() {
 
     let salt = BytesN::from_array(&env, &[0x22u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_bob = client.deploy_normal_1155(
         &bob,
-        &currency,
         &String::from_str(&env, "Bob Grief 1155"),
         &0u32,
         &royalty_receiver,
@@ -560,7 +529,6 @@ fn front_runner_cannot_grief_normal_1155() {
 
     let addr_alice = client.deploy_normal_1155(
         &alice,
-        &currency,
         &String::from_str(&env, "Alice 1155"),
         &0u32,
         &royalty_receiver,
@@ -582,11 +550,9 @@ fn front_runner_cannot_grief_lazy_721() {
     let salt = BytesN::from_array(&env, &[0x33u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x03u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_bob = client.deploy_lazy_721(
         &bob,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Bob Grief L721"),
         &String::from_str(&env, "BGL7"),
@@ -598,7 +564,6 @@ fn front_runner_cannot_grief_lazy_721() {
 
     let addr_alice = client.deploy_lazy_721(
         &alice,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Alice L721"),
         &String::from_str(&env, "ALL7"),
@@ -623,11 +588,9 @@ fn front_runner_cannot_grief_lazy_1155() {
     let salt = BytesN::from_array(&env, &[0x44u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x04u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr_bob = client.deploy_lazy_1155(
         &bob,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Bob Grief L1155"),
         &0u32,
@@ -637,7 +600,6 @@ fn front_runner_cannot_grief_lazy_1155() {
 
     let addr_alice = client.deploy_lazy_1155(
         &alice,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Alice L1155"),
         &0u32,
@@ -661,9 +623,10 @@ fn initialize_twice_fails() {
 
     let admin = Address::generate(&env);
     let fee_receiver = Address::generate(&env);
-    client.initialize(&admin, &fee_receiver, &0u32);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &fee_receiver, &0u32, &fee_token);
 
-    let result = client.try_initialize(&admin, &fee_receiver, &0u32);
+    let result = client.try_initialize(&admin, &fee_receiver, &0u32, &fee_token);
     assert_eq!(result, Err(Ok(Error::AlreadyInitialized)));
 }
 
@@ -678,15 +641,14 @@ fn deploy_without_wasm_hashes_fails() {
     let admin = Address::generate(&env);
     let fee_receiver = Address::generate(&env);
     let creator = Address::generate(&env);
-    client.initialize(&admin, &fee_receiver, &0u32);
+    let fee_token = Address::generate(&env);
+    client.initialize(&admin, &fee_receiver, &0u32, &fee_token);
 
     let salt = BytesN::from_array(&env, &[0x99u8; 32]);
-    let currency = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
 
     let result = client.try_deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "No Wasm"),
         &String::from_str(&env, "NOWASM"),
         &100u64,
@@ -767,12 +729,10 @@ fn collections_by_creator_returns_correct_collections() {
 
     let other = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0x55u8; 32]);
-    let currency = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
 
     client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator Coll"),
         &String::from_str(&env, "CRC"),
         &100u64,
@@ -849,12 +809,10 @@ fn deployed_lazy_721_rejects_invalid_ed25519_signature() {
 
     let creator_pubkey = BytesN::from_array(&env, &[1u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xA1u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Sig Test 721"),
         &String::from_str(&env, "ST7"),
@@ -891,12 +849,10 @@ fn deployed_lazy_721_rejects_expired_voucher() {
 
     let creator_pubkey = BytesN::from_array(&env, &[2u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xA2u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Expiry Test 721"),
         &String::from_str(&env, "ET7"),
@@ -941,11 +897,9 @@ fn get_collection_by_id_returns_record() {
 
     let salt = BytesN::from_array(&env, &[0xB1u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     let addr = client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Query Test"),
         &String::from_str(&env, "QT7"),
         &100u64,
@@ -983,11 +937,9 @@ fn get_creator_collections_returns_only_caller_collections() {
 
     let other = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator A"),
         &String::from_str(&env, "CA7"),
         &100u64,
@@ -998,7 +950,6 @@ fn get_creator_collections_returns_only_caller_collections() {
 
     client.deploy_normal_1155(
         &creator,
-        &currency,
         &String::from_str(&env, "Creator B"),
         &0u32,
         &royalty_receiver,
@@ -1022,11 +973,9 @@ fn get_all_collections_returns_all_deployed() {
 
     let alice = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Coll 1"),
         &String::from_str(&env, "C1"),
         &100u64,
@@ -1037,7 +986,6 @@ fn get_all_collections_returns_all_deployed() {
 
     client.deploy_normal_1155(
         &alice,
-        &currency,
         &String::from_str(&env, "Coll 2"),
         &0u32,
         &royalty_receiver,
@@ -1056,14 +1004,12 @@ fn get_collection_count_increments_per_deploy() {
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
     let creator_pubkey = BytesN::from_array(&env, &[0x05u8; 32]);
 
     assert_eq!(client.get_collection_count(), 0u64);
 
     client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Count 1"),
         &String::from_str(&env, "CNT1"),
         &100u64,
@@ -1075,7 +1021,6 @@ fn get_collection_count_increments_per_deploy() {
 
     client.deploy_lazy_1155(
         &creator,
-        &currency,
         &creator_pubkey,
         &String::from_str(&env, "Count 2"),
         &0u32,
@@ -1093,13 +1038,11 @@ fn deploy_events_include_kind_in_payload() {
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
 
     // Deploy one of each type and confirm no panic (events are emitted).
     // The soroban test SDK exposes env.events().all() to inspect events.
     let addr_n721 = client.deploy_normal_721(
         &creator,
-        &currency,
         &String::from_str(&env, "Evt 721"),
         &String::from_str(&env, "EV7"),
         &100u64,
@@ -1110,7 +1053,6 @@ fn deploy_events_include_kind_in_payload() {
 
     let addr_n1155 = client.deploy_normal_1155(
         &creator,
-        &currency,
         &String::from_str(&env, "Evt 1155"),
         &0u32,
         &royalty_receiver,
@@ -1139,8 +1081,9 @@ fn setup_launchpad_with_staking(env: &Env) -> (LaunchpadClient<'_>, Address, Add
     let admin = Address::generate(env);
     let creator = Address::generate(env);
     let fee_receiver = Address::generate(env);
+    let fee_token = Address::generate(env);
 
-    client.initialize(&admin, &fee_receiver, &0u32);
+    client.initialize(&admin, &fee_receiver, &0u32, &fee_token);
 
     let wasm_staking_bytes = wasm_bytes("nft_staking");
     let wasm_staking = env
@@ -1164,7 +1107,6 @@ fn deploys_staking_pool_for_nft_collection() {
 
     let pool_a = client.deploy_staking_pool(
         &creator,
-        &reward_token,
         &nft_address,
         &reward_token,
         &1_000_000i128,
@@ -1176,7 +1118,6 @@ fn deploys_staking_pool_for_nft_collection() {
 
     let duplicate = client.try_deploy_staking_pool(
         &creator,
-        &reward_token,
         &nft_address,
         &reward_token,
         &1_000_000i128,

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -75,10 +75,6 @@ fn setup_launchpad(env: &Env) -> (LaunchpadClient<'_>, Address, Address, Address
     (client, admin, fee_receiver, creator)
 }
 
-fn approve_currency(client: &LaunchpadClient, currency: &Address) {
-    client.add_approved_currency(currency);
-}
-
 #[test]
 fn deploys_normal_721_twice_with_unique_addresses() {
     let env = Env::default();
@@ -88,8 +84,6 @@ fn deploys_normal_721_twice_with_unique_addresses() {
     let salt_a = BytesN::from_array(&env, &[10u8; 32]);
     let salt_b = BytesN::from_array(&env, &[11u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_normal_721(
         &creator,
@@ -135,8 +129,6 @@ fn deploys_normal_1155_twice_with_unique_addresses() {
     let salt_a = BytesN::from_array(&env, &[20u8; 32]);
     let salt_b = BytesN::from_array(&env, &[21u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_normal_1155(
         &creator,
@@ -179,8 +171,6 @@ fn deploys_lazy_721_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[31u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[7u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_lazy_721(
         &creator,
@@ -229,8 +219,6 @@ fn deploys_lazy_1155_twice_with_unique_addresses() {
     let salt_b = BytesN::from_array(&env, &[41u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[9u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let deployed_a = client.deploy_lazy_1155(
         &creator,
@@ -272,8 +260,6 @@ fn deploy_calls_extend_instance_ttl() {
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     // After initialize(), instance TTL is bumped to 100_000 ledgers.
     // Move forward so remaining TTL is below threshold (50_000),
@@ -344,8 +330,6 @@ fn same_salt_different_creators_normal_721_yields_different_addresses() {
 
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_normal_721(
         &alice,
@@ -385,8 +369,6 @@ fn same_salt_different_creators_normal_1155_yields_different_addresses() {
 
     let salt = BytesN::from_array(&env, &[0xBBu8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_normal_1155(
         &alice,
@@ -419,8 +401,6 @@ fn same_salt_different_creators_lazy_721_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xCCu8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x01u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_lazy_721(
         &alice,
@@ -459,8 +439,6 @@ fn same_salt_different_creators_lazy_1155_yields_different_addresses() {
     let salt = BytesN::from_array(&env, &[0xDDu8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x02u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_alice = client.deploy_lazy_1155(
         &alice,
@@ -500,8 +478,6 @@ fn front_runner_cannot_grief_normal_721() {
 
     let salt = BytesN::from_array(&env, &[0x11u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     // Bob front-runs using Alice's raw salt.
     let addr_bob = client.deploy_normal_721(
@@ -542,8 +518,6 @@ fn front_runner_cannot_grief_normal_1155() {
 
     let salt = BytesN::from_array(&env, &[0x22u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_normal_1155(
         &bob,
@@ -576,8 +550,6 @@ fn front_runner_cannot_grief_lazy_721() {
     let salt = BytesN::from_array(&env, &[0x33u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x03u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_lazy_721(
         &bob,
@@ -616,8 +588,6 @@ fn front_runner_cannot_grief_lazy_1155() {
     let salt = BytesN::from_array(&env, &[0x44u8; 32]);
     let creator_pubkey = BytesN::from_array(&env, &[0x04u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr_bob = client.deploy_lazy_1155(
         &bob,
@@ -675,8 +645,6 @@ fn deploy_without_wasm_hashes_fails() {
     client.initialize(&admin, &fee_receiver, &0u32, &fee_token);
 
     let salt = BytesN::from_array(&env, &[0x99u8; 32]);
-    let currency = Address::generate(&env);
-    client.add_approved_currency(&currency);
     let royalty_receiver = Address::generate(&env);
 
     let result = client.try_deploy_normal_721(
@@ -761,8 +729,6 @@ fn collections_by_creator_returns_correct_collections() {
 
     let other = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0x55u8; 32]);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
     let royalty_receiver = Address::generate(&env);
 
     client.deploy_normal_721(
@@ -843,8 +809,6 @@ fn deployed_lazy_721_rejects_invalid_ed25519_signature() {
 
     let creator_pubkey = BytesN::from_array(&env, &[1u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
     let salt = BytesN::from_array(&env, &[0xA1u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
@@ -885,8 +849,6 @@ fn deployed_lazy_721_rejects_expired_voucher() {
 
     let creator_pubkey = BytesN::from_array(&env, &[2u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
     let salt = BytesN::from_array(&env, &[0xA2u8; 32]);
 
     let collection_addr = client.deploy_lazy_721(
@@ -935,8 +897,6 @@ fn get_collection_by_id_returns_record() {
 
     let salt = BytesN::from_array(&env, &[0xB1u8; 32]);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     let addr = client.deploy_normal_721(
         &creator,
@@ -977,8 +937,6 @@ fn get_creator_collections_returns_only_caller_collections() {
 
     let other = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     client.deploy_normal_721(
         &creator,
@@ -1015,8 +973,6 @@ fn get_all_collections_returns_all_deployed() {
 
     let alice = Address::generate(&env);
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     client.deploy_normal_721(
         &creator,
@@ -1049,7 +1005,6 @@ fn get_collection_count_increments_per_deploy() {
 
     let royalty_receiver = Address::generate(&env);
     let creator_pubkey = BytesN::from_array(&env, &[0x05u8; 32]);
-    approve_currency(&client, &currency);
 
     assert_eq!(client.collection_count(), 0u64);
 
@@ -1083,8 +1038,6 @@ fn deploy_events_include_kind_in_payload() {
     let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
 
     let royalty_receiver = Address::generate(&env);
-    let currency = Address::generate(&env);
-    approve_currency(&client, &currency);
 
     // Deploy one of each type and confirm no panic (events are emitted).
     // The soroban test SDK exposes env.events().all() to inspect events.
@@ -1151,7 +1104,6 @@ fn deploys_staking_pool_for_nft_collection() {
     let nft_address = Address::generate(&env);
     let reward_token = Address::generate(&env);
     let salt = BytesN::from_array(&env, &[0xAAu8; 32]);
-    approve_currency(&client, &reward_token);
 
     let pool_a =
         client.deploy_staking_pool(&creator, &nft_address, &reward_token, &1_000_000i128, &salt);

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -10,7 +10,7 @@ pub enum Error {
     WasmHashNotSet = 4,
     StakingPoolAlreadyExists = 5,
     PlatformFeeTokenNotSet = 6,
-    InvalidCurrency = 6,
+    InvalidCurrency = 7,
 }
 
 /// Which of the four collection types was deployed.

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -9,6 +9,7 @@ pub enum Error {
     NotAdmin = 3,
     WasmHashNotSet = 4,
     StakingPoolAlreadyExists = 5,
+    PlatformFeeTokenNotSet = 6,
 }
 
 /// Which of the four collection types was deployed.
@@ -37,6 +38,8 @@ pub enum DataKey {
     Admin,
     PlatformFeeReceiver,
     PlatformFeeBps,
+    PlatformFeeToken,
+    PlatformFeeToken,
     WasmNormal721,
     WasmNormal1155,
     WasmLazy721,

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -40,7 +40,6 @@ pub enum DataKey {
     PlatformFeeReceiver,
     PlatformFeeBps,
     PlatformFeeToken,
-    PlatformFeeToken,
     WasmNormal721,
     WasmNormal1155,
     WasmLazy721,

--- a/contracts/lazy_mint_erc721/src/lib.rs
+++ b/contracts/lazy_mint_erc721/src/lib.rs
@@ -489,15 +489,6 @@ impl LazyMint721 {
         env.storage()
             .persistent()
             .set(&DataKey::BalanceOf(from.clone()), &(from_bal - 1));
-        let from_bal: u64 = env
-            .storage()
-            .persistent()
-            .get(&DataKey::BalanceOf(from.clone()))
-            .unwrap_or(0);
-        env.storage().persistent().set(
-            &DataKey::BalanceOf(from.clone()),
-            &(from_bal.saturating_sub(1)),
-        );
         env.storage().persistent().extend_ttl(
             &DataKey::BalanceOf(from.clone()),
             TTL_THRESHOLD,

--- a/contracts/royalty-splitter/src/contract.rs
+++ b/contracts/royalty-splitter/src/contract.rs
@@ -21,7 +21,7 @@ impl RoyaltySplitter {
         if is_initialized(&env) {
             panic_with_error!(&env, SplitterError::AlreadyInitialized);
         }
-        if beneficiaries.len() == 0 {
+        if beneficiaries.is_empty() {
             panic_with_error!(&env, SplitterError::NoBeneficiaries);
         }
         if beneficiaries.len() > MAX_BENEFICIARIES {
@@ -70,7 +70,7 @@ impl RoyaltySplitter {
             let share = shares.get(i).unwrap() as i128;
             let amount = balance * share / 10_000;
             if amount > 0 {
-                token_client.transfer(&contract_addr, &beneficiaries.get(i).unwrap(), &amount);
+                token_client.transfer(&contract_addr, beneficiaries.get(i).unwrap(), &amount);
                 distributed += amount;
             }
         }

--- a/contracts/soroban-marketplace/src/contract.rs
+++ b/contracts/soroban-marketplace/src/contract.rs
@@ -618,7 +618,7 @@ impl MarketplaceContract {
         if let Some(prev) = auction.highest_bidder.clone() {
             token_client.transfer(&env.current_contract_address(), &prev, &auction.highest_bid);
         }
-        token_client.transfer(&bidder, &env.current_contract_address(), &amount);
+        token_client.transfer(&bidder, env.current_contract_address(), &amount);
         auction.highest_bid = amount;
         auction.highest_bidder = Some(bidder.clone());
         save_auction(&env, &auction);
@@ -657,11 +657,9 @@ impl MarketplaceContract {
         }
 
         // Time check
-        if env.ledger().timestamp() < auction.end_time {
-            if caller != auction.creator {
-                release_auction_lock(&env, auction_id);
-                panic_with_error!(&env, MarketplaceError::Unauthorized);
-            }
+        if env.ledger().timestamp() < auction.end_time && caller != auction.creator {
+            release_auction_lock(&env, auction_id);
+            panic_with_error!(&env, MarketplaceError::Unauthorized);
         }
 
         let (finalized_winner, finalized_amount) =
@@ -731,7 +729,7 @@ impl MarketplaceContract {
         if amount <= 0 {
             panic_with_error!(&env, MarketplaceError::InsufficientOfferAmount);
         }
-        TokenClient::new(&env, &token).transfer(&offerer, &env.current_contract_address(), &amount);
+        TokenClient::new(&env, &token).transfer(&offerer, env.current_contract_address(), &amount);
         let offer_id = increment_offer_count(&env);
         save_offer(
             &env,
@@ -1019,7 +1017,7 @@ impl MarketplaceContract {
     ) {
         let token = TokenClient::new(env, token_addr);
         if transfer_from_buyer {
-            token.transfer(buyer, &env.current_contract_address(), &amount);
+            token.transfer(buyer, env.current_contract_address(), &amount);
         }
         let mut payout = amount;
 

--- a/contracts/soroban-marketplace/src/events.rs
+++ b/contracts/soroban-marketplace/src/events.rs
@@ -1,6 +1,6 @@
 // events.rs — Defines all contract event schemas for Afristore Marketplace
 
-use soroban_sdk::{contracttype, symbol_short, Address, Bytes, Env, Symbol};
+use soroban_sdk::{contracttype, symbol_short, Address, Env, Symbol};
 
 // Versioned event topics as Symbol constants
 pub const LISTING_CREATED: Symbol = symbol_short!("lst_crtd");

--- a/contracts/soroban-marketplace/src/types.rs
+++ b/contracts/soroban-marketplace/src/types.rs
@@ -1,5 +1,5 @@
 // types.rs
-use soroban_sdk::{contracterror, contracttype, Address, Bytes, Symbol};
+use soroban_sdk::{contracterror, contracttype, Address, Symbol};
 
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/frontend/afristore-app/src/__tests__/launchpad-client.test.ts
+++ b/frontend/afristore-app/src/__tests__/launchpad-client.test.ts
@@ -28,7 +28,6 @@ describe("Launchpad Client", () => {
 
     await deployNormal721(
       mockCreator,
-      mockCurrency,
       "Test Collection",
       "TEST",
       1000,
@@ -48,15 +47,15 @@ describe("Launchpad Client", () => {
     const args = (invokeContract as jest.Mock).mock.calls[0][2] as xdr.ScVal[];
 
     // Check name
-    expect(scValToNative(args[2])).toBe("Test Collection");
+    expect(scValToNative(args[1])).toBe("Test Collection");
     // Check symbol
-    expect(scValToNative(args[3])).toBe("TEST");
+    expect(scValToNative(args[2])).toBe("TEST");
     // Check maxSupply
-    expect(scValToNative(args[4])).toBe(1000n);
+    expect(scValToNative(args[3])).toBe(1000n);
     // Check royaltyBps
-    expect(scValToNative(args[5])).toBe(500);
+    expect(scValToNative(args[4])).toBe(500);
     // Check salt
-    expect(scValToNative(args[7])).toEqual(Uint8Array.from(mockSalt));
+    expect(scValToNative(args[6])).toEqual(Uint8Array.from(mockSalt));
   });
 
   it("handles errors from invokeContract", async () => {
@@ -67,7 +66,6 @@ describe("Launchpad Client", () => {
     await expect(
       deployNormal721(
         mockCreator,
-        mockCurrency,
         "Test",
         "T",
         100,

--- a/frontend/afristore-app/src/app/staking/setup/page.tsx
+++ b/frontend/afristore-app/src/app/staking/setup/page.tsx
@@ -93,7 +93,6 @@ export default function StakingSetupPage() {
 
       const poolAddress = await deployStakingPool(
         publicKey,
-        token.address, // currency
         lookupAddress,
         token.address, // reward token
         rateStroops,

--- a/frontend/afristore-app/src/components/CheckoutModal.tsx
+++ b/frontend/afristore-app/src/components/CheckoutModal.tsx
@@ -23,18 +23,21 @@ export function CheckoutModal({
   isBuyingCrypto,
 }: CheckoutModalProps) {
   const [method, setMethod] = useState<"crypto" | "fiat">("crypto");
+  const [quantity, setQuantity] = useState(1);
 
   if (!isOpen) return null;
 
   const priceXlm = Number(stroopsToXlm(listing.price));
-  const estimatedFiat = (priceXlm * 0.12).toFixed(2);
+  const totalPriceXlm = priceXlm * quantity;
+  const estimatedFiat = (totalPriceXlm * 0.12).toFixed(2);
 
   const handleCryptoPurchase = async () => {
     const success = await onCryptoPurchase();
     if (success) {
       posthog.capture("Purchase Successful", {
         listing_id: listing.listing_id,
-        price_xlm: priceXlm,
+        price_xlm: totalPriceXlm,
+        quantity,
         method: "crypto",
       });
       onPurchased?.();
@@ -66,13 +69,35 @@ export function CheckoutModal({
         <div className="p-6">
           <div className="mb-6 flex justify-between rounded-2xl bg-gray-50 p-4">
             <div>
-              <p className="text-sm text-gray-500">Total Price</p>
-              <p className="font-display text-2xl font-bold text-gray-900">
+              <p className="text-sm text-gray-500">Unit Price</p>
+              <p className="font-display text-lg font-bold text-gray-700">
                 {priceXlm} XLM
               </p>
+              <p className="text-sm text-gray-500 mt-1">Quantity</p>
+              <div className="flex items-center gap-3 mt-1">
+                <button
+                  onClick={() => setQuantity((q) => Math.max(1, q - 1))}
+                  className="rounded-lg bg-gray-200 px-3 py-1 text-sm font-bold hover:bg-gray-300 transition"
+                >
+                  -
+                </button>
+                <span className="font-display text-lg font-bold text-gray-900 min-w-[2ch] text-center">
+                  {quantity}
+                </span>
+                <button
+                  onClick={() => setQuantity((q) => q + 1)}
+                  className="rounded-lg bg-gray-200 px-3 py-1 text-sm font-bold hover:bg-gray-300 transition"
+                >
+                  +
+                </button>
+              </div>
             </div>
             <div className="text-right">
-              <p className="text-sm text-gray-500">Estimated</p>
+              <p className="text-sm text-gray-500">Total Price</p>
+              <p className="font-display text-2xl font-bold text-gray-900">
+                {totalPriceXlm} XLM
+              </p>
+              <p className="text-sm text-gray-500 mt-1">Estimated</p>
               <p className="font-display text-xl font-bold text-brand-500">
                 ~${estimatedFiat}
               </p>
@@ -114,7 +139,7 @@ export function CheckoutModal({
                   <Loader2 className="animate-spin" size={18} /> Processing...
                 </>
               ) : (
-                `Pay ${priceXlm} XLM`
+                `Pay ${totalPriceXlm} XLM`
               )}
             </button>
           </div>

--- a/frontend/afristore-app/src/components/CollectionForm.tsx
+++ b/frontend/afristore-app/src/components/CollectionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   useDeployCollection,
   DeployCollectionInput,
@@ -9,6 +9,8 @@ import { useWalletContext } from "@/context/WalletContext";
 import { Loader2, Rocket, CheckCircle, ArrowRight, Info, ChevronDown } from "lucide-react";
 import { GuardButton } from "./WalletGuard";
 import { CollectionKind } from "@/lib/launchpad";
+import { useSupportedTokens } from "@/hooks/useSupportedTokens";
+import { getDefaultSupportedToken } from "@/lib/token-support";
 
 const SPLITTER_TOOLTIP =
   "If you want to split royalties with multiple people, paste your deployed Royalty Splitter contract address here, or deploy one first via Launchpad → Royalty Splitter.";
@@ -45,6 +47,8 @@ function isStellarAddress(v: string) {
 export function CollectionForm() {
   const { publicKey } = useWalletContext();
   const { deploy, isDeploying, error } = useDeployCollection(publicKey);
+  const { tokens: supportedTokens } = useSupportedTokens();
+  const hasSupportedTokens = supportedTokens.length > 0;
 
   const [successAddress, setSuccessAddress] = useState<string | null>(null);
 
@@ -59,6 +63,7 @@ export function CollectionForm() {
     maxSupply: 10000,
     royaltyBps: 500, // 5%
     royaltyReceiver: publicKey || "",
+    currencyAddress: "",
   });
 
   useEffect(() => {

--- a/frontend/afristore-app/src/components/CollectionForm.tsx
+++ b/frontend/afristore-app/src/components/CollectionForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import {
   useDeployCollection,
   DeployCollectionInput,
@@ -9,15 +9,10 @@ import { useWalletContext } from "@/context/WalletContext";
 import { Loader2, Rocket, CheckCircle, ArrowRight } from "lucide-react";
 import { GuardButton } from "./WalletGuard";
 import { CollectionKind } from "@/lib/launchpad";
-import { DEFAULT_TOKEN } from "@/config/tokens";
-import { useSupportedTokens } from "@/hooks/useSupportedTokens";
-import { getDefaultSupportedToken } from "@/lib/token-support";
 
 export function CollectionForm() {
   const { publicKey } = useWalletContext();
   const { deploy, isDeploying, error } = useDeployCollection(publicKey);
-  const { tokens: supportedTokens } = useSupportedTokens();
-  const hasSupportedTokens = supportedTokens.length > 0;
 
   const [successAddress, setSuccessAddress] = useState<string | null>(null);
   const [form, setForm] = useState({
@@ -27,23 +22,7 @@ export function CollectionForm() {
     maxSupply: 10000,
     royaltyBps: 500, // 5%
     royaltyReceiver: publicKey || "",
-    currencyAddress: DEFAULT_TOKEN.address,
   });
-
-  useEffect(() => {
-    if (supportedTokens.length === 0) {
-      return;
-    }
-
-    if (
-      !supportedTokens.some((token) => token.address === form.currencyAddress)
-    ) {
-      setForm((current) => ({
-        ...current,
-        currencyAddress: getDefaultSupportedToken(supportedTokens).address,
-      }));
-    }
-  }, [form.currencyAddress, supportedTokens]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -53,6 +32,25 @@ export function CollectionForm() {
       ...form,
       royaltyReceiver: form.royaltyReceiver || publicKey,
     };
+
+    // If it's a lazy collection, we need the pubkey bytes
+    if (form.kind.startsWith("LazyMint")) {
+      try {
+        // Dynamically import StrKey to avoid Node deps in initial bundle
+        const sdk = await import("@stellar/stellar-sdk");
+        const decoded = sdk.StrKey.decodeEd25519PublicKey(publicKey);
+        input.creatorPubkeyBytes = Buffer.from(decoded);
+      } catch (err) {
+        console.error("Failed to decode public key", err);
+        return;
+      }
+    }
+
+    const addr = await deploy(input);
+    if (addr) {
+      setSuccessAddress(addr);
+    }
+  };
 
     // If it's a lazy collection, we need the pubkey bytes
     if (form.kind.startsWith("LazyMint")) {
@@ -249,31 +247,6 @@ export function CollectionForm() {
               </div>
             </div>
 
-            <div className="space-y-2">
-              <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
-                Fee Payment Token *
-              </label>
-              <select
-                required
-                disabled={!hasSupportedTokens}
-                value={form.currencyAddress}
-                onChange={(e) =>
-                  setForm({ ...form, currencyAddress: e.target.value })
-                }
-                className="w-full appearance-none rounded-2xl border border-gray-200 bg-gray-50/50 px-5 py-4 text-base focus:border-brand-500 focus:bg-white focus:outline-none transition-all shadow-sm font-inter"
-              >
-                {hasSupportedTokens ? (
-                  supportedTokens.map((token) => (
-                    <option key={token.address} value={token.address}>
-                      {token.name} ({token.symbol})
-                    </option>
-                  ))
-                ) : (
-                  <option value="">No supported tokens available</option>
-                )}
-              </select>
-            </div>
-
             <div className="sm:col-span-2 space-y-2">
               <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
                 Royalty Receiver Address
@@ -297,7 +270,7 @@ export function CollectionForm() {
 
           <GuardButton
             type="submit"
-            disabled={isDeploying || !hasSupportedTokens}
+            disabled={isDeploying}
             actionName="to deploy your collection"
             className="w-full flex items-center justify-center gap-3 rounded-2xl bg-brand-500 py-5 text-xl font-bold text-white shadow-2xl shadow-brand-500/30 hover:bg-brand-600 hover:scale-[1.01] transition-all active:scale-[0.98] disabled:opacity-50 disabled:hover:scale-100"
           >

--- a/frontend/afristore-app/src/components/CollectionForm.tsx
+++ b/frontend/afristore-app/src/components/CollectionForm.tsx
@@ -115,25 +115,6 @@ export function CollectionForm() {
     }
   };
 
-    // If it's a lazy collection, we need the pubkey bytes
-    if (form.kind.startsWith("LazyMint")) {
-      try {
-        // Dynamically import StrKey to avoid Node deps in initial bundle
-        const sdk = await import("@stellar/stellar-sdk");
-        const decoded = sdk.StrKey.decodeEd25519PublicKey(publicKey);
-        input.creatorPubkeyBytes = Buffer.from(decoded);
-      } catch (err) {
-        console.error("Failed to decode public key", err);
-        return;
-      }
-    }
-
-    const addr = await deploy(input);
-    if (addr) {
-      setSuccessAddress(addr);
-    }
-  };
-
   if (successAddress) {
     return (
       <div className="max-w-xl mx-auto flex flex-col items-center gap-6 rounded-3xl border border-green-100 bg-white p-12 text-center shadow-2xl shadow-green-900/5">

--- a/frontend/afristore-app/src/components/ListingForm.tsx
+++ b/frontend/afristore-app/src/components/ListingForm.tsx
@@ -66,6 +66,7 @@ export function ListingForm({
     collectionAddress: prefilledCollectionAddress || "",
     nftTokenId: prefilledTokenId !== undefined ? prefilledTokenId : 0,
     price: 10,
+    amount: 1,
     tokenAddress: DEFAULT_TOKEN.address,
   });
   const [successId, setSuccessId] = useState<number | null>(null);
@@ -94,6 +95,7 @@ export function ListingForm({
             collectionAddress: listing.collection,
             nftTokenId: Number(listing.token_id),
             price: parseFloat(stroopsToXlm(listing.price)),
+            amount: 1,
             tokenAddress: listing.token,
           });
         })
@@ -174,6 +176,7 @@ export function ListingForm({
                   collectionAddress: "",
                   nftTokenId: 0,
                   price: 10,
+                  amount: 1,
                   tokenAddress: defaultToken.address,
                 });
               }}
@@ -242,6 +245,25 @@ export function ListingForm({
               />
             </div>
 
+            <div className="sm:col-span-2 space-y-2">
+              <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
+                Amount (ERC-1155 Quantity)
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={form.amount}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    amount: Math.max(1, parseInt(e.target.value) || 1),
+                  })
+                }
+                className="w-full rounded-2xl border border-gray-200 bg-gray-50/50 px-5 py-4 text-base focus:border-brand-500 focus:bg-white focus:outline-none transition-all shadow-sm font-inter"
+                placeholder="Number of copies to list (default: 1)"
+              />
+            </div>
+
             <div className="space-y-2">
               <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
                 Price ({selectedToken.symbol}) *
@@ -262,6 +284,22 @@ export function ListingForm({
                   {selectedToken.symbol}
                 </span>
               </div>
+            </div>
+
+            <div className="space-y-2">
+              <label className="block text-sm font-bold text-gray-950 uppercase tracking-wider font-inter">
+                Amount *
+              </label>
+              <input
+                required
+                type="number"
+                min={1}
+                value={form.amount}
+                onChange={(e) =>
+                  setForm({ ...form, amount: parseInt(e.target.value) || 1 })
+                }
+                className="w-full rounded-2xl border border-gray-200 bg-gray-50/50 px-5 py-4 text-base focus:border-brand-500 focus:bg-white focus:outline-none transition-all shadow-sm font-inter"
+              />
             </div>
 
             <div className="space-y-2">

--- a/frontend/afristore-app/src/hooks/useLaunchpad.ts
+++ b/frontend/afristore-app/src/hooks/useLaunchpad.ts
@@ -13,7 +13,6 @@ import {
   CollectionMetadata,
   CollectionKind,
 } from "@/lib/launchpad";
-import { assertSupportedTokenAddress } from "@/lib/token-support";
 
 const COLLECTIONS_PAGE_SIZE = 50;
 
@@ -140,7 +139,6 @@ export interface DeployCollectionInput {
   maxSupply?: number; // only for 721
   royaltyBps: number;
   royaltyReceiver: string;
-  currencyAddress: string;
   creatorPubkeyBytes?: Buffer; // only for Lazy
 }
 
@@ -159,10 +157,6 @@ export function useDeployCollection(creatorPublicKey: string | null) {
       setError(null);
 
       try {
-        const token = await assertSupportedTokenAddress(
-          input.currencyAddress,
-          "collection",
-        );
         const salt = Buffer.alloc(32); // Simple salt for now, can be randomized
         window.crypto.getRandomValues(salt);
 
@@ -172,7 +166,6 @@ export function useDeployCollection(creatorPublicKey: string | null) {
           case "Normal721":
             address = await deployNormal721(
               creatorPublicKey,
-              token.address,
               input.name,
               input.symbol || "",
               input.maxSupply || 0,
@@ -184,7 +177,6 @@ export function useDeployCollection(creatorPublicKey: string | null) {
           case "Normal1155":
             address = await deployNormal1155(
               creatorPublicKey,
-              token.address,
               input.name,
               input.royaltyBps,
               input.royaltyReceiver,
@@ -196,7 +188,6 @@ export function useDeployCollection(creatorPublicKey: string | null) {
               throw new Error("Missing creator pubkey bytes");
             address = await deployLazy721(
               creatorPublicKey,
-              token.address,
               input.creatorPubkeyBytes,
               input.name,
               input.symbol || "",
@@ -211,7 +202,6 @@ export function useDeployCollection(creatorPublicKey: string | null) {
               throw new Error("Missing creator pubkey bytes");
             address = await deployLazy1155(
               creatorPublicKey,
-              token.address,
               input.creatorPubkeyBytes,
               input.name,
               input.royaltyBps,

--- a/frontend/afristore-app/src/hooks/useMarketplace.ts
+++ b/frontend/afristore-app/src/hooks/useMarketplace.ts
@@ -146,6 +146,7 @@ export interface CreateListingInput {
   collectionAddress: string;
   nftTokenId: number;
   price: number;
+  amount: number;
   tokenAddress?: string;
 }
 

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -48,7 +48,6 @@ function toAddressScVal(address: string): xdr.ScVal {
  */
 export async function deployNormal721(
   creatorPublicKey: string,
-  currencyAddress: string,
   name: string,
   symbol: string,
   maxSupply: number,
@@ -58,7 +57,6 @@ export async function deployNormal721(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
-    toAddressScVal(currencyAddress),
     nativeToScVal(name, { type: "string" }),
     nativeToScVal(symbol, { type: "string" }),
     nativeToScVal(BigInt(maxSupply), { type: "u64" }),
@@ -82,7 +80,6 @@ export async function deployNormal721(
  */
 export async function deployNormal1155(
   creatorPublicKey: string,
-  currencyAddress: string,
   name: string,
   royaltyBps: number,
   royaltyReceiver: string,
@@ -90,7 +87,6 @@ export async function deployNormal1155(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
-    toAddressScVal(currencyAddress),
     nativeToScVal(name, { type: "string" }),
     nativeToScVal(royaltyBps, { type: "u32" }),
     toAddressScVal(royaltyReceiver),
@@ -112,7 +108,6 @@ export async function deployNormal1155(
  */
 export async function deployLazy721(
   creatorPublicKey: string,
-  currencyAddress: string,
   creatorPubkeyBytes: Buffer, // 32 bytes
   name: string,
   symbol: string,
@@ -123,7 +118,6 @@ export async function deployLazy721(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
-    toAddressScVal(currencyAddress),
     nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
     nativeToScVal(name, { type: "string" }),
     nativeToScVal(symbol, { type: "string" }),
@@ -148,7 +142,6 @@ export async function deployLazy721(
  */
 export async function deployLazy1155(
   creatorPublicKey: string,
-  currencyAddress: string,
   creatorPubkeyBytes: Buffer,
   name: string,
   royaltyBps: number,
@@ -157,7 +150,6 @@ export async function deployLazy1155(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
-    toAddressScVal(currencyAddress),
     nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
     nativeToScVal(name, { type: "string" }),
     nativeToScVal(royaltyBps, { type: "u32" }),
@@ -265,7 +257,6 @@ export async function getStakingPoolByNft(
  */
 export async function deployStakingPool(
   creatorPublicKey: string,
-  currencyAddress: string,
   nftAddress: string,
   rewardToken: string,
   rewardRate: bigint,
@@ -273,7 +264,6 @@ export async function deployStakingPool(
 ): Promise<string> {
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
-    toAddressScVal(currencyAddress),
     toAddressScVal(nftAddress),
     toAddressScVal(rewardToken),
     nativeToScVal(rewardRate, { type: "i128" }),
@@ -423,17 +413,27 @@ export async function getCollectionMetadata(
 }
 
 /**
- * Mint a new NFT in a Normal 721 collection.
+ * deploy_lazy_721
  */
-export async function mint721(
+export async function deployLazy721(
   creatorPublicKey: string,
-  collectionAddress: string,
-  recipient: string,
-  metadataCid: string,
-): Promise<number> {
+  creatorPubkeyBytes: Buffer, // 32 bytes
+  name: string,
+  symbol: string,
+  maxSupply: number,
+  royaltyBps: number,
+  royaltyReceiver: string,
+  salt: Buffer,
+): Promise<string> {
   const args: xdr.ScVal[] = [
-    toAddressScVal(recipient),
-    nativeToScVal(metadataCid, { type: "string" }),
+    toAddressScVal(creatorPublicKey),
+    nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
+    nativeToScVal(name, { type: "string" }),
+    nativeToScVal(symbol, { type: "string" }),
+    nativeToScVal(BigInt(maxSupply), { type: "u64" }),
+    nativeToScVal(royaltyBps, { type: "u32" }),
+    toAddressScVal(royaltyReceiver),
+    nativeToScVal(Uint8Array.from(salt), { type: "bytes" }),
   ];
 
   const retVal = await invokeContract(

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -444,28 +444,25 @@ export async function getCollectionMetadata(
   };
 }
 
+function mapKeySymbol(name: string, val: xdr.ScVal): xdr.ScMapEntry {
+  return new xdr.ScMapEntry({
+    key: nativeToScVal(name, { type: "symbol" }),
+    val,
+  });
+}
+
 /**
- * deploy_lazy_721
+ * mint721 — Mint a single token in a Normal 721 collection.
  */
-export async function deployLazy721(
+export async function mint721(
   creatorPublicKey: string,
-  creatorPubkeyBytes: Buffer, // 32 bytes
-  name: string,
-  symbol: string,
-  maxSupply: number,
-  royaltyBps: number,
-  royaltyReceiver: string,
-  salt: Buffer,
-): Promise<string> {
+  collectionAddress: string,
+  recipient: string,
+  uri: string,
+): Promise<number> {
   const args: xdr.ScVal[] = [
-    toAddressScVal(creatorPublicKey),
-    nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
-    nativeToScVal(name, { type: "string" }),
-    nativeToScVal(symbol, { type: "string" }),
-    nativeToScVal(BigInt(maxSupply), { type: "u64" }),
-    nativeToScVal(royaltyBps, { type: "u32" }),
-    toAddressScVal(royaltyReceiver),
-    nativeToScVal(Uint8Array.from(salt), { type: "bytes" }),
+    toAddressScVal(recipient),
+    nativeToScVal(uri, { type: "string" }),
   ];
 
   const retVal = await invokeContract(
@@ -476,13 +473,6 @@ export async function deployLazy721(
     collectionAddress,
   );
   return Number(scValToNative(retVal));
-}
-
-function mapKeySymbol(name: string, val: xdr.ScVal): xdr.ScMapEntry {
-  return new xdr.ScMapEntry({
-    key: nativeToScVal(name, { type: "symbol" }),
-    val,
-  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- **#442 — Launchpad Spoofable Platform Fees**: Removed the user-supplied `currency` parameter from all deploy functions. The platform fee token is now set globally by the admin via `initialize()` or `set_platform_fee_token()`. Deploy functions read the token from on-chain storage, preventing malicious users from bypassing fees with worthless tokens.
- **#440 — Lazy Mint 721 Double Balance Deduction**: Fixed `_transfer` in `lazy_mint_erc721/src/lib.rs` which was reading and decrementing the sender's balance twice (once via subtraction, once via `saturating_sub`). Every transfer was deducting 2 balance instead of 1.
- **#443 — Obsolete Launchpad Fee Token Input**: Removed the "Fee Payment Token" dropdown from `CollectionForm.tsx` and stripped the `currencyAddress` parameter from all frontend deploy functions, matching the contract-level fix in #442.
- **#444 — Missing ERC-1155 Quantity Inputs**: Added an amount numerical input to `ListingForm.tsx` for specifying how many ERC-1155 copies to list, and added a quantity selector with +/- buttons and dynamic total price calculation to `CheckoutModal.tsx`.
## Changes
### Contracts
- `contracts/launchpad/src/contract.rs` — Removed `currency` param from 5 deploy functions; added `set_platform_fee_token` admin function; added `platform_fee_token` view; added `PlatformFeeToken` to `initialize`
- `contracts/launchpad/src/storage.rs` — Added `set_platform_fee_token` / `get_platform_fee_token` helpers
- `contracts/launchpad/src/types.rs` — Added `PlatformFeeToken` data key and `PlatformFeeTokenNotSet` error variant
- `contracts/launchpad/src/test.rs` — Updated all test calls to match new function signatures
- `contracts/lazy_mint_erc721/src/lib.rs` — Removed redundant second balance decrement in `_transfer`
### Frontend
- `frontend/afristore-app/src/components/CollectionForm.tsx` — Removed Fee Payment Token dropdown and unused imports
- `frontend/afristore-app/src/components/ListingForm.tsx` — Added ERC-1155 amount input
- `frontend/afristore-app/src/components/CheckoutModal.tsx` — Added quantity selector with dynamic pricing
- `frontend/afristore-app/src/hooks/useLaunchpad.ts` — Removed `currencyAddress` from `DeployCollectionInput`
- `frontend/afristore-app/src/hooks/useMarketplace.ts` — Added `amount` to `CreateListingInput`
- `frontend/afristore-app/src/lib/launchpad.ts` — Removed `currencyAddress` from all deploy functions

## Fixes 
closes #440 
closes #442 
closes #443 
closes #444 