### PR TITLE
Feat: Add E2E Test for Profile Page

### DIFF
--- a/frontend/afristore-app/e2e/profile.spec.ts
+++ b/frontend/afristore-app/e2e/profile.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from "@playwright/test";
+import { connectFreighterWallet } from "./helpers/wallet";
+
+const MOCK_PUBLIC_KEY =
+  "GBVFEOFMZAUI7WVPDMGTQZ3BO63BKGKVFKFKMLMDAZDCIYB2MZZXKVW";
+
+const MOCK_LISTINGS = [
+  {
+    id: "clv16g90l000108l96g3g5d7y",
+    title: "Hand-carved Wooden Mask",
+    description: "A beautiful, traditional mask from the Ashanti region.",
+    price: "120.50",
+    seller: MOCK_PUBLIC_KEY,
+    asset_id: "WOODMASK:GB...",
+    image_url: "/images/mock-mask.jpg",
+  },
+];
+
+test.describe("Profile Page", () => {
+  test.beforeEach(async ({ page }) => {
+    // Mock the API endpoint that fetches user listings
+    await page.route(
+      `**/users/${MOCK_PUBLIC_KEY}/listings`,
+      async (route) => {
+        await route.fulfill({ json: MOCK_LISTINGS });
+      },
+    );
+
+    // Connect a mock wallet to simulate an authenticated user
+    await connectFreighterWallet(page, MOCK_PUBLIC_KEY);
+  });
+
+  test("displays user's active listings", async ({ page }) => {
+    await page.goto(`/profile/${MOCK_PUBLIC_KEY}`);
+
+    // Verify that the "My Listings" section is visible
+    await expect(page.getByRole("heading", { name: "My Listings" })).toBeVisible();
+
+    // Verify that the mocked listing card is rendered on the page
+    await expect(page.getByText(MOCK_LISTINGS[0].title)).toBeVisible();
+  });
+});


### PR DESCRIPTION
### Feat: Add E2E Test for Profile Page Listings
closes #479 
This PR introduces a new end-to-end test suite to verify that a user's active listings are correctly displayed on their profile page.

#### Description
A new test file, `e2e/profile.spec.ts`, has been created to automate and validate this core user journey.

The test case, `"displays user's active listings"`, performs the following:
1.  Mocks the API response for a user's listings using `page.route()` to ensure a stable and predictable test.
2.  Simulates an authenticated session by connecting a mock wallet.
3.  Navigates to the user's profile page.
4.  Asserts that the "My Listings" section and the mock listing data are rendered correctly.

This test prevents regressions and ensures that users can always see their active listings, a critical component of the marketplace experience.
