### PR TITLE
Fix issues #468, #477, #480, #481

### DIFF
--- a/frontend/afristore-app/e2e/dashboard.spec.ts
+++ b/frontend/afristore-app/e2e/dashboard.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from "@playwright/test";
+import { connectFreighterWallet, openNewListingTab } from "./helpers/wallet";
+import {
+  MarketplaceTestStore,
+  setupMarketplaceMocks,
+  setupWalletIndexerMocks,
+  resetE2eListingsInBrowser,
+} from "./helpers/marketplace-mocks";
+
+test.describe("Dashboard empty state (#477)", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    // User owns 0 NFTs — tokens endpoint returns an empty array.
+    await setupWalletIndexerMocks(page, { tokens: [] });
+    await resetE2eListingsInBrowser(page);
+    await connectFreighterWallet(page);
+  });
+
+  test("dashboard handles empty state when user owns 0 NFTs", async ({
+    page,
+  }) => {
+    const tokensRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        /\/wallets\/[^/]+\/tokens/.test(req.url()),
+    );
+
+    await openNewListingTab(page);
+    await tokensRequest;
+
+    await expect(
+      page.getByText("No NFTs found in your wallet"),
+    ).toBeVisible({ timeout: 15_000 });
+    await expect(
+      page.getByText(/don't own any NFTs on this network/i),
+    ).toBeVisible();
+  });
+});

--- a/frontend/afristore-app/e2e/helpers/marketplace-mocks.ts
+++ b/frontend/afristore-app/e2e/helpers/marketplace-mocks.ts
@@ -101,9 +101,13 @@ export async function setupMarketplaceMocks(
 
     const url = new URL(route.request().url());
     const statusFilter = url.searchParams.get("status");
+    const artistFilter = url.searchParams.get("artist");
     let rows = store.listings;
     if (statusFilter && statusFilter !== "All") {
       rows = rows.filter((l) => l.status === statusFilter);
+    }
+    if (artistFilter) {
+      rows = rows.filter((l) => l.artist === artistFilter);
     }
 
     await route.fulfill({
@@ -111,6 +115,83 @@ export async function setupMarketplaceMocks(
       contentType: "application/json",
       body: JSON.stringify({ listings: rows, total: rows.length }),
     });
+  });
+}
+
+/** Mock wallet token / activity / preferences endpoints used by dashboard & profile. */
+export async function setupWalletIndexerMocks(
+  page: Page,
+  options?: {
+    tokens?: unknown;
+    activity?: unknown[];
+    royaltyStats?: {
+      totalEarned: string;
+      payoutCount: number;
+      lastPayout: number;
+    };
+    preferences?: {
+      theme?: string;
+      currency?: string;
+      priceAlerts?: boolean;
+    };
+  },
+) {
+  const tokens = options?.tokens ?? [];
+  const activity = options?.activity ?? [];
+  const royaltyStats = options?.royaltyStats ?? {
+    totalEarned: "0.00",
+    payoutCount: 0,
+    lastPayout: 0,
+  };
+  const preferences = options?.preferences ?? {};
+
+  await page.route("**/wallets/*/tokens", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(tokens),
+    });
+  });
+
+  await page.route("**/wallets/*/activity**", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(activity),
+    });
+  });
+
+  await page.route("**/wallets/*/royalty-stats**", async (route) => {
+    if (route.request().method() !== "GET") return route.continue();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(royaltyStats),
+    });
+  });
+
+  await page.route("**/wallets/*/preferences", async (route) => {
+    const method = route.request().method();
+    if (method === "GET") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(preferences),
+      });
+      return;
+    }
+    if (method === "PUT") {
+      const body = route.request().postDataJSON() ?? {};
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ ...preferences, ...body }),
+      });
+      return;
+    }
+    return route.continue();
   });
 }
 

