### PR TITLE
feat(e2e): implement notifications and dashboard owned NFTs E2E tests

### DIFF
--- a/frontend/afristore-app/e2e/dashboard.spec.ts
+++ b/frontend/afristore-app/e2e/dashboard.spec.ts
@@ -11,6 +11,7 @@ test.describe("Dashboard empty state (#477)", () => {
   const store = new MarketplaceTestStore();
 
   test.beforeEach(async ({ page }) => {
+    test.setTimeout(90000);
     store.reset();
     await setupMarketplaceMocks(page, store);
     // User owns 0 NFTs — tokens endpoint returns an empty array.
@@ -37,5 +38,51 @@ test.describe("Dashboard empty state (#477)", () => {
     await expect(
       page.getByText(/don't own any NFTs on this network/i),
     ).toBeVisible();
+  });
+});
+
+test.describe("Dashboard owned NFTs (#476)", () => {
+  const store = new MarketplaceTestStore();
+
+  const MOCK_TOKENS = [
+    {
+      collectionAddress: "CDP7YNF7SOWQ3GLR2ZGMH7TQZ2N2LHCP5JH5C4H4K2PJ7X2OV4YH4L7I",
+      tokenId: 42,
+      name: "Serengeti Sunset",
+      image: "ipfs://image-cid-1",
+    },
+    {
+      collectionAddress: "CDP7YNF7SOWQ3GLR2ZGMH7TQZ2N2LHCP5JH5C4H4K2PJ7X2OV4YH4L7I",
+      tokenId: 99,
+      name: "African Horizon",
+      image: "ipfs://image-cid-2",
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    test.setTimeout(90000);
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    // User owns 2 NFTs
+    await setupWalletIndexerMocks(page, { tokens: MOCK_TOKENS });
+    await resetE2eListingsInBrowser(page);
+    await connectFreighterWallet(page);
+  });
+
+  test("dashboard displays correct owned NFTs from indexer", async ({
+    page,
+  }) => {
+    // Navigate to new listing / gallery view to load owned NFTs
+    await page.goto("/dashboard");
+    await page.getByRole("button", { name: /new listing/i }).click();
+
+    // Check that we can see the selection title
+    await expect(page.getByText("Select an NFT to List")).toBeVisible({ timeout: 15_000 });
+
+    // Assert that the tokens returned from the indexer are correctly displayed
+    for (const token of MOCK_TOKENS) {
+      await expect(page.getByText(token.name)).toBeVisible();
+      await expect(page.getByText(`ID: ${token.tokenId}`)).toBeVisible();
+    }
   });
 });

--- a/frontend/afristore-app/e2e/notifications.spec.ts
+++ b/frontend/afristore-app/e2e/notifications.spec.ts
@@ -3,6 +3,7 @@ import { connectFreighterWallet } from "./helpers/wallet";
 
 test.describe("Notifications", () => {
   test.beforeEach(async ({ page }) => {
+    test.setTimeout(90000);
     await connectFreighterWallet(page);
   });
 
@@ -76,5 +77,160 @@ test.describe("Notifications", () => {
         }
       }
     }
+  });
+
+  // ── Issue #488 ──────────────────────────────────────────────────────────────
+  test("clicking notification bell opens dropdown with recent events", async ({
+    page,
+  }) => {
+    const INDEXER_URL = (
+      process.env.NEXT_PUBLIC_INDEXER_URL ?? "http://localhost:4000"
+    ).replace(/\/$/, "");
+
+    const MOCK_NOTIFICATIONS = [
+      {
+        id: "n-1",
+        type: "sale",
+        title: "Your NFT sold",
+        message: "E2E Serengeti Sunset was purchased for 100 XLM",
+        read: false,
+        created_at: Date.now() - 60_000,
+        link: "/listings/1",
+      },
+      {
+        id: "n-2",
+        type: "bid",
+        title: "New bid received",
+        message: "Someone bid 50 XLM on your auction",
+        read: false,
+        created_at: Date.now() - 120_000,
+        link: "/auctions/2",
+      },
+    ];
+
+    // Mock the notifications API before navigating so the app receives seeded data.
+    await page.route(`${INDEXER_URL}/notifications**`, async (route) => {
+      if (route.request().method() !== "GET") return route.continue();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ notifications: MOCK_NOTIFICATIONS }),
+      });
+    });
+
+    await page.goto("/");
+
+    const notificationBell = page.locator('[data-testid="notification-bell"]');
+    await expect(notificationBell).toBeVisible({ timeout: 10_000 });
+
+    // Dropdown must NOT be visible before the bell is clicked.
+    const dropdown = page.locator('[data-testid="notification-panel"]');
+    await expect(dropdown).not.toBeVisible();
+
+    // Act: click the bell.
+    await notificationBell.click();
+
+    // Assert: dropdown opens and lists the seeded recent events.
+    await expect(dropdown).toBeVisible({ timeout: 5_000 });
+
+    const items = dropdown.locator('[data-testid="notification-item"]');
+    await expect(items).toHaveCount(MOCK_NOTIFICATIONS.length, {
+      timeout: 5_000,
+    });
+
+    for (const notification of MOCK_NOTIFICATIONS) {
+      await expect(dropdown.getByText(notification.title)).toBeVisible();
+    }
+  });
+
+  // ── Issue #490 ──────────────────────────────────────────────────────────────
+  test("mark all as read clears the notification counter", async ({ page }) => {
+    const INDEXER_URL = (
+      process.env.NEXT_PUBLIC_INDEXER_URL ?? "http://localhost:4000"
+    ).replace(/\/$/, "");
+
+    const notifications = [
+      {
+        id: "n-1",
+        type: "sale",
+        title: "NFT sold",
+        message: "Your NFT sold for 100 XLM",
+        read: false,
+        created_at: Date.now() - 60_000,
+        link: "/listings/1",
+      },
+      {
+        id: "n-2",
+        type: "bid",
+        title: "Bid received",
+        message: "New bid of 50 XLM",
+        read: false,
+        created_at: Date.now() - 90_000,
+        link: "/auctions/3",
+      },
+    ];
+
+    // Track whether the mark-all-read PATCH request has fired.
+    let markedAllRead = false;
+
+    await page.route(`${INDEXER_URL}/notifications**`, async (route) => {
+      const method = route.request().method();
+
+      if (method === "GET") {
+        // Return all-read payload after the PATCH so the badge reflects 0.
+        const payload = markedAllRead
+          ? notifications.map((n) => ({ ...n, read: true }))
+          : notifications;
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ notifications: payload }),
+        });
+        return;
+      }
+
+      if (method === "PATCH") {
+        markedAllRead = true;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ success: true }),
+        });
+        return;
+      }
+
+      return route.continue();
+    });
+
+    await page.goto("/");
+
+    const notificationBell = page.locator('[data-testid="notification-bell"]');
+    await expect(notificationBell).toBeVisible({ timeout: 10_000 });
+
+    // Badge should reflect the unread count before acting.
+    const badge = notificationBell.locator(
+      '[data-testid="notification-count"]',
+    );
+    await expect(badge).toBeVisible({ timeout: 5_000 });
+    const initialCount = await badge
+      .textContent()
+      .then((t) => parseInt(t ?? "0", 10));
+    expect(initialCount).toBeGreaterThan(0);
+
+    // Open the dropdown.
+    await notificationBell.click();
+    const panel = page.locator('[data-testid="notification-panel"]');
+    await expect(panel).toBeVisible({ timeout: 5_000 });
+
+    // Click "Mark all as read".
+    const markAllBtn = panel.getByRole("button", { name: /mark all as read/i });
+    await expect(markAllBtn).toBeVisible({ timeout: 5_000 });
+    await markAllBtn.click();
+
+    // The badge must either display "0" or be hidden entirely.
+    const badgeGone = badge.waitFor({ state: "hidden", timeout: 5_000 });
+    const badgeZero = expect(badge).toHaveText("0", { timeout: 5_000 });
+    await Promise.race([badgeGone, badgeZero]);
   });
 });

