### PR TITLE
test: verify unstake_nft fails when user hasn't staked the specific NFT (closes #553

### DIFF
--- a/contracts/nft-staking/src/test.rs
+++ b/contracts/nft-staking/src/test.rs
@@ -70,6 +70,7 @@ use soroban_sdk::{
 };
 
 use crate::contract::NftStakingClient;
+use crate::StakingError;
 
 fn setup() -> (Env, NftStakingClient<'static>, Address, Address, Address) {
     let env = Env::default();
@@ -248,4 +249,105 @@ fn test_stake_fails_when_not_owner() {
         soroban_sdk::vec![&env, 0u64.into_val(&env)],
     );
     assert_eq!(owner, user, "token should still belong to original owner");
+}
+
+// Issue #553 (literal ask): unstaking an NFT the caller never staked must fail
+// with the typed `NotStaked` error — not a generic panic — and must not mutate
+// any state as a side effect. The position lookup is keyed by the caller's own
+// address (DataKey::StakedPosition(user, token, id)), so "never staked" is the
+// canonical path through the `NotStaked` guard in `unstake_erc721`.
+#[test]
+fn test_unstake_fails_when_not_staked() {
+    let (env, staking, user, collection, _admin) = setup_with_mock();
+
+    // Mint the token to the user but deliberately never stake it.
+    mint_token(&env, &collection, &user, 0);
+
+    // Sanity: precondition state is empty before the failing call.
+    assert!(
+        staking
+            .get_staked_position(&user, &collection, &0)
+            .is_none(),
+        "no position should exist before staking"
+    );
+    assert_eq!(staking.total_staked(), 0);
+
+    // The call must revert with the typed `NotStaked` error, asserted exactly
+    // via the generated `try_` client method (repo-wide convention).
+    let err = staking
+        .try_unstake(&user, &collection, &0)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, StakingError::NotStaked.into());
+
+    // No storage mutation must have occurred: no stray position, unchanged
+    // total, and the NFT still owned by the user (never moved to the pool).
+    assert!(
+        staking
+            .get_staked_position(&user, &collection, &0)
+            .is_none(),
+        "failed unstake must not create a staking record"
+    );
+    assert_eq!(
+        staking.total_staked(),
+        0,
+        "failed unstake must not change total staked"
+    );
+    let owner: Address = env.invoke_contract(
+        &collection,
+        &Symbol::new(&env, "owner_of"),
+        soroban_sdk::vec![&env, 0u64.into_val(&env)],
+    );
+    assert_eq!(owner, user, "token ownership must be unchanged");
+}
+
+// Adjacent gap found during #553 work (not the issue's literal scope): unstaking
+// an NFT that *is* staked, but by a *different* user, must also fail with
+// `NotStaked` for the caller. Because positions are keyed by caller address, the
+// victim's position lives under a different key and is invisible to the attacker
+// — so this correctly collapses to the same `NotStaked` guard. This test proves
+// a caller cannot unstake (and thereby steal) another user's staked NFT, and
+// that the victim's position and the NFT custody are left intact.
+#[test]
+fn test_unstake_fails_when_staked_by_different_user() {
+    let (env, staking, victim, collection, _admin) = setup_with_mock();
+    let attacker = Address::generate(&env);
+
+    // Victim legitimately stakes token 0.
+    mint_token(&env, &collection, &victim, 0);
+    staking.stake(&victim, &collection, &0);
+    assert!(staking
+        .get_staked_position(&victim, &collection, &0)
+        .is_some());
+    assert_eq!(staking.total_staked(), 1);
+
+    // Attacker (who has staked nothing) tries to unstake the victim's token.
+    let err = staking
+        .try_unstake(&attacker, &collection, &0)
+        .unwrap_err()
+        .unwrap();
+    assert_eq!(err, StakingError::NotStaked.into());
+
+    // The victim's position must be untouched and the pool must still custody
+    // the NFT — the attacker must not have been able to divert it.
+    assert!(
+        staking
+            .get_staked_position(&victim, &collection, &0)
+            .is_some(),
+        "victim's staking record must remain intact"
+    );
+    assert_eq!(
+        staking.total_staked(),
+        1,
+        "failed unstake by non-staker must not change total staked"
+    );
+    let owner: Address = env.invoke_contract(
+        &collection,
+        &Symbol::new(&env, "owner_of"),
+        soroban_sdk::vec![&env, 0u64.into_val(&env)],
+    );
+    assert_eq!(
+        owner, staking.address,
+        "NFT must remain in the staking pool's custody"
+    );
 }


### PR DESCRIPTION
## Summary

Adds test coverage for `unstake_nft` failing correctly when the caller hasn't staked the specific NFT in question. Closes #553 .

## Changes

- `contracts/nft-staking/src/test.rs` (+102 lines, no other files touched)
  - `test_unstake_fails_when_not_staked` — user mints but never stakes token 0; `try_unstake` returns the typed `StakingError::NotStaked`, with no state mutation (position stays `None`, `total_staked == 0`, NFT ownership unchanged).
  - `test_unstake_fails_when_staked_by_different_user` — an attacker who staked nothing attempts to unstake a victim's staked NFT; also correctly rejected with `NotStaked`, with the victim's position, `total_staked`, and pool custody all verified unchanged.

## Recon Notes

- `unstake_nft` → `unstake_erc721` (`contract.rs:222`) keys staked positions by `DataKey::StakedPosition(user, token_address, token_id)` — i.e. namespaced by the *caller's own address*. A missing entry triggers `panic_with_error!(NotStaked)`, a typed error rather than a bare panic.
- Because the key embeds the caller, "never staked," "staked by someone else," and "already unstaked" all collapse to the same `NotStaked` check. This means the downstream `position.owner != user` → `Unauthorized` branch (`contract.rs:233`) is currently unreachable dead code — not a bug, just noted for visibility. No implementation changes made.
- No state mutation happens before the `NotStaked` panic in any of these cases (pre-checks are read-only).

## Not Added

- A "double unstake" test was deliberately skipped — it would hit the identical `load_staked_position → NotStaked` path as "never staked," so it'd be redundant with the first test.

## Test Results

running 10 tests
test test::test_get_user_stakes_empty ... ok
test test::test_calculate_rewards ... ok
test test::test_pause_unpause ... ok
test test::test_stake_and_get_position ... ok
test test::test_multiple_stakes_per_user ... ok
test test::test_stake_fails_when_not_owner ... ok
test test::test_unstake_fails_when_not_staked ... ok
test test::test_unstake_fails_when_staked_by_different_user ... ok
test test::test_unstake_returns_nft ... ok
test test::test_total_staked ... ok

test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
---
- `cargo fmt -p nft-staking --check` → clean
- `cargo clippy -p nft-staking --tests` → no new warnings (5 pre-existing, unrelated to this change)

## Checklist

- [x] `unstake_nft` fails with the correct typed error when the user hasn't staked that specific NFT (`test.rs:281`)
- [x] Unchanged-state assertions included (`test.rs:285, 290, 296`)
- [x] Adjacent authorization boundary covered — can't unstake another user's NFT (`test.rs:312-344`)
- [x] No implementation code changed
- [x] Scope limited to `contracts/nft-staking/src/test.rs`