### PR TITLE
test: cover explore multi-filter, clear-filters, wrong-network, and l…

### DIFF
--- a/frontend/afristore-app/e2e/explore.spec.ts
+++ b/frontend/afristore-app/e2e/explore.spec.ts
@@ -23,6 +23,8 @@ const PAGE_SIZE = 12;
 const CID_BAOBAB = "QmE2eBaobabTwilightCid";
 const CID_LAGOS = "QmE2eLagosSkylineCid";
 const CID_NAIROBI = "QmE2eNairobiStreetsCid";
+const CID_KENTE = "QmE2eKenteWeaveCid";
+const CID_ADINKRA = "QmE2eAdinkraCarvingCid";
 
 const EXTRA_METADATA: Record<string, typeof MOCK_ARTWORK_METADATA> = {
   [CID_BAOBAB]: {
@@ -39,6 +41,16 @@ const EXTRA_METADATA: Record<string, typeof MOCK_ARTWORK_METADATA> = {
     ...MOCK_ARTWORK_METADATA,
     title: "Nairobi Streets",
     category: "Photography",
+  },
+  [CID_KENTE]: {
+    ...MOCK_ARTWORK_METADATA,
+    title: "Kente Weave",
+    category: "Sculpture",
+  },
+  [CID_ADINKRA]: {
+    ...MOCK_ARTWORK_METADATA,
+    title: "Adinkra Carving",
+    category: "Sculpture",
   },
 };
 
@@ -81,6 +93,41 @@ async function mockIndexerSearch(page: Page, store: MarketplaceTestStore) {
     const rows = store.listings.filter((l) =>
       l.artist.toLowerCase().includes(q),
     );
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ listings: rows, total: rows.length }),
+    });
+  });
+}
+
+/**
+ * Mirrors the indexer's price range + status + search filtering (`where.price.gte/lte`,
+ * `where.status`, `where.OR` — see indexer/src/api/routes.ts), all ANDed together like
+ * the real backend. Falls back to the base marketplace mock for requests without
+ * min/max price params.
+ */
+async function mockIndexerPriceRange(page: Page, store: MarketplaceTestStore) {
+  await page.route(`${INDEXER_URL}/listings**`, async (route) => {
+    if (route.request().method() !== "GET") return route.fallback();
+    const url = new URL(route.request().url());
+    const minPrice = url.searchParams.get("minPrice");
+    const maxPrice = url.searchParams.get("maxPrice");
+    if (!minPrice && !maxPrice) return route.fallback();
+
+    const statusFilter = url.searchParams.get("status");
+    const search = url.searchParams.get("search");
+    let rows = store.listings;
+    if (statusFilter && statusFilter !== "All") {
+      rows = rows.filter((l) => l.status === statusFilter);
+    }
+    if (minPrice) rows = rows.filter((l) => Number(l.price) >= Number(minPrice));
+    if (maxPrice) rows = rows.filter((l) => Number(l.price) <= Number(maxPrice));
+    if (search) {
+      const q = search.toLowerCase();
+      rows = rows.filter((l) => l.artist.toLowerCase().includes(q));
+    }
+
     await route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -464,5 +511,243 @@ test.describe("Explore page sorts by Newest correctly (#493)", () => {
       "Baobab Twilight",
       "Lagos Skyline",
     ]);
+  });
+});
+
+test.describe("Explore page applies category, price range, and status filters together (#584)", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await mockExtraArtworkMetadata(page);
+    await mockIndexerPriceRange(page, store);
+    await resetE2eListingsInBrowser(page);
+
+    // Sculpture, active, mid-priced — should survive every filter combination.
+    store.upsertActive(
+      makeListing({
+        listing_id: 9801,
+        metadata_cid: CID_BAOBAB,
+        price: String(10 * 10_000_000),
+        status: "Active",
+      }),
+    );
+    // Wrong category — excluded once "Sculpture" is selected.
+    store.upsertActive(
+      makeListing({
+        listing_id: 9802,
+        metadata_cid: CID_LAGOS,
+        price: String(10 * 10_000_000),
+        status: "Active",
+      }),
+    );
+    // Right category, too expensive — excluded once the price range is applied.
+    store.upsertActive(
+      makeListing({
+        listing_id: 9803,
+        metadata_cid: CID_KENTE,
+        price: String(50 * 10_000_000),
+        status: "Active",
+      }),
+    );
+    // Right category and price, wrong status — excluded once "Active" is selected.
+    store.upsertActive(
+      makeListing({
+        listing_id: 9804,
+        metadata_cid: CID_ADINKRA,
+        price: String(10 * 10_000_000),
+        status: "Sold",
+      }),
+    );
+  });
+
+  test("narrows the grid to listings matching category, price range, and status simultaneously", async ({
+    page,
+  }) => {
+    const listingsRequest = waitForListingsRequest(page);
+    await page.goto("/explore");
+    await listingsRequest;
+
+    await expect(page.getByText("Baobab Twilight")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.getByText("Lagos Skyline")).toBeVisible();
+    await expect(page.getByText("Kente Weave")).toBeVisible();
+    await expect(page.getByText("Adinkra Carving")).toBeVisible();
+
+    await page.getByRole("button", { name: /advanced filters/i }).click();
+
+    // Category filter
+    await page.getByRole("combobox").nth(1).selectOption("Sculpture");
+    await expect(page.getByText("Lagos Skyline")).toHaveCount(0);
+    await expect(page.getByText("Baobab Twilight")).toBeVisible();
+    await expect(page.getByText("Kente Weave")).toBeVisible();
+    await expect(page.getByText("Adinkra Carving")).toBeVisible();
+
+    // Price range filter (stacks on top of category)
+    const minPriceRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes(`minPrice=${5 * 10_000_000}`),
+    );
+    await page.getByPlaceholder("Min").fill(String(5 * 10_000_000));
+    await minPriceRequest;
+
+    const maxPriceRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes(`maxPrice=${15 * 10_000_000}`),
+    );
+    await page.getByPlaceholder("Max").fill(String(15 * 10_000_000));
+    await maxPriceRequest;
+
+    await expect(page.getByText("Kente Weave")).toHaveCount(0);
+    await expect(page.getByText("Baobab Twilight")).toBeVisible();
+    await expect(page.getByText("Adinkra Carving")).toBeVisible();
+
+    // Status filter (stacks on top of category + price range)
+    const statusRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes("status=Active"),
+    );
+    await page.getByRole("button", { name: "Active", exact: true }).click();
+    await statusRequest;
+
+    await expect(page.getByText("Adinkra Carving")).toHaveCount(0);
+    await expect(page.getByText("Baobab Twilight")).toBeVisible();
+    await expect(
+      page.getByText(/Found\s+1\s+results\s+matching\s+your\s+criteria/i),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: /buy now/i })).toHaveCount(
+      1,
+    );
+  });
+});
+
+test.describe("Clearing all filters on the Explore page resets the view to default (#585)", () => {
+  const store = new MarketplaceTestStore();
+
+  test.beforeEach(async ({ page }) => {
+    store.reset();
+    await setupMarketplaceMocks(page, store);
+    await mockExtraArtworkMetadata(page);
+    await mockIndexerSearch(page, store);
+    await mockIndexerPriceRange(page, store);
+    await resetE2eListingsInBrowser(page);
+
+    store.upsertActive(
+      makeListing({
+        listing_id: 9901,
+        artist: TEST_PUBLIC_KEY,
+        metadata_cid: CID_BAOBAB,
+        price: String(10 * 10_000_000),
+        status: "Active",
+      }),
+    );
+    store.upsertActive(
+      makeListing({
+        listing_id: 9902,
+        artist: BUYER_PUBLIC_KEY,
+        metadata_cid: CID_LAGOS,
+        price: String(50 * 10_000_000),
+        status: "Active",
+      }),
+    );
+    store.upsertActive(
+      makeListing({
+        listing_id: 9903,
+        artist: BUYER_PUBLIC_KEY,
+        metadata_cid: CID_NAIROBI,
+        price: String(10 * 10_000_000),
+        status: "Sold",
+      }),
+    );
+  });
+
+  test("resets search, category, price range, and status back to defaults", async ({
+    page,
+  }) => {
+    const listingsRequest = waitForListingsRequest(page);
+    await page.goto("/explore");
+    await listingsRequest;
+
+    await expect(page.getByText("Baobab Twilight")).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(
+      page.getByText(/Showing\s+1\s*-\s*3\s+of\s+3\s+artworks/i),
+    ).toBeVisible();
+
+    // Apply a mix of filters that narrows the grid down to a single result.
+    const query = TEST_PUBLIC_KEY.slice(0, 10);
+    const searchRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes(`search=${encodeURIComponent(query)}`),
+    );
+    await page
+      .getByPlaceholder(/search by title, artist, or description/i)
+      .fill(query);
+    await searchRequest;
+
+    await page.getByRole("button", { name: /advanced filters/i }).click();
+    await page.getByRole("combobox").nth(1).selectOption("Sculpture");
+
+    const statusRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes("status=Active"),
+    );
+    await page.getByRole("button", { name: "Active", exact: true }).click();
+    await statusRequest;
+
+    const minPriceRequest = page.waitForRequest(
+      (req) =>
+        req.method() === "GET" &&
+        req.url().includes(`${INDEXER_URL}/listings`) &&
+        req.url().includes(`minPrice=${5 * 10_000_000}`),
+    );
+    await page.getByPlaceholder("Min").fill(String(5 * 10_000_000));
+    await minPriceRequest;
+
+    await expect(page.getByText("Baobab Twilight")).toBeVisible();
+    await expect(page.getByText("Lagos Skyline")).toHaveCount(0);
+    await expect(page.getByText("Nairobi Streets")).toHaveCount(0);
+    await expect(
+      page.getByText(/Showing\s+1\s*-\s*1\s+of\s+1\s+artwork/i),
+    ).toBeVisible();
+
+    // Clear all filters from the advanced filters panel.
+    const resetRequest = waitForListingsRequest(page);
+    await page.getByRole("button", { name: /reset all filters/i }).click();
+    await resetRequest;
+
+    // Every input/control is back to its default state.
+    await expect(
+      page.getByPlaceholder(/search by title, artist, or description/i),
+    ).toHaveValue("");
+    await expect(page.getByPlaceholder("Min")).toHaveValue("");
+    await expect(page.getByRole("combobox").nth(1)).toHaveValue("All");
+    await expect(
+      page.getByRole("button", { name: "All", exact: true }),
+    ).toHaveClass(/bg-brand-500/);
+    await expect(
+      page.getByRole("button", { name: /reset all filters/i }),
+    ).toHaveCount(0);
+
+    // The full, unfiltered result set is showing again.
+    await expect(page.getByText("Baobab Twilight")).toBeVisible();
+    await expect(page.getByText("Lagos Skyline")).toBeVisible();
+    await expect(page.getByText("Nairobi Streets")).toBeVisible();
+    await expect(
+      page.getByText(/Showing\s+1\s*-\s*3\s+of\s+3\s+artworks/i),
+    ).toBeVisible();
   });
 });