--- a/frontend/afristore-app/playwright.config.ts
+++ b/frontend/afristore-app/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  timeout: 90 * 1000, // 90 seconds timeout per test
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
@@ -20,7 +21,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: "npm run dev:e2e",
+    command: "NEXT_PUBLIC_E2E_MOCK_CHAIN=true npx next dev",
     url: "http://localhost:3000",
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,

--- a/frontend/afristore-app/src/components/Navbar.tsx
+++ b/frontend/afristore-app/src/components/Navbar.tsx
@@ -1,7 +1,6 @@
 // ─────────────────────────────────────────────────────────────
 // components/Navbar.tsx — Afristore Navigation (Redesigned)
 // ─────────────────────────────────────────────────────────────
-
 "use client";
 
 import { useState, useEffect, useRef } from "react";
@@ -9,6 +8,7 @@ import Link from "next/link";
 import { useWalletContext } from "@/context/WalletContext";
 import {
   AlertTriangle,
+  Bell,
   ChevronDown,
   Compass,
   Gavel,
@@ -79,6 +79,82 @@ export function Navbar() {
       document.removeEventListener("mousedown", handleClickOutside);
     };
   }, [userMenuOpen]);
+
+  const [notifications, setNotifications] = useState<any[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const INDEXER_URL = (
+    process.env.NEXT_PUBLIC_INDEXER_URL ?? "http://localhost:4000"
+  ).replace(/\/$/, "");
+
+  const fetchNotifications = async () => {
+    if (!publicKey) return;
+    try {
+      const res = await fetch(`${INDEXER_URL}/notifications?address=${publicKey}`);
+      if (res.ok) {
+        const data = await res.json();
+        const list = data.notifications || [];
+        setNotifications(list);
+        setUnreadCount(list.filter((n: any) => !n.read).length);
+      }
+    } catch (err) {
+      console.error("Failed to fetch notifications:", err);
+    }
+  };
+
+  const markAllAsRead = async () => {
+    if (!publicKey) return;
+    try {
+      const res = await fetch(`${INDEXER_URL}/notifications?address=${publicKey}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+      });
+      if (res.ok) {
+        setNotifications((prev) => prev.map((n) => ({ ...n, read: true })));
+        setUnreadCount(0);
+      }
+    } catch (err) {
+      console.error("Failed to mark notifications as read:", err);
+    }
+  };
+
+  useEffect(() => {
+    if (!publicKey) {
+      setNotifications([]);
+      setUnreadCount(0);
+      return;
+    }
+
+    fetchNotifications();
+
+    const eventSource = new EventSource(`${INDEXER_URL}/events/stream`);
+    eventSource.onmessage = () => {
+      fetchNotifications();
+    };
+    eventSource.onerror = () => {
+      // ignore
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [publicKey]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (panelRef.current && !panelRef.current.contains(e.target as Node)) {
+        setPanelOpen(false);
+      }
+    };
+    if (panelOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+    }
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [panelOpen]);
 
   return (
     <>
@@ -157,6 +233,80 @@ export function Navbar() {
                     Connected
                   </div>
                 )}
+
+                {/* Notification Bell */}
+                <div className="relative" ref={panelRef}>
+                  <button
+                    data-testid="notification-bell"
+                    onClick={() => setPanelOpen((prev) => !prev)}
+                    className="relative flex items-center justify-center w-9 h-9 rounded-xl bg-white/5 border border-white/10 hover:bg-white/10 text-white/70 hover:text-white transition-colors"
+                  >
+                    <Bell size={18} />
+                    {unreadCount > 0 && (
+                      <span
+                        data-testid="notification-count"
+                        className="absolute -top-1 -right-1 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-brand-500 px-1 text-[9px] font-bold text-white ring-2 ring-midnight-950"
+                      >
+                        {unreadCount}
+                      </span>
+                    )}
+                  </button>
+
+                  {/* Notification Dropdown Panel */}
+                  {panelOpen && (
+                    <div
+                      data-testid="notification-panel"
+                      className="absolute right-0 mt-2 w-80 rounded-2xl bg-midnight-900/98 backdrop-blur-xl border border-white/10 shadow-xl shadow-black/40 overflow-hidden z-50 animate-in fade-in slide-in-from-top-2 duration-200"
+                    >
+                      <div className="flex items-center justify-between px-4 py-3 border-b border-white/5 bg-white/[0.02]">
+                        <span className="text-xs font-bold text-white">Notifications</span>
+                        {unreadCount > 0 && (
+                          <button
+                            onClick={markAllAsRead}
+                            className="text-[10px] font-bold text-brand-400 hover:text-brand-300 transition-colors uppercase tracking-wider"
+                          >
+                            Mark all as read
+                          </button>
+                        )}
+                      </div>
+
+                      <div className="max-h-72 overflow-y-auto divide-y divide-white/5">
+                        {notifications.length === 0 ? (
+                          <div className="flex flex-col items-center justify-center py-8 text-center px-4">
+                            <span className="text-2xl mb-2">🔔</span>
+                            <p className="text-xs text-white/40">No notifications yet</p>
+                          </div>
+                        ) : (
+                          notifications.map((n) => (
+                            <div
+                              key={n.id}
+                              data-testid="notification-item"
+                              className={`p-4 transition-colors hover:bg-white/[0.02] ${
+                                !n.read ? "bg-white/[0.01]" : ""
+                              }`}
+                            >
+                              <Link href={n.link || "#"} onClick={() => setPanelOpen(false)}>
+                                <div className="flex items-start gap-3 flex-row">
+                                  <div className="flex-1 min-w-0 text-left">
+                                    <p className={`text-xs text-white truncate ${!n.read ? "font-bold" : "font-medium"}`}>
+                                      {n.title}
+                                    </p>
+                                    <p className="text-[11px] text-white/50 mt-0.5 leading-normal whitespace-normal">
+                                      {n.message}
+                                    </p>
+                                  </div>
+                                  {!n.read && (
+                                    <span className="w-1.5 h-1.5 rounded-full bg-brand-500 shrink-0 mt-1.5" />
+                                  )}
+                                </div>
+                              </Link>
+                            </div>
+                          ))
+                        )}
+                      </div>
+                    </div>
+                  )}
+                </div>
 
                 <div className="relative" ref={userMenuRef}>
                   <button


### PR DESCRIPTION
### Summary of Changes
Consolidates E2E testing improvements and component support across notifications and the artist dashboard:

- **Notifications Dropdown (#488)**: Added `Notification Bell` component to `Navbar` with dropdown panel displaying recent events and Playwright E2E coverage.
- **Mark All as Read (#490)**: Added "Mark all as read" API trigger and UI button to reset unread counters with Playwright E2E coverage.
- **Dashboard Owned NFTs (#476)**: Added Playwright E2E tests verifying owned tokens from `/wallets/:address/tokens` display in the dashboard gallery.

Closes #476
Closes #488
Closes #490
