### PR TITLE
Fix issues #459, #458, #464, #457

### DIFF
--- a/frontend/afristore-app/src/app/collections/[address]/page.tsx
+++ b/frontend/afristore-app/src/app/collections/[address]/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { getCollection, IndexerCollectionRow, fetchListings } from "@/lib/indexer";
+import { Listing } from "@/lib/contract";
+import { ListingCard } from "@/components/ListingCard";
+import { Package, Tag, Clock } from "lucide-react";
+import { clsx } from "clsx";
+
+export default function CollectionPage() {
+  const params = useParams();
+  const address = params?.address;
+  const collectionAddress = Array.isArray(address) ? address[0] : address;
+
+  const [collection, setCollection] = useState<IndexerCollectionRow | null>(null);
+  const [tokens, setTokens] = useState<Listing[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!collectionAddress) return;
+
+    let isMounted = true;
+    async function fetchData() {
+      try {
+        setIsLoading(true);
+        const col = await getCollection(collectionAddress as string);
+        if (!col) {
+          if (isMounted) setError("Collection not found");
+          return;
+        }
+        if (isMounted) setCollection(col);
+
+        // Fetch tokens (listings) for this collection
+        const { listings } = await fetchListings({ search: collectionAddress as string });
+        if (isMounted) {
+          // Filter strictly for this collection just in case search is fuzzy
+          const colListings = listings.filter(l => l.collection === collectionAddress);
+          setTokens(colListings);
+        }
+      } catch (err) {
+        console.error("Failed to load collection details:", err);
+        if (isMounted) setError("Failed to load collection data");
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    }
+
+    fetchData();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [collectionAddress]);
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen bg-midnight-950 pb-20 pt-24 flex flex-col items-center justify-center space-y-6">
+        <div className="h-16 w-16 rounded-[1.5rem] border-4 border-white/5 border-t-brand-500 animate-spin" />
+        <p className="text-xs text-brand-400 font-bold uppercase tracking-[0.3em] animate-pulse">
+          Loading Collection...
+        </p>
+      </div>
+    );
+  }
+
+  if (error || !collection) {
+    return (
+      <div className="min-h-screen bg-midnight-950 pb-20 pt-24 flex flex-col items-center justify-center">
+        <p className="text-white text-xl">{error || "Collection not found"}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-midnight-950 pb-20 pt-24 selection:bg-brand-500 selection:text-white">
+      {/* Background Pattern */}
+      <div className="fixed inset-0 pointer-events-none opacity-[0.03] z-0 overflow-hidden">
+        <div className="absolute inset-0 tribal-pattern scale-150 rotate-12" />
+      </div>
+
+      <div className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        {/* Collection Header */}
+        <div className="relative mb-12 overflow-hidden rounded-[3rem] bg-midnight-900 border border-white/5 shadow-2xl p-8 sm:p-12">
+          <div className="absolute -top-24 -right-24 h-64 w-64 rounded-full bg-brand-500/10 blur-[100px]" />
+          <div className="absolute top-0 right-0 left-0 tribal-strip h-1.5 opacity-40" />
+
+          <div className="flex flex-col md:flex-row items-center md:items-start gap-8">
+            <div className="flex h-32 w-32 items-center justify-center rounded-[2.2rem] bg-midnight-950 border border-white/10 shadow-2xl shrink-0">
+              <Package size={56} className="text-brand-400" />
+            </div>
+
+            <div className="flex flex-col items-center md:items-start gap-4 flex-1">
+              <h1 className="font-display text-4xl sm:text-5xl font-bold tracking-tight text-white">
+                {collection.name || "Unnamed Collection"}
+              </h1>
+              {collection.symbol && (
+                <p className="text-brand-300/60 font-medium text-sm tracking-widest uppercase">
+                  Symbol: {collection.symbol}
+                </p>
+              )}
+              <div className="font-mono text-xs text-mint-400/90 break-all bg-white/5 px-4 py-2.5 rounded-2xl border border-white/10 mt-2">
+                {collection.contractAddress}
+              </div>
+              <p className="text-sm text-white/40 mt-2">
+                Created by: <span className="font-mono text-mint-400">{collection.creator}</span>
+              </p>
+            </div>
+            
+            <div className="flex flex-col gap-4 self-center md:self-end">
+              <div className="group rounded-[2rem] bg-white/5 border border-white/10 px-8 py-6 text-center backdrop-blur-md">
+                <p className="text-[10px] uppercase tracking-[0.3em] text-white/40 font-bold mb-2">
+                  Total Items
+                </p>
+                <p className="font-display text-4xl font-bold text-white tracking-tight">
+                  {tokens.length}
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Tokens List */}
+        <div>
+          <h2 className="text-2xl font-bold text-white mb-8 flex items-center gap-3">
+            <Tag className="text-brand-400" /> Collection Tokens
+          </h2>
+          {tokens.length > 0 ? (
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4">
+              {tokens.map((token) => (
+                <div key={token.listing_id} className="hover:-translate-y-2 transition-transform duration-500">
+                  <ListingCard listing={token} />
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="flex flex-col items-center justify-center rounded-[3.5rem] bg-midnight-900/50 border-2 border-dashed border-white/5 py-32 px-10 text-center">
+              <Clock size={48} className="text-white/10 mb-6" />
+              <h3 className="font-display text-3xl font-bold text-white">No Tokens Found</h3>
+              <p className="mt-4 text-sm text-brand-300/40 max-w-sm">
+                There are no tokens available in this collection yet.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/afristore-app/src/lib/indexer.ts
+++ b/frontend/afristore-app/src/lib/indexer.ts
@@ -332,6 +332,24 @@ export async function getCollections(
 }
 
 /**
+ * Fetch a single collection by contract address from the indexer.
+ */
+export async function getCollection(address: string): Promise<IndexerCollectionRow | null> {
+  if (!isNonEmptyString(address)) return null;
+  try {
+    const raw = await fetchWithRetry<unknown>(`/collections/${encodeURIComponent(address)}`);
+    if (isIndexerCollectionRow(raw)) return raw;
+    return null;
+  } catch (e) {
+    console.warn(
+      "[indexer] getCollection:",
+      e instanceof Error ? e.message : e,
+    );
+    return null;
+  }
+}
+
+/**
  * Fetch royalty stats for an artist (alias for getRoyaltyStats for server-side usage)
  */
 export async function fetchRoyaltyStats(

--- a/indexer/prisma/schema.prisma
+++ b/indexer/prisma/schema.prisma
@@ -114,3 +114,12 @@ model StakedNFT {
   @@index([owner, tokenAddress, tokenId])
   @@index([status])
 }
+
+model UserPreferences {
+  walletAddress String   @id
+  priceAlerts   Boolean  @default(false)
+  theme         String   @default("dark")
+  currency      String   @default("XLM")
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
+}

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -470,4 +470,81 @@ router.get('/stats', async (req: Request, res: Response) => {
     }
 });
 
+// GET /wallets/:address/tokens — user's owned NFTs (from listings and staked)
+router.get('/wallets/:address/tokens', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    try {
+        const ownedListings = await prisma.listing.findMany({
+            where: { owner: address as string },
+        });
+        const stakedNFTs = await prisma.stakedNFT.findMany({
+            where: { owner: address as string },
+        });
+        res.json({
+            ownedListings: serialize(ownedListings.map(mapListing)),
+            stakedNFTs: serialize(stakedNFTs),
+        });
+    } catch (err) {
+        console.error('Error details:', err);
+        res.status(500).json({ error: 'Failed to fetch tokens' });
+    }
+});
+
+// GET /wallets/:address/preferences — user settings
+router.get('/wallets/:address/preferences', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    try {
+        const preferences = await prisma.userPreferences.findUnique({
+            where: { walletAddress: address },
+        });
+        res.json(preferences || {});
+    } catch (err) {
+        console.error('Error details:', err);
+        res.status(500).json({ error: 'Failed to fetch preferences' });
+    }
+});
+
+// PUT /wallets/:address/preferences — update user settings
+router.put('/wallets/:address/preferences', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    const { theme, currency, priceAlerts } = req.body || {};
+    try {
+        const preferences = await prisma.userPreferences.upsert({
+            where: { walletAddress: address },
+            update: { 
+                theme: theme !== undefined ? String(theme) : undefined, 
+                currency: currency !== undefined ? String(currency) : undefined, 
+                priceAlerts: priceAlerts !== undefined ? Boolean(priceAlerts) : undefined 
+            },
+            create: { 
+                walletAddress: address, 
+                theme: theme !== undefined ? String(theme) : "dark", 
+                currency: currency !== undefined ? String(currency) : "XLM", 
+                priceAlerts: priceAlerts !== undefined ? Boolean(priceAlerts) : false 
+            },
+        });
+        res.json(preferences);
+    } catch (err) {
+        console.error('Error details:', err);
+        res.status(500).json({ error: 'Failed to update preferences' });
+    }
+});
+
+// GET /collections/:address — fetch a single collection by contract address
+router.get('/collections/:address', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    try {
+        const collection = await prisma.collection.findUnique({
+            where: { contractAddress: address as string },
+        });
+        if (!collection) {
+            return res.status(404).json({ error: 'Collection not found' });
+        }
+        res.json(serialize(collection));
+    } catch (err) {
+        console.error('Error details:', err);
+        res.status(500).json({ error: 'Failed to fetch collection' });
+    }
+});
+
 export default router;

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -492,7 +492,7 @@ router.get('/wallets/:address/tokens', async (req: Request, res: Response) => {
 
 // GET /wallets/:address/preferences — user settings
 router.get('/wallets/:address/preferences', async (req: Request, res: Response) => {
-    const { address } = req.params;
+    const address = req.params.address as string;
     try {
         const preferences = await prisma.userPreferences.findUnique({
             where: { walletAddress: address },
@@ -506,7 +506,7 @@ router.get('/wallets/:address/preferences', async (req: Request, res: Response) 
 
 // PUT /wallets/:address/preferences — update user settings
 router.put('/wallets/:address/preferences', async (req: Request, res: Response) => {
-    const { address } = req.params;
+    const address = req.params.address as string;
     const { theme, currency, priceAlerts } = req.body || {};
     try {
         const preferences = await prisma.userPreferences.upsert({

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -535,7 +535,10 @@ export async function processEvent(event: any, tx?: any, skipInsert = false) {
             address: r.address.toString(),
             percentage: Number(r.percentage)
           }))
-        : [];
+        : (data.recipients || []).map((r: any) => ({
+            address: r.address?.toString() || r.address,
+            percentage: Number(r.percentage)
+          }));
 
       const metadataCid = await fetchTokenUri(collection, nftTokenId);
 


### PR DESCRIPTION
Closes #459
Closes #458
Closes #464
Closes #457

This PR introduces the following changes:
- **Backend API Routes (#459, #464, #457)**: Added `GET /wallets/:address/tokens`, `GET /wallets/:address/preferences`, `PUT /wallets/:address/preferences`, and `GET /collections/:address` to the indexer API.
- **Backend Poller (#458)**: Fixed the `LISTING_CREATED` handler in `indexer/src/poller.ts` to correctly fallback to parsing recipients from `data.recipients` when the chain indexer hydration is stubbed, resolving the issue where royalty stats were perpetually 0.
- **Frontend Collections (#457)**: Created a new page at `frontend/afristore-app/src/app/collections/[address]/page.tsx` to display collection metadata, total items, and their marketplace listing status.