--- a/frontend/afristore-app/e2e/wallet-network.spec.ts
+++ b/frontend/afristore-app/e2e/wallet-network.spec.ts
@@ -23,4 +23,36 @@ test.describe("Wallet Network Detection", () => {
       timeout: 10000,
     });
   });
+
+  test("prompts to switch networks instead of granting connected access", async ({
+    page,
+  }) => {
+    await mockFreighterWrongNetwork(page);
+    await page.goto("/");
+    await page
+      .getByRole("navigation")
+      .getByRole("button", { name: "Connect Wallet", exact: true })
+      .click();
+
+    await expect(
+      page.getByRole("heading", { name: "Wrong Network" }),
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/switch the network/i)).toBeVisible();
+    const refreshButton = page.getByRole("button", {
+      name: /refresh connection/i,
+    });
+    await expect(refreshButton).toBeVisible();
+
+    // The wallet never reaches the connected "Success!" state while the
+    // network mismatch persists.
+    await expect(page.getByText(/^success!$/i)).toHaveCount(0);
+
+    // Retrying while still on the wrong network keeps the same prompt up
+    // rather than closing the modal or granting access.
+    await refreshButton.click();
+    await expect(
+      page.getByRole("heading", { name: "Wrong Network" }),
+    ).toBeVisible();
+    await expect(page.getByText(/^success!$/i)).toHaveCount(0);
+  });
 });