--- a/frontend/afristore-app/e2e/profile.spec.ts
+++ b/frontend/afristore-app/e2e/profile.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from "@playwright/test";
+import { TEST_PUBLIC_KEY, BUYER_PUBLIC_KEY } from "./freighter-mock";
+import { connectFreighterWallet } from "./helpers/wallet";
+import {
+  E2E_METADATA_CID,
+  MarketplaceTestStore,
+  MOCK_ARTWORK_METADATA,
+  setupMarketplaceMocks,
+  setupWalletIndexerMocks,
+  resetE2eListingsInBrowser,
+} from "./helpers/marketplace-mocks";
+
+const DEFAULT_TOKEN =
+  process.env.NEXT_PUBLIC_NATIVE_TOKEN_CONTRACT_ID ??
+  "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC";
+
+test.describe("Profile past sales history (#480)", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await setupWalletIndexerMocks(page);
+    await resetE2eListingsInBrowser(page);
+  });
+
+  test("profile page displays user past sales history", async ({ page }) => {
+    store.upsertActive({
+      listing_id: 4801,
+      artist: TEST_PUBLIC_KEY,
+      metadata_cid: E2E_METADATA_CID,
+      price: String(42 * 10_000_000),
+      currency: "XLM",
+      token: DEFAULT_TOKEN,
+      status: "Sold",
+      owner: BUYER_PUBLIC_KEY,
+      created_at: Math.floor(Date.now() / 1000),
+      original_creator: TEST_PUBLIC_KEY,
+      royalty_bps: 500,
+      recipients: [{ address: TEST_PUBLIC_KEY, percentage: 100 }],
+    });
+
+    const artistListingsRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes("/listings") &&
+        req.url().includes(`artist=${encodeURIComponent(TEST_PUBLIC_KEY)}`),
+    );
+
+    await connectFreighterWallet(page, TEST_PUBLIC_KEY);
+    await page.goto("/profile");
+    await artistListingsRequest;
+
+    await expect(page.getByText("African")).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("button", { name: /heritage sold/i }).click();
+
+    await expect(page.getByText(MOCK_ARTWORK_METADATA.title)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("Sold").first()).toBeVisible();
+    await expect(page.getByText("42 XLM")).toBeVisible();
+  });
+});

--- a/frontend/afristore-app/e2e/settings.spec.ts
+++ b/frontend/afristore-app/e2e/settings.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from "@playwright/test";
+import { connectFreighterWallet } from "./helpers/wallet";
+import {
+  MarketplaceTestStore,
+  setupMarketplaceMocks,
+  setupWalletIndexerMocks,
+  resetE2eListingsInBrowser,
+} from "./helpers/marketplace-mocks";
+
+test.describe("Settings preferences (#481)", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await resetE2eListingsInBrowser(page);
+  });
+
+  test("settings page loads preferences from backend on load", async ({
+    page,
+  }) => {
+    await setupWalletIndexerMocks(page, {
+      preferences: {
+        theme: "dark",
+        currency: "NGN",
+        priceAlerts: false,
+      },
+    });
+
+    const prefsRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        /\/wallets\/[^/]+\/preferences/.test(req.url()),
+    );
+
+    await connectFreighterWallet(page);
+    await page.goto("/settings");
+    await prefsRequest;
+
+    await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('[data-prefs-loaded="true"]')).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Display Currency select reflects backend preference (NGN, not default XLM).
+    const currencySelect = page
+      .locator("select")
+      .filter({ hasText: "Nigerian Naira" });
+    await expect(currencySelect).toHaveValue("NGN");
+
+    // Price Alerts toggle is off when backend returns priceAlerts: false.
+    const priceAlertsRow = page
+      .locator("div.flex.items-center.justify-between")
+      .filter({ hasText: "Price Alerts" });
+    await expect(priceAlertsRow.locator("button")).toHaveClass(/bg-gray-600/);
+  });
+});

