### PR TITLE
test(e2e): add e2e tests for bidding errors and launchpad contract deployment

### DIFF
--- a/frontend/afristore-app/e2e/bidding.spec.ts
+++ b/frontend/afristore-app/e2e/bidding.spec.ts
@@ -6,6 +6,7 @@ import {
   setupMarketplaceMocks,
   resetE2eListingsInBrowser,
   seedE2eAuctionInBrowser,
+  failNextE2eTransaction,
 } from "./helpers/marketplace-mocks";
 import { connectFreighterWallet } from "./helpers/wallet";
 
@@ -99,5 +100,111 @@ test.describe("Bidding E2E", () => {
     await expect(
       page.locator('[data-testid="outbid-notification"]'),
     ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("bidding with insufficient funds shows UI error (#524)", async ({ page }) => {
+    await connectFreighterWallet(page, BUYER_PUBLIC_KEY);
+    await resetE2eListingsInBrowser(page);
+
+    const futureTime = Math.floor(Date.now() / 1000) + 86400;
+    await seedE2eAuctionInBrowser(page, {
+      auction_id: 8005,
+      creator: TEST_PUBLIC_KEY,
+      metadata_cid: E2E_METADATA_CID,
+      collection: "CA1234567890",
+      token_id: 5,
+      token: DEFAULT_TOKEN,
+      reserve_price: 100_000_000n, // 10 XLM
+      highest_bid: 0n,
+      highest_bidder: null,
+      end_time: futureTime,
+      status: "Active",
+      recipients: [{ address: TEST_PUBLIC_KEY, percentage: 100 }],
+      created_at: Math.floor(Date.now() / 1000),
+    });
+
+    await page.goto("/auctions/8005");
+    await expect(page.getByText("Current Bid")).toBeVisible({ timeout: 15_000 });
+
+    const bidInput = page.getByPlaceholder(/min/i);
+    await expect(bidInput).toBeVisible();
+    await bidInput.fill("20");
+
+    const bidBtn = page.getByRole("button", { name: /^bid$/i });
+    await expect(bidBtn).toBeVisible();
+
+    await failNextE2eTransaction(page, "Insufficient balance to place bid");
+    await bidBtn.click();
+
+    await expect(
+      page.getByText(/insufficient balance|insufficient funds|failed to place bid/i).first(),
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  test("bidding below reserve price or current highest bid is rejected (#525)", async ({
+    page,
+  }) => {
+    await connectFreighterWallet(page, BUYER_PUBLIC_KEY);
+    await resetE2eListingsInBrowser(page);
+
+    const futureTime = Math.floor(Date.now() / 1000) + 86400;
+
+    await seedE2eAuctionInBrowser(page, {
+      auction_id: 8006,
+      creator: TEST_PUBLIC_KEY,
+      metadata_cid: E2E_METADATA_CID,
+      collection: "CA1234567890",
+      token_id: 6,
+      token: DEFAULT_TOKEN,
+      reserve_price: 100_000_000n, // 10 XLM
+      highest_bid: 0n,
+      highest_bidder: null,
+      end_time: futureTime,
+      status: "Active",
+      recipients: [{ address: TEST_PUBLIC_KEY, percentage: 100 }],
+      created_at: Math.floor(Date.now() / 1000),
+    });
+
+    await page.goto("/auctions/8006");
+    await expect(page.getByText("Current Bid")).toBeVisible({ timeout: 15_000 });
+
+    const bidInput = page.getByPlaceholder(/min/i);
+    await expect(bidInput).toBeVisible();
+
+    // Bidding below reserve price (5 XLM < 10 XLM)
+    await bidInput.fill("5");
+    await expect(
+      page.getByText(/must be at least 10 XLM/i),
+    ).toBeVisible();
+
+    const bidBtn = page.getByRole("button", { name: /^bid$/i });
+    await expect(bidBtn).toBeDisabled();
+
+    // Bidding below current highest bid
+    await seedE2eAuctionInBrowser(page, {
+      auction_id: 8007,
+      creator: TEST_PUBLIC_KEY,
+      metadata_cid: E2E_METADATA_CID,
+      collection: "CA1234567890",
+      token_id: 7,
+      token: DEFAULT_TOKEN,
+      reserve_price: 100_000_000n, // 10 XLM
+      highest_bid: 150_000_000n, // 15 XLM
+      highest_bidder: TEST_PUBLIC_KEY,
+      end_time: futureTime,
+      status: "Active",
+      recipients: [{ address: TEST_PUBLIC_KEY, percentage: 100 }],
+      created_at: Math.floor(Date.now() / 1000),
+    });
+
+    await page.goto("/auctions/8007");
+    await expect(page.getByText("Current Bid")).toBeVisible({ timeout: 15_000 });
+    await expect(page.getByText("15 XLM")).toBeVisible();
+
+    await bidInput.fill("12");
+    await expect(
+      page.getByText(/higher than current bid/i),
+    ).toBeVisible();
+    await expect(bidBtn).toBeDisabled();
   });
 });

--- a/frontend/afristore-app/e2e/helpers/marketplace-mocks.ts
+++ b/frontend/afristore-app/e2e/helpers/marketplace-mocks.ts
@@ -222,6 +222,14 @@ export async function rejectNextE2eTransaction(page: Page) {
   });
 }
 
+/** Forces the next mocked on-chain write to throw with a custom error message. */
+export async function failNextE2eTransaction(page: Page, message: string) {
+  await page.evaluate((msg) => {
+    (window as Window & { __E2E_NEXT_TX_ERROR__?: string }).__E2E_NEXT_TX_ERROR__ =
+      msg;
+  }, message);
+}
+
 export async function seedE2eAuctionInBrowser(
   page: Page,
   auction: {

--- a/frontend/afristore-app/e2e/launchpad.spec.ts
+++ b/frontend/afristore-app/e2e/launchpad.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from "@playwright/test";
+import { TEST_PUBLIC_KEY } from "./freighter-mock";
+import {
+  MarketplaceTestStore,
+  setupMarketplaceMocks,
+  resetE2eListingsInBrowser,
+  rejectNextE2eTransaction,
+} from "./helpers/marketplace-mocks";
+import { connectFreighterWallet } from "./helpers/wallet";
+
+test.describe("Launchpad E2E", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await resetE2eListingsInBrowser(page);
+    await connectFreighterWallet(page, TEST_PUBLIC_KEY);
+  });
+
+  test("launchpad deployment signs soroban contract deployment (#531)", async ({
+    page,
+  }) => {
+    await page.goto("/launchpad/create");
+    await expect(page.getByText(/new collection/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Fill collection details
+    await page
+      .getByPlaceholder(/african legends/i)
+      .fill("African Genesis");
+    await page.getByPlaceholder(/afrl/i).fill("AFGEN");
+
+    const deployBtn = page.getByRole("button", { name: /deploy collection/i });
+    await expect(deployBtn).toBeEnabled();
+
+    // Verify rejection scenario
+    await rejectNextE2eTransaction(page);
+    await deployBtn.click();
+
+    await expect(
+      page.getByText(/user declined access|failed/i).first(),
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Deploy successfully
+    await deployBtn.click();
+
+    await expect(page.getByText("Collection Deployed!")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText(/CB[A-Z0-9]+/i).first(),
+    ).toBeVisible();
+  });
+
+  test("successful deployment redirects to new Collection page (#532)", async ({
+    page,
+  }) => {
+    await page.goto("/launchpad/create");
+    await expect(page.getByText(/new collection/i)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await page
+      .getByPlaceholder(/african legends/i)
+      .fill("Safari Legends");
+    await page.getByPlaceholder(/afrl/i).fill("SAFARI");
+
+    const deployBtn = page.getByRole("button", { name: /deploy collection/i });
+    await deployBtn.click();
+
+    await expect(page.getByText("Collection Deployed!")).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const viewCollectionLink = page.getByRole("link", {
+      name: /view collection/i,
+    });
+    await expect(viewCollectionLink).toBeVisible();
+    await viewCollectionLink.click();
+
+    await expect(page).toHaveURL(/\/launchpad\/collections\/CB[A-Z0-9]+/);
+    await expect(page.getByText("Safari Legends").first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/frontend/afristore-app/src/lib/e2e-chain-mock.ts
+++ b/frontend/afristore-app/src/lib/e2e-chain-mock.ts
@@ -9,6 +9,18 @@ const listings = new Map<number, Listing>();
 let nextAuctionId = 8001;
 const auctions = new Map<number, Auction>();
 
+let nextCollectionId = 1;
+export interface E2eMockCollection {
+  name: string;
+  symbol: string;
+  creator: string;
+  totalSupply: number;
+  maxSupply: number;
+  royaltyBps: number;
+  royaltyReceiver: string;
+}
+const collections = new Map<string, E2eMockCollection>();
+
 declare global {
   interface Window {
     __E2E_GET_LISTINGS__?: () => Listing[];
@@ -17,6 +29,7 @@ declare global {
     __E2E_RESET_AUCTIONS__?: () => void;
     __E2E_SEED_AUCTION__?: (auction: Auction) => void;
     __E2E_REJECT_NEXT_TX__?: boolean;
+    __E2E_NEXT_TX_ERROR__?: string;
   }
 }
 
@@ -24,9 +37,16 @@ declare global {
 const FREIGHTER_REJECTION_MESSAGE = "User declined access";
 
 function consumeForcedRejection(): void {
-  if (typeof window !== "undefined" && window.__E2E_REJECT_NEXT_TX__) {
-    window.__E2E_REJECT_NEXT_TX__ = false;
-    throw new Error(FREIGHTER_REJECTION_MESSAGE);
+  if (typeof window !== "undefined") {
+    if (window.__E2E_NEXT_TX_ERROR__) {
+      const msg = window.__E2E_NEXT_TX_ERROR__;
+      window.__E2E_NEXT_TX_ERROR__ = undefined;
+      throw new Error(msg);
+    }
+    if (window.__E2E_REJECT_NEXT_TX__) {
+      window.__E2E_REJECT_NEXT_TX__ = false;
+      throw new Error(FREIGHTER_REJECTION_MESSAGE);
+    }
   }
 }
 
@@ -46,6 +66,11 @@ export function getE2eMockListings(): Listing[] {
 export function resetE2eMockAuctions(): void {
   auctions.clear();
   nextAuctionId = 8001;
+}
+
+export function resetE2eMockCollections(): void {
+  collections.clear();
+  nextCollectionId = 1;
 }
 
 export function getE2eMockAuctions(): Auction[] {
@@ -70,6 +95,7 @@ export function registerE2eMockListingsOnWindow(): void {
   window.__E2E_RESET_LISTINGS__ = () => {
     resetE2eMockListings();
     resetE2eMockAuctions();
+    resetE2eMockCollections();
   };
   window.__E2E_GET_AUCTIONS__ = getE2eMockAuctions;
   window.__E2E_RESET_AUCTIONS__ = resetE2eMockAuctions;
@@ -133,6 +159,8 @@ export function e2eMockPlaceBid(
   auctionId: number,
   amountXlm: number,
 ): boolean {
+  consumeForcedRejection();
+
   const auction = auctions.get(auctionId);
   if (!auction) {
     throw new Error(`Auction #${auctionId} not found`);
@@ -144,6 +172,43 @@ export function e2eMockPlaceBid(
   auction.highest_bid = amountStroops;
   auction.highest_bidder = bidderPublicKey;
   return true;
+}
+
+export function e2eMockDeployCollection(
+  creatorPublicKey: string,
+  name: string,
+  symbol = "MOCK",
+  maxSupply = 10000,
+  royaltyBps = 500,
+  royaltyReceiver?: string,
+): string {
+  consumeForcedRejection();
+
+  const address = `CB${"A".repeat(49)}${String(nextCollectionId++).padStart(5, "0")}`;
+  collections.set(address, {
+    name,
+    symbol,
+    creator: creatorPublicKey,
+    totalSupply: 0,
+    maxSupply,
+    royaltyBps,
+    royaltyReceiver: royaltyReceiver || creatorPublicKey,
+  });
+  return address;
+}
+
+export function getE2eMockCollection(address: string): E2eMockCollection {
+  return (
+    collections.get(address) ?? {
+      name: "Mock Collection",
+      symbol: "MOCK",
+      creator: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+      totalSupply: 0,
+      maxSupply: 10000,
+      royaltyBps: 500,
+      royaltyReceiver: "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN",
+    }
+  );
 }
 
 export function e2eMockFinalizeAuction(

--- a/frontend/afristore-app/src/lib/launchpad.ts
+++ b/frontend/afristore-app/src/lib/launchpad.ts
@@ -6,6 +6,11 @@ import {
 } from "@stellar/stellar-sdk";
 import { config } from "./config";
 import { invokeContract } from "./contract";
+import {
+  isE2eMockChain,
+  e2eMockDeployCollection,
+  getE2eMockCollection,
+} from "./e2e-chain-mock";
 
 // ── Types ─────────────────────────────────────────────────────
 
@@ -55,6 +60,17 @@ export async function deployNormal721(
   royaltyReceiver: string,
   salt: Buffer, // 32 bytes
 ): Promise<string> {
+  if (isE2eMockChain()) {
+    return e2eMockDeployCollection(
+      creatorPublicKey,
+      name,
+      symbol,
+      maxSupply,
+      royaltyBps,
+      royaltyReceiver,
+    );
+  }
+
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
     nativeToScVal(name, { type: "string" }),
@@ -85,6 +101,17 @@ export async function deployNormal1155(
   royaltyReceiver: string,
   salt: Buffer,
 ): Promise<string> {
+  if (isE2eMockChain()) {
+    return e2eMockDeployCollection(
+      creatorPublicKey,
+      name,
+      "MOCK",
+      10000,
+      royaltyBps,
+      royaltyReceiver,
+    );
+  }
+
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
     nativeToScVal(name, { type: "string" }),
@@ -116,6 +143,17 @@ export async function deployLazy721(
   royaltyReceiver: string,
   salt: Buffer,
 ): Promise<string> {
+  if (isE2eMockChain()) {
+    return e2eMockDeployCollection(
+      creatorPublicKey,
+      name,
+      symbol,
+      maxSupply,
+      royaltyBps,
+      royaltyReceiver,
+    );
+  }
+
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
     nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
@@ -148,6 +186,17 @@ export async function deployLazy1155(
   royaltyReceiver: string,
   salt: Buffer,
 ): Promise<string> {
+  if (isE2eMockChain()) {
+    return e2eMockDeployCollection(
+      creatorPublicKey,
+      name,
+      "MOCK",
+      10000,
+      royaltyBps,
+      royaltyReceiver,
+    );
+  }
+
   const args: xdr.ScVal[] = [
     toAddressScVal(creatorPublicKey),
     nativeToScVal(Uint8Array.from(creatorPubkeyBytes), { type: "bytes" }),
@@ -417,6 +466,10 @@ export interface CollectionMetadata {
 export async function getCollectionMetadata(
   collectionAddress: string,
 ): Promise<CollectionMetadata> {
+  if (isE2eMockChain()) {
+    return getE2eMockCollection(collectionAddress);
+  }
+
   const DUMMY_KEY = "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
 
   const [name, symbol, creator, totalSupply, maxSupply, royalty] =


### PR DESCRIPTION
## Summary
This PR adds automated end-to-end tests for bidding validation and launchpad collection deployment flows:

1. **Bidding with insufficient funds shows UI error** (#524)
2. **Bidding below reserve price or current highest bid is rejected** (#525)
3. **Launchpad deployment signs Soroban contract deployment** (#531)
4. **Successful deployment redirects to new Collection page** (#532)

Closes #524
Closes #525
Closes #531
Closes #532