### PR TITLE
test: add empty collection name state-change tests (#561)

### DIFF
--- a/contracts/launchpad/src/test.rs
+++ b/contracts/launchpad/src/test.rs
@@ -749,6 +749,126 @@ fn deploy_lazy_1155_fails_on_empty_name() {
     assert_eq!(result, Err(Ok(Error::EmptyName)));
 }
 
+// ── Issue #561: deploy_collection fails if collection name is empty ──────────
+//
+// Verify that deploying with an empty name:
+//   1. Returns EmptyName error
+//   2. Does NOT increment collection_count
+//   3. Does NOT record any collection in all_collections or collections_by_creator
+
+#[test]
+fn deploy_normal_721_empty_name_no_state_change() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0x60u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+
+    let result = client.try_deploy_normal_721(
+        &creator,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "SYM"),
+        &100u64,
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+
+    // State must remain unchanged
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+    assert!(client.collections_by_creator(&creator).is_empty());
+}
+
+#[test]
+fn deploy_normal_1155_empty_name_no_state_change() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0x61u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+
+    let result = client.try_deploy_normal_1155(
+        &creator,
+        &String::from_str(&env, ""),
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+    assert!(client.collections_by_creator(&creator).is_empty());
+}
+
+#[test]
+fn deploy_lazy_721_empty_name_no_state_change() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0x62u8; 32]);
+    let creator_pubkey = BytesN::from_array(&env, &[0x09u8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+
+    let result = client.try_deploy_lazy_721(
+        &creator,
+        &creator_pubkey,
+        &String::from_str(&env, ""),
+        &String::from_str(&env, "SYM"),
+        &100u64,
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+    assert!(client.collections_by_creator(&creator).is_empty());
+}
+
+#[test]
+fn deploy_lazy_1155_empty_name_no_state_change() {
+    let env = Env::default();
+    env.ledger().with_mut(|li| li.sequence_number = 1);
+    let (client, _admin, _fee_receiver, creator) = setup_launchpad(&env);
+
+    let salt = BytesN::from_array(&env, &[0x63u8; 32]);
+    let creator_pubkey = BytesN::from_array(&env, &[0x0Au8; 32]);
+    let royalty_receiver = Address::generate(&env);
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+
+    let result = client.try_deploy_lazy_1155(
+        &creator,
+        &creator_pubkey,
+        &String::from_str(&env, ""),
+        &500u32,
+        &royalty_receiver,
+        &salt,
+    );
+    assert_eq!(result, Err(Ok(Error::EmptyName)));
+
+    assert_eq!(client.collection_count(), 0u64);
+    assert!(client.all_collections().is_empty());
+    assert!(client.collections_by_creator(&creator).is_empty());
+}
+
 // ── Symbol length validation tests ──────────────────────────────
 
 /// Symbol of exactly max length (10) succeeds; symbol of 11+ fails.


### PR DESCRIPTION
## Description
**Resolves Issue:** ### Soroban Safety Checklist
- [ ] **TTL Extensions:** If I modified `Persistent` storage, I explicitly called `extend_ttl` for those exact keys immediately after setting them.
- [ ] **Instance TTL:** I ensured `extend_instance_ttl` is called if this is a public, state-modifying entry point.
- [ ] **Authorization:** I verified that `require_auth` is used correctly and doesn't accidentally block approved operators or token owners.
- [ ] **Gas Efficiency:** I have avoided putting storage reads/writes or `.get(i).unwrap()` host calls inside loops.
- [ ] **State Bloat:** I have not used unbounded `Vec` arrays for global state tracking.
- [ ] **Signature Security:** If I implemented off-chain signatures, the digest explicitly includes the contract address to prevent replays.
- [ ] **Front-Running Protection:** If I used `deploy_v2`, I hashed the caller's address into the deployment salt.
- [ ] **Error Handling:** I avoided using `.unwrap_or()` combined with `.saturating_sub()` to silently hide balance underflows.

## Testing
- [ ] I have added unit tests to cover my changes and tested edge cases.
- [ ] All tests pass locally (`cargo test`).

## Additional Context

closes #561 