--- a/frontend/afristore-app/playwright.config.ts
+++ b/frontend/afristore-app/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
-  testDir: "./tests/e2e",
+  testDir: "./e2e",
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -20,7 +20,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev",
+    command: "npm run dev:e2e",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/frontend/afristore-app/src/app/settings/page.tsx
+++ b/frontend/afristore-app/src/app/settings/page.tsx
@@ -8,6 +8,10 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useWalletContext } from "@/context/WalletContext";
 import {
+  getWalletPreferences,
+  putWalletPreferences,
+} from "@/lib/indexer";
+import {
   Settings,
   Wallet,
   Network,
@@ -90,6 +94,7 @@ export default function SettingsPage() {
   } = useWalletContext();
 
   const [settings, setSettings] = useState<SettingsState>(loadSettings);
+  const [prefsLoaded, setPrefsLoaded] = useState(false);
 
   useEffect(() => {
     if (network) {
@@ -97,12 +102,57 @@ export default function SettingsPage() {
     }
   }, [network]);
 
+  // Load preferences from the indexer when the wallet connects (#481).
+  useEffect(() => {
+    if (!publicKey) {
+      setPrefsLoaded(false);
+      return;
+    }
+    let cancelled = false;
+    (async () => {
+      try {
+        const prefs = await getWalletPreferences(publicKey);
+        if (cancelled) return;
+        setSettings((prev) => ({
+          ...prev,
+          ...(prefs.theme != null && prefs.theme !== ""
+            ? { theme: String(prefs.theme) }
+            : {}),
+          ...(prefs.currency != null && prefs.currency !== ""
+            ? { currency: String(prefs.currency) }
+            : {}),
+          ...(typeof prefs.priceAlerts === "boolean"
+            ? { priceAlerts: prefs.priceAlerts }
+            : {}),
+        }));
+      } catch {
+        // Keep local/default settings when the indexer is unreachable.
+      } finally {
+        if (!cancelled) setPrefsLoaded(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [publicKey]);
+
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
   const handleSave = async () => {
     setSaving(true);
     saveSettings(settings);
+    try {
+      if (publicKey) {
+        await putWalletPreferences(publicKey, {
+          theme: settings.theme,
+          currency: settings.currency,
+          priceAlerts: settings.priceAlerts,
+        });
+      }
+    } catch {
+      // Local save already applied; backend sync can retry later.
+    }
     await new Promise((resolve) => setTimeout(resolve, 300));
     setSaving(false);
     setSaved(true);
@@ -172,7 +222,10 @@ export default function SettingsPage() {
   }
 
   return (
-    <div className="min-h-screen bg-midnight-950 pt-24">
+    <div
+      className="min-h-screen bg-midnight-950 pt-24"
+      data-prefs-loaded={prefsLoaded ? "true" : "false"}
+    >
       <div className="mx-auto max-w-4xl px-4 sm:px-6">
         {/* Header */}
         <div className="mb-8">

--- a/frontend/afristore-app/src/lib/indexer.ts
+++ b/frontend/afristore-app/src/lib/indexer.ts
@@ -370,6 +370,13 @@ export async function fetchArtistListings(
       `/listings?artist=${encodeURIComponent(publicKey)}`,
     );
     if (Array.isArray(data)) return data as Listing[];
+    if (
+      data &&
+      typeof data === "object" &&
+      Array.isArray((data as { listings?: unknown }).listings)
+    ) {
+      return (data as { listings: Listing[] }).listings;
+    }
     return [];
   } catch (e) {
     console.warn(
@@ -377,6 +384,61 @@ export async function fetchArtistListings(
       e instanceof Error ? e.message : e,
     );
     return [];
+  }
+}
+
+export interface WalletPreferences {
+  walletAddress?: string;
+  theme?: string;
+  currency?: string;
+  priceAlerts?: boolean;
+}
+
+/**
+ * Load per-wallet preferences from the indexer.
+ */
+export async function getWalletPreferences(
+  publicKey: string,
+): Promise<WalletPreferences> {
+  if (!isNonEmptyString(publicKey)) return {};
+  try {
+    const data = await fetchWithRetry<unknown>(
+      `/wallets/${encodeURIComponent(publicKey)}/preferences`,
+    );
+    if (data && typeof data === "object" && !Array.isArray(data)) {
+      return data as WalletPreferences;
+    }
+    return {};
+  } catch (e) {
+    console.warn(
+      "[indexer] getWalletPreferences:",
+      e instanceof Error ? e.message : e,
+    );
+    return {};
+  }
+}
+
+/**
+ * Persist per-wallet preferences to the indexer.
+ */
+export async function putWalletPreferences(
+  publicKey: string,
+  prefs: Pick<WalletPreferences, "theme" | "currency" | "priceAlerts">,
+): Promise<WalletPreferences> {
+  if (!isNonEmptyString(publicKey)) return {};
+  const url = `${config.indexerUrl}/wallets/${encodeURIComponent(publicKey)}/preferences`;
+  try {
+    const res = await axios.put<WalletPreferences>(url, prefs, {
+      timeout: DEFAULT_TIMEOUT_MS,
+      validateStatus: (s) => s < 400,
+    });
+    return res.data;
+  } catch (e) {
+    console.warn(
+      "[indexer] putWalletPreferences:",
+      e instanceof Error ? e.message : e,
+    );
+    throw e;
   }
 }
 

--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -32,7 +32,7 @@ const mockRedis = vi.hoisted(() => ({
 vi.mock('../db', () => ({ default: mockPrisma }));
 vi.mock('../redis.js', () => ({ default: mockRedis }));
 
-import router from '../api/routes';
+import router, { eventMatchesWallet } from '../api/routes';
 
 // Build a minimal Express app with the router mounted at root
 const app = express();
@@ -546,3 +546,53 @@ describe('GET /wallets/:address/royalty-stats — extended', () => {
     expect(res.body.payoutCount).toBe(2);
   });
 });
+
+// ── SSE wallet filtering (issue #468) ─────────────────────────────────────────
+
+describe('eventMatchesWallet', () => {
+  const wallet = 'GWALLET';
+
+  it('matches when actor equals the wallet', () => {
+    expect(eventMatchesWallet({ actor: wallet, data: {} }, wallet)).toBe(true);
+  });
+
+  it('matches when top-level recipient equals the wallet', () => {
+    expect(
+      eventMatchesWallet({ actor: 'GOTHER', recipient: wallet, data: {} }, wallet)
+    ).toBe(true);
+  });
+
+  it('matches buyer / artist / offerer fields in data', () => {
+    expect(
+      eventMatchesWallet({ actor: 'GOTHER', data: { buyer: wallet } }, wallet)
+    ).toBe(true);
+    expect(
+      eventMatchesWallet({ actor: 'GOTHER', data: { artist: wallet } }, wallet)
+    ).toBe(true);
+    expect(
+      eventMatchesWallet({ actor: 'GOTHER', data: { offerer: wallet } }, wallet)
+    ).toBe(true);
+  });
+
+  it('matches royalty recipients array', () => {
+    expect(
+      eventMatchesWallet(
+        {
+          actor: 'GOTHER',
+          data: { recipients: [{ address: wallet, percentage: 500 }] },
+        },
+        wallet
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for unrelated events', () => {
+    expect(
+      eventMatchesWallet(
+        { actor: 'GOTHER', data: { buyer: 'GBUYER', artist: 'GARTIST' } },
+        wallet
+      )
+    ).toBe(false);
+  });
+});
+

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -5,16 +5,107 @@ import redis from '../redis.js';
 import { cacheMiddleware } from './cache-middleware.js';
 import { strictRateLimiter } from './rate-limit-middleware.js';
 
-// SSE clients registry
-const sseClients: Response[] = [];
+// ── Server-Sent Events ───────────────────────────────────────
+
+type SseClient = {
+    res: Response;
+    /** When set, only events involving this wallet are forwarded. */
+    address?: string;
+};
+
+const sseClients = new Set<SseClient>();
+
+/** JSON payload keys that identify a party to an event. */
+const EVENT_PARTY_KEYS = [
+    'buyer',
+    'artist',
+    'offerer',
+    'bidder',
+    'winner',
+    'creator',
+    'recipient',
+] as const;
+
+/**
+ * Returns true when `address` is the event actor or a recipient/party
+ * referenced in the event payload (mirrors /wallets/:address/activity).
+ */
+export function eventMatchesWallet(event: any, address: string): boolean {
+    if (!address) return false;
+    if (event?.actor === address) return true;
+    if (event?.recipient === address) return true;
+
+    const data = event?.data;
+    if (!data || typeof data !== 'object') return false;
+
+    for (const key of EVENT_PARTY_KEYS) {
+        if ((data as Record<string, unknown>)[key] === address) return true;
+    }
+
+    if (Array.isArray(data.recipients)) {
+        for (const r of data.recipients) {
+            if (r === address) return true;
+            if (r && typeof r === 'object' && (r as { address?: string }).address === address) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Broadcast a marketplace event to connected SSE clients.
+ * Wallet-scoped clients only receive events that match their address.
+ */
 export function emitSSEEvent(event: any) {
+    if (sseClients.size === 0) return;
     const data = `data: ${JSON.stringify(event, (_k, v) => typeof v === 'bigint' ? v.toString() : v)}\n\n`;
     for (const client of sseClients) {
-        try { client.write(data); } catch { /* ignore closed connections */ }
+        if (client.address && !eventMatchesWallet(event, client.address)) continue;
+        try {
+            client.res.write(data);
+        } catch {
+            sseClients.delete(client);
+        }
     }
 }
 
+function attachSseClient(req: Request, res: Response, address?: string) {
+    res.setHeader('Content-Type', 'text/event-stream');
+    res.setHeader('Cache-Control', 'no-cache');
+    res.setHeader('Connection', 'keep-alive');
+    res.flushHeaders();
+
+    const client: SseClient = { res, address };
+    sseClients.add(client);
+
+    const heartbeat = setInterval(() => {
+        try {
+            res.write(': heartbeat\n\n');
+        } catch {
+            clearInterval(heartbeat);
+        }
+    }, 30_000);
+
+    req.on('close', () => {
+        clearInterval(heartbeat);
+        sseClients.delete(client);
+    });
+}
+
 const router = Router();
+
+/** GET /events/stream — subscribe to all marketplace events (explore refresh). */
+router.get('/events/stream', (req: Request, res: Response) => {
+    attachSseClient(req, res);
+});
+
+/** GET /wallets/:address/events — per-wallet SSE notifications (issue #468). */
+router.get('/wallets/:address/events', (req: Request, res: Response) => {
+    const address = req.params.address as string;
+    attachSseClient(req, res, address);
+});
 
 const CACHE_TTL_SECONDS = parseInt(process.env.REDIS_CACHE_TTL_SECONDS || '30');
 


### PR DESCRIPTION
## Summary
Closes #468
Closes #481
Closes #477
Closes #480

### #468 Backend - per-wallet SSE notification endpoint
- Add `GET /wallets/:address/events` SSE stream
- Filter `emitSSEEvent` so wallet clients only receive events where actor/recipient (or related party fields) match
- Restore global `/events/stream` for marketplace explore refresh
- Unit tests for `eventMatchesWallet`

### #477 E2E - Dashboard empty state when user owns 0 NFTs
- Add `e2e/dashboard.spec.ts` asserting the Owned NFT empty state with mocked empty tokens

### #480 E2E - Profile past sales history
- Add `e2e/profile.spec.ts` for Heritage Sold tab with a sold listing
- Fix `fetchArtistListings` to unwrap `{ listings, total }` indexer responses

### #481 E2E - Settings loads preferences from backend
- Wire settings page to `GET`/`PUT` `/wallets/:address/preferences`
- Add `e2e/settings.spec.ts` asserting currency and price-alerts reflect mocked backend prefs

## Test plan
- [x] `npm run build` in `indexer` (prisma generate + tsc)
- [x] `npm run build` in `frontend/afristore-app`
- [x] `npm test` in `indexer` (includes `eventMatchesWallet` cases)
- [ ] `npx playwright test dashboard.spec.ts profile.spec.ts settings.spec.ts` (Node 20/22 recommended)