### PR TITLE
test(contracts): add tests verifying update_royalty fails for non-creator #559

### DIFF
--- a/contracts/collection_nft_erc1155/src/test.rs
+++ b/contracts/collection_nft_erc1155/src/test.rs
@@ -273,3 +273,37 @@ fn burn_with_missing_total_supply_key_returns_zero_not_amount() {
     // total_supply must be 0, not 3 (the old unwrap_or(amount) result).
     assert_eq!(client.total_supply(&token_id), 0u128);
 }
+
+#[test]
+fn update_royalty_changes_receiver_and_bps() {
+    let (env, client, _, _) = setup();
+    let new_receiver = Address::generate(&env);
+
+    client.update_royalty(&new_receiver, &250u32);
+    let (recv, bps) = client.royalty_info();
+    assert_eq!(recv, new_receiver);
+    assert_eq!(bps, 250u32);
+}
+
+#[test]
+fn update_royalty_fails_if_not_creator() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let contract_id = env.register(NormalNFT1155, ());
+    let client = NormalNFT1155Client::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let royalty_receiver = Address::generate(&env);
+
+    client.initialize(
+        &creator,
+        &String::from_str(&env, "Test 1155"),
+        &500u32,
+        &royalty_receiver,
+    );
+
+    let new_receiver = Address::generate(&env);
+    let result = client.try_update_royalty(&new_receiver, &250u32);
+    assert!(result.is_err());
+}

--- a/contracts/collection_nft_erc721/src/test.rs
+++ b/contracts/collection_nft_erc721/src/test.rs
@@ -525,6 +525,31 @@ fn update_royalty_changes_receiver_and_bps() {
     assert_eq!(bps, 250u32);
 }
 
+#[test]
+fn update_royalty_fails_if_not_creator() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let contract_id = env.register(NormalNFT721, ());
+    let client = NormalNFT721Client::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let royalty_receiver = Address::generate(&env);
+
+    client.initialize(
+        &creator,
+        &String::from_str(&env, "Test Collection 721"),
+        &String::from_str(&env, "T721"),
+        &1_000u64,
+        &500u32,
+        &royalty_receiver,
+    );
+
+    let new_receiver = Address::generate(&env);
+    let result = client.try_update_royalty(&new_receiver, &250u32);
+    assert!(result.is_err());
+}
+
 // ── Balance corruption fix test ───────────────────────────────────────────────
 
 #[test]

--- a/contracts/lazy_mint_erc1155/src/test.rs
+++ b/contracts/lazy_mint_erc1155/src/test.rs
@@ -621,3 +621,24 @@ fn burn_with_missing_total_supply_key_returns_zero_not_amount() {
     // total_supply must be 0, not 3 (the old unwrap_or(amount) result).
     assert_eq!(client.total_supply(&token_id), 0u128);
 }
+
+#[test]
+fn update_royalty_changes_receiver_and_bps() {
+    let (env, client, _, _, _) = setup_env();
+    env.mock_all_auths();
+    let new_receiver = Address::generate(&env);
+
+    client.update_royalty(&new_receiver, &250u32);
+    let (recv, bps) = client.royalty_info();
+    assert_eq!(recv, new_receiver);
+    assert_eq!(bps, 250u32);
+}
+
+#[test]
+fn update_royalty_fails_if_not_creator() {
+    let (env, client, _, _, _) = setup_env();
+    // Do NOT call env.mock_all_auths()
+    let new_receiver = Address::generate(&env);
+    let result = client.try_update_royalty(&new_receiver, &250u32);
+    assert!(result.is_err());
+}

--- a/contracts/lazy_mint_erc721/src/test.rs
+++ b/contracts/lazy_mint_erc721/src/test.rs
@@ -292,3 +292,53 @@ fn test_voucher_expired_returns_proper_error() {
 
     assert_eq!(result, Err(Ok(Error::VoucherExpired)));
 }
+
+#[test]
+fn update_royalty_changes_receiver_and_bps() {
+    let (env, client, creator) = setup_test();
+    let pubkey = BytesN::from_array(&env, &[0u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    client.initialize(
+        &creator,
+        &pubkey,
+        &String::from_str(&env, "Token Name"),
+        &String::from_str(&env, "TKN"),
+        &1000u64,
+        &500u32,
+        &royalty_receiver,
+    );
+
+    let new_receiver = Address::generate(&env);
+    client.update_royalty(&new_receiver, &250u32);
+    let (recv, bps) = client.royalty_info();
+    assert_eq!(recv, new_receiver);
+    assert_eq!(bps, 250u32);
+}
+
+#[test]
+fn update_royalty_fails_if_not_creator() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+
+    let contract_id = env.register(LazyMint721, ());
+    let client = LazyMint721Client::new(&env, &contract_id);
+
+    let creator = Address::generate(&env);
+    let pubkey = BytesN::from_array(&env, &[0u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    client.initialize(
+        &creator,
+        &pubkey,
+        &String::from_str(&env, "Token Name"),
+        &String::from_str(&env, "TKN"),
+        &1000u64,
+        &500u32,
+        &royalty_receiver,
+    );
+
+    let new_receiver = Address::generate(&env);
+    let result = client.try_update_royalty(&new_receiver, &250u32);
+    assert!(result.is_err());
+}


### PR DESCRIPTION
Resolves #559. Adds automated tests to verify that update_royalty (which manages the royalty split configuration) correctly fails with an authorization error when called by a non-creator/non-admin.