### PR TITLE
Contracts archiving due to keep-alive bot only simulating TTL bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ checksum = "2bfcf67fea2815c2fc3b90873fae90957be12ff417335dfadc7f52927feb03b2"
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "ff"

--- a/indexer/src/crank.ts
+++ b/indexer/src/crank.ts
@@ -1,88 +1,182 @@
-import { rpc, Contract, TransactionBuilder, Keypair, Account } from '@stellar/stellar-sdk';
+import {
+  rpc,
+  TransactionBuilder,
+  Keypair,
+  Account,
+  Operation,
+  StrKey,
+  xdr,
+} from '@stellar/stellar-sdk';
 import prisma from './db.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
 
 const RPC_URL = process.env.STELLAR_RPC_URL || 'https://soroban-testnet.stellar.org';
-const NETWORK_PASSPHRASE = process.env.STELLAR_NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015';
+const NETWORK_PASSPHRASE =
+  process.env.STELLAR_NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015';
 const MARKETPLACE_CONTRACT_ID = process.env.MARKETPLACE_CONTRACT_ID;
 const LAUNCHPAD_CONTRACT_ID = process.env.LAUNCHPAD_CONTRACT_ID;
-// Run every 5 minutes by default
-const CRANK_INTERVAL_MS = parseInt(process.env.CRANK_INTERVAL_MS || '300000'); 
+const CRANK_SECRET_KEY = process.env.CRANK_SECRET_KEY;
+const CRANK_INTERVAL_MS = parseInt(process.env.CRANK_INTERVAL_MS || '300000');
+const EXTEND_LEDGERS = 500_000;
 
 const rpcServer = new rpc.Server(RPC_URL, { allowHttp: false });
 