--- a/indexer/src/__tests__/api.test.ts
+++ b/indexer/src/__tests__/api.test.ts
@@ -146,6 +146,32 @@ describe('GET /listings', () => {
       expect.objectContaining({ skip: 10000 })
     );
   });
+
+  it('returns 400 for an invalid sort parameter', async () => {
+    const res = await request(app).get('/listings?sort=bogus');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(mockPrisma.listing.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for a sort value colliding with an Object prototype property', async () => {
+    const res = await request(app).get('/listings?sort=toString');
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBeDefined();
+    expect(mockPrisma.listing.findMany).not.toHaveBeenCalled();
+  });
+
+  it('orders by price ascending when sort=price_asc is provided', async () => {
+    mockPrisma.listing.findMany.mockResolvedValue([]);
+
+    await request(app).get('/listings?sort=price_asc');
+
+    expect(mockPrisma.listing.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { price: 'asc' } })
+    );
+  });
 });
 
 // ── GET /listings/:id/history ─────────────────────────────────────────────────

--- a/indexer/src/api/routes.ts
+++ b/indexer/src/api/routes.ts
@@ -162,10 +162,23 @@ function normaliseGateway(gateway: string): string {
     return gateway.endsWith('/') ? gateway : `${gateway}/`;
 }
 
