### PR TITLE
fix(indexer): resolve TS compilation errors and enhance reorg test coverage

### DIFF
--- a/indexer/src/__tests__/reorg.test.ts
+++ b/indexer/src/__tests__/reorg.test.ts
@@ -1,4 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const mockRedisClient: any = vi.hoisted(() => ({
+  isReady: true,
+  flushDb: vi.fn().mockResolvedValue('OK'),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+}));
 
 const mockPrisma: any = vi.hoisted(() => {
   const mPrisma: any = {
@@ -21,6 +27,7 @@ const mockPrisma: any = vi.hoisted(() => {
 });
 
 vi.mock('../db', () => ({ default: mockPrisma }));
+vi.mock('../redis', () => ({ default: mockRedisClient }));
 
 vi.mock('@stellar/stellar-sdk', () => ({
   rpc: {
@@ -40,6 +47,8 @@ describe('Chain Re-organization Rollback', () => {
     mockPrisma.$transaction.mockImplementation(
       (callback: (tx: typeof mockPrisma) => Promise<void>) => callback(mockPrisma)
     );
+    mockRedisClient.isReady = true;
+    mockRedisClient.flushDb.mockResolvedValue('OK');
   });
 
   it('deletes events and listings created after the safe ledger', async () => {
@@ -86,11 +95,68 @@ describe('Chain Re-organization Rollback', () => {
     await revertLedgers(50);
 
     expect(mockPrisma.$transaction).toHaveBeenCalledOnce();
-    // All DB calls happen inside the transaction callback
     expect(mockPrisma.marketplaceEvent.deleteMany).toHaveBeenCalledOnce();
     expect(mockPrisma.listing.deleteMany).toHaveBeenCalledOnce();
     expect(mockPrisma.listing.updateMany).toHaveBeenCalledOnce();
     expect(mockPrisma.collection.deleteMany).toHaveBeenCalledOnce();
     expect(mockPrisma.syncState.update).toHaveBeenCalledOnce();
+  });
+
+  it('invalidates Redis cache after successful rollback when Redis is ready', async () => {
+    await revertLedgers(100);
+
+    expect(mockRedisClient.flushDb).toHaveBeenCalledOnce();
+  });
+
+  it('skips Redis cache invalidation when Redis is not ready', async () => {
+    mockRedisClient.isReady = false;
+
+    await revertLedgers(100);
+
+    expect(mockRedisClient.flushDb).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when Redis flushDb fails', async () => {
+    mockRedisClient.flushDb.mockRejectedValue(new Error('Redis connection lost'));
+
+    await expect(revertLedgers(100)).resolves.not.toThrow();
+  });
+
+  it('propagates transaction errors to the caller', async () => {
+    mockPrisma.$transaction.mockRejectedValue(new Error('Transaction failed'));
+
+    await expect(revertLedgers(100)).rejects.toThrow('Transaction failed');
+  });
+
+  it('handles graceful degradation when zero records match the safe ledger', async () => {
+    mockPrisma.marketplaceEvent.deleteMany.mockResolvedValue({ count: 0 });
+    mockPrisma.listing.deleteMany.mockResolvedValue({ count: 0 });
+    mockPrisma.listing.updateMany.mockResolvedValue({ count: 0 });
+    mockPrisma.collection.deleteMany.mockResolvedValue({ count: 0 });
+
+    await expect(revertLedgers(1)).resolves.not.toThrow();
+  });
+
+  it('passes the correct safe ledger to all database operations', async () => {
+    const safeLedger = 505;
+    await revertLedgers(safeLedger);
+
+    expect(mockPrisma.marketplaceEvent.deleteMany).toHaveBeenCalledWith({
+      where: { ledgerSequence: { gt: safeLedger } },
+    });
+    expect(mockPrisma.listing.deleteMany).toHaveBeenCalledWith({
+      where: { createdAtLedger: { gt: safeLedger } },
+    });
+    expect(mockPrisma.listing.updateMany).toHaveBeenCalledWith({
+      where: { updatedAtLedger: { gt: safeLedger } },
+      data: { status: 'Active', updatedAtLedger: safeLedger },
+    });
+    expect(mockPrisma.collection.deleteMany).toHaveBeenCalledWith({
+      where: { deployedAtLedger: { gt: safeLedger } },
+    });
+    expect(mockPrisma.syncState.update).toHaveBeenCalledWith({
+      where: { id: 1 },
+      data: { lastLedger: safeLedger, lastLedgerHash: null },
+    });
   });
 });

--- a/indexer/src/poller.ts
+++ b/indexer/src/poller.ts
@@ -133,6 +133,17 @@ export async function revertLedgers(safeAtLedger: number): Promise<void> {
       data: { lastLedger: safeAtLedger, lastLedgerHash: null },
     });
   });
+
+  // Invalidate cached data that may be stale after the rollback
+  if (redis && redis.isReady) {
+    try {
+      await redis.flushDb();
+      console.log('[Reorg] Redis cache invalidated after rollback');
+    } catch (err) {
+      console.warn('[Reorg] Failed to invalidate Redis cache:', err);
+    }
+  }
+
   console.log(`[Reorg] Rollback complete. Resuming from ledger ${safeAtLedger + 1}`);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1505,9 +1505,9 @@
       }
     },
     "indexer/node_modules/typescript": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
-      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
+      "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {


### PR DESCRIPTION
## Summary

Fixes TypeScript compilation errors in the indexer and enhances reorg test coverage with Redis cache invalidation.
Closes #566 
Closes #567 
Closes #568 
Closes #569 

## Changes

### Bug Fix
- **Corrupted TypeScript installation**: The package-lock.json had TypeScript ^6.0.2 but the package.json specified ^5.4.5. This caused TS 6.0.3 to be installed, which was missing \lib.es5.d.ts\ — the file containing core global types (\Boolean\, \CallableFunction\, \NewableFunction\, \Object\). Locked to 5.4.5.

### Enhancement
- **Redis cache invalidation on reorg**: \
evertLedgers()\ now calls \
edis.flushDb()\ after a successful database rollback to clear stale cached data that may reference now-invalid records.

### Test Coverage (reorg.test.ts)
Added 6 new test cases (147 total, +6):
1. Redis cache invalidation when Redis is ready
2. Skips invalidation when Redis is not ready
3. Graceful handling when Redis flushDb fails
4. Transaction error propagation
5. Graceful degradation with zero matching records
6. Consistent safe-ledger parameter verification across all operations

## CI Checks
- \
pm run test\: 147/147 passed
- \
pm run lint\ (prisma:generate + tsc --noEmit): passes