### PR TITLE
feat(indexer): add GET /collections/:address/stats endpoint and tests…

### DIFF
--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -17,6 +17,7 @@ const mockPrisma = vi.hoisted(() => ({
   },
   collection: {
     findMany: vi.fn(),
+    findUnique: vi.fn(),
   },
   userPreferences: {
     findUnique: vi.fn(),
@@ -685,6 +686,68 @@ describe('PUT /wallets/:address/preferences', () => {
     expect(call.update.theme).toBeUndefined();
     expect(call.update.currency).toBeUndefined();
     expect(call.update.priceAlerts).toBeUndefined();
+  });
+});
+
+// ── GET /collections/:id/stats ───────────────────────────────────────────────
+
+describe('GET /collections/:id/stats', () => {
+  const CONTRACT = 'CCONTRACT123';
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('correctly aggregates volume, floor price, and total items', async () => {
+    mockPrisma.collection.findUnique.mockResolvedValue({
+      contractAddress: CONTRACT,
+      kind: 'normal_721',
+      creator: 'GCREATOR',
+      deployedAtLedger: 100,
+    });
+    mockPrisma.listing.aggregate
+      .mockResolvedValueOnce({ _sum: { price: '3000.0000000' } })  // volume
+      .mockResolvedValueOnce({ _min: { price: '500.0000000' } });  // floor
+    mockPrisma.listing.count.mockResolvedValue(12);
+
+    const res = await request(app).get(`/collections/${CONTRACT}/stats`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.contractAddress).toBe(CONTRACT);
+    expect(res.body.totalVolume).toBe('3000.0000000');
+    expect(res.body.floorPrice).toBe('500.0000000');
+    expect(res.body.totalItems).toBe(12);
+  });
+
+  it('returns null floorPrice when there are no active listings', async () => {
+    mockPrisma.collection.findUnique.mockResolvedValue({ contractAddress: CONTRACT });
+    mockPrisma.listing.aggregate
+      .mockResolvedValueOnce({ _sum: { price: null } })
+      .mockResolvedValueOnce({ _min: { price: null } });
+    mockPrisma.listing.count.mockResolvedValue(0);
+
+    const res = await request(app).get(`/collections/${CONTRACT}/stats`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.totalVolume).toBe('0');
+    expect(res.body.floorPrice).toBeNull();
+    expect(res.body.totalItems).toBe(0);
+  });
+
+  it('returns 404 when the collection does not exist', async () => {
+    mockPrisma.collection.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).get('/collections/DOESNOTEXIST/stats');
+
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('Collection not found');
+  });
+
+  it('returns 500 when the database throws', async () => {
+    mockPrisma.collection.findUnique.mockRejectedValue(new Error('DB down'));
+
+    const res = await request(app).get(`/collections/${CONTRACT}/stats`);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBeDefined();
   });
 });
 

--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -23,12 +23,16 @@ const mockPrisma = vi.hoisted(() => ({
     findUnique: vi.fn(),
     upsert: vi.fn(),
   },
+  stakedNFT: {
+    findMany: vi.fn(),
+  },
 }));
 
 const mockRedis = vi.hoisted(() => ({
   isOpen: false,
   isReady: false,
   get: vi.fn(),
+  set: vi.fn().mockResolvedValue(undefined),
   setEx: vi.fn().mockResolvedValue(undefined),
   on: vi.fn(),
   connect: vi.fn().mockRejectedValue(new Error('No Redis')),

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -621,6 +621,43 @@ router.put('/wallets/:address/preferences', async (req: Request, res: Response) 
     }
 });
 
+// GET /collections/:address/stats — volume, floor price, and total items for a collection
+router.get('/collections/:address/stats', async (req: Request, res: Response) => {
+    const { address } = req.params;
+    try {
+        const collection = await prisma.collection.findUnique({
+            where: { contractAddress: address },
+        });
+        if (!collection) {
+            return res.status(404).json({ error: 'Collection not found' });
+        }
+
+        const [volumeResult, floorResult, totalItems] = await Promise.all([
+            prisma.listing.aggregate({
+                _sum: { price: true },
+                where: { collection: address, status: 'Sold' },
+            }),
+            prisma.listing.aggregate({
+                _min: { price: true },
+                where: { collection: address, status: 'Active' },
+            }),
+            prisma.listing.count({
+                where: { collection: address },
+            }),
+        ]);
+
+        res.json({
+            contractAddress: address,
+            totalVolume: volumeResult._sum.price?.toString() ?? '0',
+            floorPrice: floorResult._min.price?.toString() ?? null,
+            totalItems,
+        });
+    } catch (err) {
+        console.error('Error details:', err);
+        res.status(500).json({ error: 'Failed to fetch collection stats' });
+    }
+});
+
 // GET /collections/:address — fetch a single collection by contract address
 router.get('/collections/:address', async (req: Request, res: Response) => {
     const { address } = req.params;

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -623,7 +623,7 @@ router.put('/wallets/:address/preferences', async (req: Request, res: Response) 
 
 // GET /collections/:address/stats — volume, floor price, and total items for a collection
 router.get('/collections/:address/stats', async (req: Request, res: Response) => {
-    const { address } = req.params;
+    const address = req.params.address as string;
     try {
         const collection = await prisma.collection.findUnique({
             where: { contractAddress: address },
@@ -648,8 +648,8 @@ router.get('/collections/:address/stats', async (req: Request, res: Response) =>
 
         res.json({
             contractAddress: address,
-            totalVolume: volumeResult._sum.price?.toString() ?? '0',
-            floorPrice: floorResult._min.price?.toString() ?? null,
+            totalVolume: volumeResult?._sum?.price?.toString() ?? '0',
+            floorPrice: floorResult?._min?.price?.toString() ?? null,
             totalItems,
         });
     } catch (err) {


### PR DESCRIPTION
Closes #565

---

… (#577)

- Add route that aggregates totalVolume (sum of Sold listings), floorPrice (min price of Active listings), and totalItems (count) for a collection
- Route validates the collection exists first, returns 404 if not found
- Route placed before /collections/:address to prevent param shadowing
- Add collection.findUnique mock to the test mock setup
- Add 4 test cases: happy path aggregation, null floor/volume, 404, 500

## Description
**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [ ] I have added unit tests to cover my changes and tested edge cases.
- [ ] All tests pass locally (`cargo test`).


Closes #577

## Additional Context