### PR TITLE
fix(launchpad): reject empty collection name during deploy

### DIFF
--- a/contracts/launchpad/src/contract.rs
+++ b/contracts/launchpad/src/contract.rs
@@ -200,6 +200,11 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
+        // Validate name is not empty
+        if name.is_empty() {
+            return Err(Error::EmptyName);
+        }
+
         // [FEE] Collect deployment fee using admin-set token (#442)
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
@@ -254,6 +259,11 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+
+        // Validate name is not empty
+        if name.is_empty() {
+            return Err(Error::EmptyName);
+        }
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
@@ -313,6 +323,11 @@ impl Launchpad {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
 
+        // Validate name is not empty
+        if name.is_empty() {
+            return Err(Error::EmptyName);
+        }
+
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);
         if fee > 0 {
@@ -367,6 +382,11 @@ impl Launchpad {
     ) -> Result<Address, Error> {
         storage::extend_instance_ttl(&env);
         creator.require_auth();
+
+        // Validate name is not empty
+        if name.is_empty() {
+            return Err(Error::EmptyName);
+        }
 
         // [FEE] Collect deployment fee (#442) — use globally-set fee token
         let (receiver, fee) = storage::get_platform_fee(&env);

--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -659,6 +659,96 @@ fn deploy_without_wasm_hashes_fails() {
     assert_eq!(result, Err(Ok(Error::WasmHashNotSet)));
 }
 
+// ── Issue #563: Empty collection name validation tests ───────────
+
+/// deploy_normal_721 with an empty name must return EmptyName error.
+#[test]
+fn deploy_normal_721_fails_on_empty_name() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0xEEu8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    let result = client.try_deploy_normal_721(
+        &creator,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "SYM"),
+        &100u64,
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+}
+
+/// deploy_normal_1155 with an empty name must return EmptyName error.
+#[test]
+fn deploy_normal_1155_fails_on_empty_name() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0xEFu8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    let result = client.try_deploy_normal_1155(
+        &creator,
+        &String::from_str(&env, ""),
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+}
+
+/// deploy_lazy_721 with an empty name must return EmptyName error.
+#[test]
+fn deploy_lazy_721_fails_on_empty_name() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0xF0u8; 32]);
+    let creator_pubkey = BytesN::from_array(&env, &[0x06u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    let result = client.try_deploy_lazy_721(
+        &creator,
+        &creator_pubkey,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "SYM"),
+        &100u64,
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+}
+
+/// deploy_lazy_1155 with an empty name must return EmptyName error.
+#[test]
+fn deploy_lazy_1155_fails_on_empty_name() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0xF1u8; 32]);
+    let creator_pubkey = BytesN::from_array(&env, &[0x07u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    let result = client.try_deploy_lazy_1155(
+        &creator,
+        &creator_pubkey,
+        &String::from_str(&env, ""),
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+}
+
 // ── Admin function tests ────────────────────────────────────────
 
 #[test]

--- a/contracts/launchpad/src/types.rs
+++ b/contracts/launchpad/src/types.rs
@@ -11,6 +11,7 @@ pub enum Error {
     StakingPoolAlreadyExists = 5,
     PlatformFeeTokenNotSet = 6,
     InvalidCurrency = 7,
+    EmptyName = 8,
 }
 
 /// Which of the four collection types was deployed.


### PR DESCRIPTION
## Summary

Adds validation to reject empty collection names in all four launchpad deploy functions. When a creator attempts to deploy a collection with an empty name string, the contract now returns `Error::EmptyName` instead of silently deploying a collection with an empty name.

## Changes

### Error enum (`types.rs`)
- Added new `EmptyName = 8` variant to the `Error` enum

### Contract logic (`contract.rs`)
- Added `name.is_empty()` validation check in all four deploy functions:
  - `deploy_normal_721`
  - `deploy_normal_1155`
  - `deploy_lazy_721`
  - `deploy_lazy_1155`
- The check runs after `creator.require_auth()` and before any fee collection or WASM deployment, failing fast to save gas

### Tests (`test.rs`)
- Added four new tests, one per deploy variant:
  - `deploy_normal_721_fails_on_empty_name`
  - `deploy_normal_1155_fails_on_empty_name`
  - `deploy_lazy_721_fails_on_empty_name`
  - `deploy_lazy_1155_fails_on_empty_name`
- Each test verifies that calling the deploy function with an empty name string returns `Err(Ok(Error::EmptyName))`

## Verification

- [ ] `cargo test --workspace -p soroban-launchpad` passes all tests
- [ ] All existing tests continue to pass

## Linked Issue

Closes #563