-/**
- * Simulates a simple read operation on the contract to ensure its state is
- * loaded by the RPC, preventing archiving due to inactivity.
- */
-async function simulateRead(contractId: string, functionName: string) {
-  if (!contractId) return;
+function contractIdToLedgerKey(contractId: string): xdr.LedgerKey {
+  const contractBytes = StrKey.decodeContract(contractId);
+  const scAddress = xdr.ScAddress.scAddressTypeContract(contractBytes as unknown as xdr.Hash);
+  return xdr.LedgerKey.contractData(
+    new xdr.LedgerKeyContractData({
+      contract: scAddress,
+      key: xdr.ScVal.scvLedgerKeyContractInstance(),
+      durability: xdr.ContractDataDurability.persistent(),
+    }),
+  );
+}
+
+async function ensureCrankKeypair(): Promise<Keypair> {
+  if (CRANK_SECRET_KEY) {
+    return Keypair.fromSecret(CRANK_SECRET_KEY);
+  }
+
+  const keypair = Keypair.random();
+  const pubKey = keypair.publicKey();
+  console.log(`[Crank] No CRANK_SECRET_KEY set. Generated ephemeral keypair: ${pubKey}`);
+
   try {
-    const contract = new Contract(contractId);
-    const dummy = Keypair.random();
-    const account = await rpcServer.getAccount(dummy.publicKey()).catch(() => new Account(dummy.publicKey(), "0"));
-    
+    await rpcServer.getAccount(pubKey);
+    return keypair;
+  } catch {
+    // Account doesn't exist — fund via Testnet Friendbot
+  }
+
+  try {
+    const res = await fetch(`https://friendbot-testnet.stellar.org?addr=${pubKey}`, {
+      method: 'GET',
+    });
+    const body: any = await res.json();
+    if (body?.hash) {
+      console.log(`[Crank] Funded ephemeral keypair via Friendbot (tx: ${body.hash})`);
+    }
+  } catch (err) {
+    console.error(`[Crank] Friendbot funding failed for ${pubKey}:`, err);
+    throw err;
+  }
+
+  return keypair;
+}
+
+async function bumpContractTtl(contractId: string, crankKeypair: Keypair) {
+  if (!contractId) return;
+
+  try {
+    const account = await rpcServer.getAccount(crankKeypair.publicKey());
+    const currentLedger = (await rpcServer.getLatestLedger()).sequence;
+    const extendTo = currentLedger + EXTEND_LEDGERS;
+
+    const ledgerKey = contractIdToLedgerKey(contractId);
+
+    const footprint = new xdr.LedgerFootprint({
+      readOnly: [ledgerKey],
+      readWrite: [],
+    });
+
+    const resources = new xdr.SorobanResources({
+      footprint,
+      instructions: 0,
+      diskReadBytes: 0,
+      writeBytes: 0,
+    });
+
+    const sorobanData = new xdr.SorobanTransactionData({
+      ext: new xdr.SorobanTransactionDataExt(0),
+      resources,
+      resourceFee: xdr.Int64.fromString('0'),
+    });
+
     const tx = new TransactionBuilder(account, {
-      fee: "10000",
+      fee: '10000',
       networkPassphrase: NETWORK_PASSPHRASE,
+      sorobanData,
     })
-      .addOperation(contract.call(functionName))
+      .addOperation(Operation.extendFootprintTtl({ extendTo }))
       .setTimeout(30)
       .build();
 
     const simResult = await rpcServer.simulateTransaction(tx);
-    if (rpc.Api.isSimulationSuccess(simResult)) {
-        console.log(`[Crank] Pinged ${contractId} via ${functionName}. Status: Success`);
+
+    if (!rpc.Api.isSimulationSuccess(simResult)) {
+      console.error(`[Crank] Simulation failed for ${contractId}`);
+      return;
+    }
+
+    const assembled = rpc.assembleTransaction(tx, simResult).build();
+    assembled.sign(crankKeypair);
+
+    const submitResult = await rpcServer.sendTransaction(assembled);
+
+    if (submitResult.status === 'ERROR') {
+      console.error(`[Crank] Submit error for ${contractId}:`, submitResult.errorResult);
+      return;
+    }
+
+    // Poll for completion
+    let txResult = await rpcServer.getTransaction(submitResult.hash);
+    while (txResult.status === rpc.Api.GetTransactionStatus.NOT_FOUND) {
+      await new Promise((r) => setTimeout(r, 1000));
+      txResult = await rpcServer.getTransaction(submitResult.hash);
+    }
+
+    if (txResult.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+      console.log(`[Crank] TTL bumped for ${contractId} to ledger ${extendTo}`);
     } else {
-        console.log(`[Crank] Pinged ${contractId} via ${functionName}. Status: Error (but footprint loaded)`);
+      console.error(`[Crank] TTL bump failed for ${contractId}:`, txResult);
     }
   } catch (err) {
-    console.error(`[Crank] Failed to ping contract ${contractId}:`, err);
+    console.error(`[Crank] Failed to bump TTL for ${contractId}:`, err);
   }
 }
 
 async function runCrank() {
   console.log(`[Crank] Starting keep-alive bot. Interval: ${CRANK_INTERVAL_MS}ms`);
 
+  const crankKeypair = await ensureCrankKeypair();
+
   while (true) {
     try {
-      console.log(`[Crank] Running keep-alive ping...`);
+      console.log(`[Crank] Running TTL extension cycle...`);
+
       if (MARKETPLACE_CONTRACT_ID) {
-        // get_protocol_fee is a read-only fn on marketplace
-        await simulateRead(MARKETPLACE_CONTRACT_ID, "get_protocol_fee");
+        await bumpContractTtl(MARKETPLACE_CONTRACT_ID, crankKeypair);
       }
 
       if (LAUNCHPAD_CONTRACT_ID) {
-        // get_platform_fee is a read-only fn on the launchpad
-        await simulateRead(LAUNCHPAD_CONTRACT_ID, "get_platform_fee");
+        await bumpContractTtl(LAUNCHPAD_CONTRACT_ID, crankKeypair);
       }
-      
-      // Ping a few recent active collections to keep them alive too
+
       const recentCollections = await prisma.collection.findMany({
         take: 20,
-        orderBy: { deployedAtLedger: 'desc' }
+        orderBy: { deployedAtLedger: 'desc' },
       });
+
       for (const col of recentCollections) {
-        // name is a standard read-only fn on NFT collections
-        await simulateRead(col.contractAddress, "name");
+        await bumpContractTtl(col.contractAddress, crankKeypair);
       }
     } catch (err) {
       console.error(`[Crank] Error during keep-alive iteration:`, err);
     }
-    
-    await new Promise(resolve => setTimeout(resolve, CRANK_INTERVAL_MS));
+
+    await new Promise((resolve) => setTimeout(resolve, CRANK_INTERVAL_MS));
   }
 }
 
-// Handle graceful shutdown
 let shuttingDown = false;
 const shutdown = () => {
-    if (shuttingDown) return;
-    shuttingDown = true;
-    console.log('[Crank] Shutting down');
-    prisma.$disconnect().finally(() => process.exit(0));
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log('[Crank] Shutting down');
+  prisma.$disconnect().finally(() => process.exit(0));
 };
 
 process.on('SIGINT', shutdown);


### PR DESCRIPTION
This pull request significantly refactors and enhances the contract keep-alive "crank" logic in `indexer/src/crank.ts`. The main improvement is switching from simulating read operations to actively extending the TTL (time-to-live) of contract data using the `extendFootprintTtl` operation. It also introduces robust key management for the crank bot and improves error handling and logging.
close #450 
**Crank TTL Extension Refactor:**

* Replaces the previous `simulateRead` method with a new `bumpContractTtl` function that sends a real transaction using the `extendFootprintTtl` operation to extend the TTL of contract data, ensuring contracts are not archived due to inactivity.
* Implements a helper, `contractIdToLedgerKey`, to construct the correct `LedgerKey` for contract data needed by the TTL extension operation.

**Crank Key Management:**

* Adds `ensureCrankKeypair` to handle crank bot keypair creation: uses `CRANK_SECRET_KEY` if set, otherwise generates and funds an ephemeral keypair via Friendbot for testnet use.

**Operational Improvements:**

* Updates the main crank loop to use the new TTL extension logic for the marketplace, launchpad, and recent collections, and improves logging and error messages for better observability.Replace simulated transactions with actual on-chain submissions signed by a dedicated crank keypair, polling for confirmation.

## Description
**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [# ] I have added unit tests to cover my changes and tested edge cases.
- [ #] All tests pass locally (`cargo test`).

## Additional Context