### PR TITLE
test(e2e): cover royalty splitter configuration

### DIFF
--- a/frontend/afristore-app/e2e/royalties.spec.ts
+++ b/frontend/afristore-app/e2e/royalties.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { TEST_PUBLIC_KEY } from "./freighter-mock";
+import {
+  MarketplaceTestStore,
+  rejectNextE2eTransaction,
+  resetE2eListingsInBrowser,
+  setupMarketplaceMocks,
+} from "./helpers/marketplace-mocks";
+import { connectFreighterWallet } from "./helpers/wallet";
+
+const SECOND_BENEFICIARY =
+  "GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN";
+
+test.describe("Royalties Splitter", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await connectFreighterWallet(page, TEST_PUBLIC_KEY);
+    await resetE2eListingsInBrowser(page);
+  });
+
+  test("#536: submitting royalties updates the contract split configuration", async ({
+    page,
+  }) => {
+    await page.goto("/dashboard/splitter");
+    await expect(
+      page.getByRole("heading", { name: "Create Royalty Splitter" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const addresses = page.getByPlaceholder(/GABC/);
+    const percentages = page.locator('input[type="number"]');
+
+    await addresses.first().fill(TEST_PUBLIC_KEY);
+    await percentages.first().fill("60");
+    await page.getByRole("button", { name: "Add", exact: true }).click();
+    await addresses.nth(1).fill(SECOND_BENEFICIARY);
+    await percentages.nth(1).fill("40");
+    await expect(page.getByText("100%", { exact: true })).toBeVisible();
+
+    const deployButton = page.getByRole("button", {
+      name: /deploy royalty splitter/i,
+    });
+
+    // A rejected Soroban signature prompt must leave the configuration editable.
+    await rejectNextE2eTransaction(page);
+    await deployButton.click();
+    await expect(page.getByText("User declined access")).toBeVisible();
+    await expect(addresses.first()).toHaveValue(TEST_PUBLIC_KEY);
+
+    await deployButton.click();
+
+    await expect(
+      page.getByRole("heading", { name: "Splitter Deployed" }),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const contractAddress = await page
+      .locator("code")
+      .filter({ hasText: /^CBR/ })
+      .textContent();
+    expect(contractAddress).toBeTruthy();
+
+    const configuration = await page.evaluate((address) => {
+      return (
+        window as Window & {
+          __E2E_GET_SPLITTER__?: (contractAddress: string) => {
+            owner: string;
+            recipients: Array<{ address: string; percentage: number }>;
+          };
+        }
+      ).__E2E_GET_SPLITTER__?.(address!);
+    }, contractAddress);
+
+    expect(configuration).toEqual({
+      owner: TEST_PUBLIC_KEY,
+      recipients: [
+        { address: TEST_PUBLIC_KEY, percentage: 60 },
+        { address: SECOND_BENEFICIARY, percentage: 40 },
+      ],
+    });
+  });
+});

--- a/frontend/afristore-app/src/lib/e2e-chain-mock.ts
+++ b/frontend/afristore-app/src/lib/e2e-chain-mock.ts
@@ -21,6 +21,13 @@ export interface E2eMockCollection {
 }
 const collections = new Map<string, E2eMockCollection>();
 
+let nextSplitterId = 1;
+export interface E2eMockSplitter {
+  owner: string;
+  recipients: Array<{ address: string; percentage: number }>;
+}
+const splitters = new Map<string, E2eMockSplitter>();
+
 declare global {
   interface Window {
     __E2E_GET_LISTINGS__?: () => Listing[];
@@ -33,6 +40,7 @@ declare global {
     __E2E_SEED_STAKING_POOL__?: (nftAddress: string, rewardRate?: bigint) => string;
     __E2E_GET_USER_STAKES__?: (publicKey: string) => E2eMockUserStake[];
     __E2E_RESET_STAKING__?: () => void;
+    __E2E_GET_SPLITTER__?: (address: string) => E2eMockSplitter | undefined;
   }
 }
 
@@ -76,6 +84,11 @@ export function resetE2eMockCollections(): void {
   nextCollectionId = 1;
 }
 
+export function resetE2eMockSplitters(): void {
+  splitters.clear();
+  nextSplitterId = 1;
+}
+
 export function getE2eMockAuctions(): Auction[] {
   return Array.from(auctions.values());
 }
@@ -99,6 +112,7 @@ export function registerE2eMockListingsOnWindow(): void {
     resetE2eMockListings();
     resetE2eMockAuctions();
     resetE2eMockCollections();
+    resetE2eMockSplitters();
     resetE2eMockStaking();
   };
 
@@ -108,6 +122,7 @@ export function registerE2eMockListingsOnWindow(): void {
   window.__E2E_GET_AUCTIONS__ = getE2eMockAuctions;
   window.__E2E_RESET_AUCTIONS__ = resetE2eMockAuctions;
   window.__E2E_SEED_AUCTION__ = seedE2eMockAuction;
+  window.__E2E_GET_SPLITTER__ = getE2eMockSplitter;
   if (window.__E2E_REJECT_NEXT_TX__ === undefined) {
     window.__E2E_REJECT_NEXT_TX__ = false;
   }
@@ -119,6 +134,30 @@ export function registerE2eMockListingsOnWindow(): void {
   }
 }
 
+export function e2eMockDeployRoyaltySplitter(
+  owner: string,
+  recipients: Array<{ address: string; percentage: number }>,
+): string {
+  consumeForcedRejection();
+
+  const address = `CB${"R".repeat(49)}${String(nextSplitterId++).padStart(5, "0")}`;
+  splitters.set(address, {
+    owner,
+    recipients: recipients.map((recipient) => ({ ...recipient })),
+  });
+  return address;
+}
+
+export function getE2eMockSplitter(
+  address: string,
+): E2eMockSplitter | undefined {
+  const splitter = splitters.get(address);
+  if (!splitter) return undefined;
+  return {
+    owner: splitter.owner,
+    recipients: splitter.recipients.map((recipient) => ({ ...recipient })),
+  };
+}
 export function e2eMockCreateListing(
   artistPublicKey: string,
   price: number,

--- a/frontend/afristore-app/src/lib/splitter.ts
+++ b/frontend/afristore-app/src/lib/splitter.ts
@@ -12,6 +12,10 @@ import {
 import { config } from "./config";
 import { signWithFreighter } from "./freighter";
 import { mapSorobanErrorMessage } from "./errors";
+import {
+  e2eMockDeployRoyaltySplitter,
+  isE2eMockChain,
+} from "./e2e-chain-mock";
 
 export interface SplitterRecipient {
   address: string;
@@ -105,6 +109,10 @@ export async function deployRoyaltySplitter(
   deployerPublicKey: string,
   recipients: SplitterRecipient[],
 ): Promise<string> {
+  if (isE2eMockChain()) {
+    return e2eMockDeployRoyaltySplitter(deployerPublicKey, recipients);
+  }
+
   const wasmHashHex = config.splitterWasmHash;
   if (!wasmHashHex) {
     throw new Error(


### PR DESCRIPTION
## Summary

- add Playwright coverage for submitting a 60/40 royalty split
- verify the UI displays a valid 100% allocation
- verify rejected Soroban signing leaves the configuration editable
- verify successful deployment stores the expected contract recipients
- add deterministic royalty-splitter support to the E2E mock chain

## Validation

- `git diff --check` passes
- Playwright/runtime checks were not run because `npm ci` repeatedly stalled before installing dependencies in the local environment

Closes #536