-// GET /listings?artist=&status=&minPrice=&maxPrice=&search=&limit=&offset=
+const LISTINGS_SORT_ORDER_BY = new Map<string, any>([
+    ['newest', { updatedAtLedger: 'desc' }],
+    ['oldest', { updatedAtLedger: 'asc' }],
+    ['price_asc', { price: 'asc' }],
+    ['price_desc', { price: 'desc' }],
+]);
+
+// GET /listings?artist=&status=&minPrice=&maxPrice=&search=&limit=&offset=&sort=
 router.get('/listings', async (req: Request, res: Response) => {
-    const { artist, owner, status, limit, offset, minPrice, maxPrice, search } = req.query;
+    const { artist, owner, status, limit, offset, minPrice, maxPrice, search, sort } = req.query;
     try {
+        if (sort && !LISTINGS_SORT_ORDER_BY.has(sort as string)) {
+            return res.status(400).json({
+                error: `Invalid sort value. Use ${[...LISTINGS_SORT_ORDER_BY.keys()].join(', ')}.`,
+            });
+        }
+
         const where: any = {};
         if (artist) where.artist = artist as string;
         if (owner) where.owner = owner as string;
@@ -194,7 +207,7 @@ router.get('/listings', async (req: Request, res: Response) => {
 
         const results = await prisma.listing.findMany({
             where,
-            orderBy: { updatedAtLedger: 'desc' },
+            orderBy: LISTINGS_SORT_ORDER_BY.get(sort as string) ?? { updatedAtLedger: 'desc' },
             take,
             skip,
         });


### PR DESCRIPTION
  Summary

  Adds automated test coverage for four flagged scenarios and the minimal production fix needed to make one of
  them testable:

  - Explore page — combined filters: new E2E test verifies Category + Price Range + Status filters narrow the grid
  correctly when applied together.
  - Explore page — clear filters: new E2E test verifies "Reset All Filters" restores the default, unfiltered view
  after search/category/status/price filters were applied.
  - Wallet — wrong network: new E2E test verifies connecting on the wrong network keeps the user in the "Wrong
  Network" prompt (never reaches the connected "Success!" state), including after retrying via "Refresh
  Connection".
  - Indexer — GET /listings sort validation: the sort query param didn't exist on this route before, so a "returns
  400 for invalid sort" test couldn't be written. Added a minimal allowlist (newest, oldest, price_asc,
  price_desc) that 400s on anything else and preserves the previous default ordering when sort is omitted — no
  existing caller sends this param today, so behavior is unchanged for them.

  Test plan

  - [x] cd indexer && npx vitest run — 162/162 passing
  - [x] cd frontend/afristore-app && npx playwright test e2e/explore.spec.ts — 8/8 passing
  - [x] cd frontend/afristore-app && npx playwright test e2e/wallet-network.spec.ts — 3/3 passing

  Issues

  Closes #584, closes #576, closes #585, closes #587