### PR TITLE
fix: add countdown timer, ending-soon badge, and restrict finalize to auction creator

### DIFF
--- a/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
+++ b/frontend/afristore-app/src/__tests__/BiddingPanel.test.tsx
@@ -123,9 +123,9 @@ describe("BiddingPanel", () => {
     expect(screen.getByText(/highest bid/i)).toBeInTheDocument();
   });
 
-  it("shows Finalize button for expired auctions", () => {
+  it("shows Finalize button for expired auctions when user is creator", () => {
     render(
-      <BiddingPanel auction={makeAuction({ end_time: 1, status: "Active" })} />,
+      <BiddingPanel auction={makeAuction({ end_time: 1, status: "Active", creator: "GBIDDER123" })} />,
     );
     expect(
       screen.getByRole("button", { name: /finalize/i }),
@@ -139,7 +139,7 @@ describe("BiddingPanel", () => {
 
     render(
       <BiddingPanel
-        auction={makeAuction({ end_time: 1 })}
+        auction={makeAuction({ end_time: 1, creator: "GBIDDER123" })}
         onFinalized={onFinalized}
       />,
     );

--- a/frontend/afristore-app/src/app/auctions/[id]/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/[id]/page.tsx
@@ -198,8 +198,11 @@ export default function AuctionDetailPage() {
   const isActive = auction?.status === "Active";
   const isFinalized = auction?.status === "Finalized";
   const isCancelled = auction?.status === "Cancelled";
-  const canFinalize = isActive && isExpired;
+  const isOwn = auction ? publicKey === auction.creator : false;
+  const canFinalize = isActive && isExpired && isOwn;
   const canBid = isActive && !isExpired;
+  const minutesRemaining = auction ? Math.floor(Math.max(0, auction.end_time - now) / 60) : 0;
+  const isEndingSoon = isActive && !isExpired && minutesRemaining > 0 && minutesRemaining <= 60;
 
   const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
   const highestBidXlm = auction ? stroopsToXlm(auction.highest_bid) : "0";
@@ -312,6 +315,12 @@ export default function AuctionDetailPage() {
                   Time Remaining
                 </p>
                 <Countdown endTime={auction.end_time} />
+                {isEndingSoon && (
+                  <div className="mt-3 flex items-center gap-2 rounded-xl bg-red-50 px-3 py-2 text-sm font-bold text-red-600 animate-pulse border border-red-200">
+                    <Clock size={14} />
+                    Ending Soon — {minutesRemaining} min remaining
+                  </div>
+                )}
               </div>
             )}
 

--- a/frontend/afristore-app/src/app/auctions/page.tsx
+++ b/frontend/afristore-app/src/app/auctions/page.tsx
@@ -75,6 +75,14 @@ function AuctionCard({ auction }: { auction: Auction }) {
 
   const imageUrl = metadata?.image ? cidToGatewayUrl(metadata.image) : null;
   const currentBidXlm = parseFloat(stroopsToXlm(auction.highest_bid));
+  const now = Math.floor(Date.now() / 1000);
+  const remainingSecs = Math.max(0, auction.end_time - now);
+  const minutesRemaining = Math.floor(remainingSecs / 60);
+  const isEndingSoon =
+    auction.status === "Active" &&
+    remainingSecs > 0 &&
+    minutesRemaining > 0 &&
+    minutesRemaining <= 60;
 
   return (
     <Link
@@ -105,6 +113,12 @@ function AuctionCard({ auction }: { auction: Auction }) {
         >
           {auction.status}
         </span>
+
+        {isEndingSoon && (
+          <span className="absolute top-3 left-3 rounded-full bg-red-100 px-2.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-red-600 animate-pulse">
+            Ending Soon
+          </span>
+        )}
       </div>
 
       {/* Info */}

--- a/frontend/afristore-app/src/components/BiddingPanel.tsx
+++ b/frontend/afristore-app/src/components/BiddingPanel.tsx
@@ -69,7 +69,7 @@ export function BiddingPanel({
     error: finalizeError,
   } = useFinalizeAuction(publicKey);
 
-  const { days, hours, minutes, seconds, isExpired } = useCountdown(
+  const { days, hours, minutes, seconds, remaining, isExpired } = useCountdown(
     auction.end_time,
   );
 
@@ -87,7 +87,9 @@ export function BiddingPanel({
   const isOwn = publicKey === auction.creator;
   const isActive = auction.status === "Active";
   const canBid = isActive && !isExpired && !isOwn;
-  const canFinalize = isActive && isExpired;
+  const canFinalize = isActive && isExpired && isOwn;
+  const minutesRemaining = Math.floor(remaining / 60);
+  const isEndingSoon = isActive && !isExpired && minutesRemaining > 0 && minutesRemaining <= 60;
 
   const bidValidation = useMemo(() => {
     const amount = parseFloat(bidAmount);
@@ -154,9 +156,21 @@ export function BiddingPanel({
         {isActive && isExpired && (
           <span className="text-xs font-semibold text-red-500">Expired</span>
         )}
+
+        {isEndingSoon && (
+          <span className="rounded-full bg-red-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider text-red-600 animate-pulse">
+            Ending Soon
+          </span>
+        )}
       </div>
 
-      {/* Countdown (large display for active auctions) */}
+      {/* Ending Soon / Countdown (large display for active auctions) */}
+      {isEndingSoon && (
+        <div className="flex items-center justify-center gap-2 rounded-xl bg-red-50 px-3 py-2 text-sm font-bold text-red-600 animate-pulse border border-red-200">
+          <Clock size={14} />
+          Ending Soon — {minutesRemaining} min remaining
+        </div>
+      )}
       {isActive && !isExpired && (
         <div className="grid grid-cols-4 gap-2 text-center">
           {[


### PR DESCRIPTION
## Summary

Fixes #453

### Changes
- Added **Ending Soon** pulsing badge for auctions with < 60 minutes remaining in BiddingPanel, auction detail page, and auction listing cards
- Restricted **Finalize Auction** CTA to only the auction creator in BiddingPanel and auction detail page (previously shown to all users)
- Existing countdown timers already display live HH:MM:SS via `setInterval`

### Files changed
- `frontend/afristore-app/src/components/BiddingPanel.tsx`
- `frontend/afristore-app/src/app/auctions/[id]/page.tsx`
- `frontend/afristore-app/src/app/auctions/page.tsx`